### PR TITLE
Add launch badge track to landing page

### DIFF
--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -12,6 +12,7 @@ import {
   MonitorOff,
   Moon,
   Package,
+  Rocket,
   Sun,
   Terminal,
   TimerOff,
@@ -790,6 +791,98 @@ function BrewCmd() {
   )
 }
 
+/* ---------- Launch badge track ---------- */
+
+// Platforms Munkel launches on. Until we actually land on one, its badge is
+// rendered in-house (the "Launching on" pill). When the listing goes live, set
+// `live: true`, point `href` at our listing, and drop the platform's official
+// badge into `img` — self-hosted under /badges so we never hot-link a third
+// party (no layout shift, no tracking, no availability risk). See issue #8.
+type LaunchPlatform = {
+  name: string
+  href: string
+  live?: boolean
+  /** Self-hosted official badge, e.g. '/badges/product-hunt.svg'. */
+  img?: string
+  alt?: string
+}
+
+// hrefs are platform homepages for now — swap each for our own listing URL as
+// we launch. Tiers mirror issue #8 (flagship → directories → long tail).
+const LAUNCH_PLATFORMS: LaunchPlatform[] = [
+  { name: 'Product Hunt', href: 'https://www.producthunt.com' },
+  { name: 'Peerlist', href: 'https://peerlist.io' },
+  { name: 'Fazier', href: 'https://fazier.com' },
+  { name: 'Uneed', href: 'https://www.uneed.best' },
+  { name: 'MicroLaunch', href: 'https://microlaunch.net' },
+  { name: 'Startup Fame', href: 'https://startupfa.me' },
+  { name: 'Twelve Tools', href: 'https://twelve.tools' },
+  { name: 'Findly.tools', href: 'https://findly.tools' },
+  { name: 'LaunchIgniter', href: 'https://launchigniter.com' },
+  { name: 'Dang.ai', href: 'https://dang.ai' },
+]
+
+function LaunchBadge({ platform }: { platform: LaunchPlatform }) {
+  const { name, href, live, img, alt } = platform
+  return (
+    <a
+      className="launch-badge"
+      href={href}
+      target="_blank"
+      rel="noopener"
+      aria-label={live ? `Featured on ${name}` : `Munkel is launching on ${name}`}
+    >
+      {img ? (
+        <img src={img} alt={alt ?? `Featured on ${name}`} loading="lazy" decoding="async" />
+      ) : (
+        <>
+          <span className="lb-glyph">
+            <Rocket aria-hidden />
+          </span>
+          <span className="lb-text">
+            <span className="lb-kicker">{live ? 'Featured on' : 'Launching on'}</span>
+            <span className="lb-name">{name}</span>
+          </span>
+        </>
+      )}
+    </a>
+  )
+}
+
+// A seamless marquee: the badge list is rendered twice (the duplicate is
+// display:contents, so its badges join the same flex row with even spacing) and
+// the row is translated by exactly -50%, looping without a seam. Under reduced
+// motion the duplicate is hidden and the badges wrap statically. Pass liveOnly
+// once we have real launches to shrink the strip to earned badges.
+function LaunchBadgeTrack({ liveOnly = false }: { liveOnly?: boolean }) {
+  const platforms = liveOnly ? LAUNCH_PLATFORMS.filter((p) => p.live) : LAUNCH_PLATFORMS
+  if (platforms.length === 0) return null
+  return (
+    <section className="badge-track">
+      <div className="container">
+        <div className="section-kicker">Launch</div>
+        <h2>Out in the wild.</h2>
+        <p>
+          Munkel is rolling out across the platforms where people hunt for new tools. Catch the
+          launch — and give us an upvote when we land.
+        </p>
+      </div>
+      <div className="badge-marquee">
+        <div className="badge-marquee-row">
+          {platforms.map((p) => (
+            <LaunchBadge key={p.name} platform={p} />
+          ))}
+          <span className="badge-dup" aria-hidden>
+            {platforms.map((p) => (
+              <LaunchBadge key={`${p.name}-dup`} platform={p} />
+            ))}
+          </span>
+        </div>
+      </div>
+    </section>
+  )
+}
+
 /* ---------- Page ---------- */
 
 function LandingPage() {
@@ -1177,6 +1270,8 @@ function LandingPage() {
           <div className="hero-meta">Signed &amp; notarized · no telemetry · macOS 14+</div>
         </div>
       </section>
+
+      <LaunchBadgeTrack />
 
       <footer>
         <div className="container footer-inner">

--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -807,8 +807,9 @@ type LaunchPlatform = {
   alt?: string
 }
 
-// hrefs are platform homepages for now — swap each for our own listing URL as
-// we launch. Tiers mirror issue #8 (flagship → directories → long tail).
+// Source of truth + status tracking: docs/launch-platforms.md. This array
+// mirrors the "live" rows from there; hrefs are platform homepages until we
+// have our own listing URL for each.
 const LAUNCH_PLATFORMS: LaunchPlatform[] = [
   { name: 'Product Hunt', href: 'https://www.producthunt.com' },
   { name: 'Peerlist', href: 'https://peerlist.io' },

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -663,6 +663,50 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0; }
 .footer-links a { font-size: var(--text-xs); color: var(--muted-foreground); }
 .footer-links a:hover { color: var(--foreground); }
 
+/* ---------- Launch badge track ---------- */
+.badge-track { text-align: center; overflow: hidden; }
+.badge-track h2 { font-size: var(--text-3xl); font-weight: 600; letter-spacing: var(--tracking-tight); margin-top: 0.75rem; }
+.badge-track > .container > p { max-width: 52ch; margin: 0.75rem auto 0; color: var(--muted-foreground); line-height: var(--leading-relaxed); text-wrap: pretty; }
+.badge-marquee {
+  margin-top: 3rem;
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+}
+.badge-marquee-row {
+  display: flex; align-items: center; gap: 1rem; width: max-content;
+  animation: badge-scroll 38s linear infinite;
+}
+.badge-marquee:hover .badge-marquee-row { animation-play-state: paused; }
+/* The duplicate copy joins the same flex row so the gap stays even, then the
+   row scrolls exactly one copy width for a seamless loop. */
+.badge-dup { display: contents; }
+@keyframes badge-scroll { to { transform: translateX(-50%); } }
+.launch-badge {
+  display: inline-flex; align-items: center; gap: 0.625rem; flex: none;
+  height: 54px; padding: 0 1rem;
+  border: 1px solid var(--border); border-radius: var(--radius-lg);
+  background: var(--card);
+  transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+}
+.launch-badge:hover {
+  border-color: var(--ring); transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+.launch-badge img { height: 40px; width: auto; display: block; }
+.launch-badge .lb-glyph {
+  display: inline-flex; align-items: center; justify-content: center; flex: none;
+  width: 30px; height: 30px; border-radius: var(--radius-md);
+  background: var(--brand-soft); color: var(--brand);
+  box-shadow: 0 0 calc(var(--glow) * 16px) color-mix(in oklab, var(--brand) 18%, transparent);
+}
+.launch-badge .lb-glyph svg.lucide { width: 15px; height: 15px; }
+.launch-badge .lb-text { display: flex; flex-direction: column; text-align: left; line-height: 1.2; gap: 1px; }
+.launch-badge .lb-kicker {
+  font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--brand);
+}
+.launch-badge .lb-name { font-size: var(--text-sm); font-weight: 600; color: var(--foreground); white-space: nowrap; }
+
 /* ---------- Responsive ---------- */
 @media (max-width: 1080px) {
   .nav-links { display: none; }
@@ -705,4 +749,8 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0; }
   .demo-caption { display: none; }
   .meanwhile { transition: none; transform: none; }
   .faq summary::after { transition: none; }
+  /* No marquee: hide the duplicate and let the badges wrap statically. */
+  .badge-marquee { -webkit-mask-image: none; mask-image: none; }
+  .badge-marquee-row { animation: none; flex-wrap: wrap; justify-content: center; width: auto; }
+  .badge-dup { display: none; }
 }

--- a/docs/launch-platforms.md
+++ b/docs/launch-platforms.md
@@ -1,0 +1,74 @@
+# Launch platforms
+
+Single source of truth for **where Munkel launches** and which launch badges
+we collect. Tracks status per platform so the landing-page badge track
+(`apps/landing` → `LAUNCH_PLATFORMS`) and the launch effort stay in sync.
+
+Related: issue [#8](https://github.com/limehq/munkel/issues/8).
+
+## How this maps to the code
+
+`LAUNCH_PLATFORMS` in `apps/landing/src/routes/index.tsx` mirrors the **live**
+rows below. Until a platform is live, its badge renders in-house
+("Launching on …"). When it goes live:
+
+1. Flip `Status` to ✅ here and fill in **Listing URL** + **Badge** + **Link rel**.
+2. In the code, set `live: true`, point `href` at the listing URL, and drop the
+   platform's official badge into `img` (self-hosted under
+   `apps/landing/public/badges/`, never hot-linked).
+
+## Status legend
+
+- 📋 **planned** — on the list, not submitted yet
+- 🚀 **submitted** — submitted / scheduled, awaiting listing or launch day
+- ✅ **live** — listed; badge earned and (where applicable) on the site
+
+## ⚠️ Verify before trusting a row
+
+Homepage URLs, badge availability, and link `rel` (dofollow vs nofollow) are
+**best-effort and unverified**. Confirm each on the platform itself before
+adding its badge to the track — `_TBD_` marks anything not yet checked.
+
+## Tier 1 — flagship (schedule deliberately)
+
+| Platform | Homepage | Listing URL | Badge | Link rel | Status | Notes |
+|---|---|---|---|---|---|---|
+| Product Hunt | https://www.producthunt.com | _TBD_ | _TBD_ | _TBD_ | 📋 | Pick a date; line up hunter + upvotes. The big one. |
+| Peerlist Launchpad | https://peerlist.io | _TBD_ | _TBD_ | _TBD_ | 📋 | Strong with the builder/dev audience; longer visibility window. |
+| Fazier | https://fazier.com | _TBD_ | _TBD_ | _TBD_ | 📋 | Clean, AI-startup friendly, less crowded. Offers a badge. |
+| Uneed | https://www.uneed.best | _TBD_ | _TBD_ | _TBD_ | 📋 | Curated directory; badge available. |
+
+## Tier 2 — solid directories with badges
+
+| Platform | Homepage | Listing URL | Badge | Link rel | Status | Notes |
+|---|---|---|---|---|---|---|
+| MicroLaunch | https://microlaunch.net | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| Startup Fame | https://startupfa.me | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| Twelve Tools | https://twelve.tools | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| Findly.tools | https://findly.tools | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| LaunchIgniter | https://launchigniter.com | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| Tiny Launch / Smol Launch | _TBD_ | _TBD_ | _TBD_ | _TBD_ | 📋 | Confirm which one; domains overlap. |
+| OpenHunts | _TBD_ | _TBD_ | _TBD_ | _TBD_ | 📋 | getwring shows an "OpenHunts Club Member" badge. |
+| Dang.ai | https://dang.ai | _TBD_ | _TBD_ | _TBD_ | 📋 | AI-tool directory. |
+
+## Tier 3 — long tail
+
+Mostly the set getwring.app uses, plus classic directories. Low effort each;
+batch-submit.
+
+| Platform | Homepage | Listing URL | Badge | Link rel | Status | Notes |
+|---|---|---|---|---|---|---|
+| FoundrList | _TBD_ | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| BuildHop | _TBD_ | _TBD_ | _TBD_ | _TBD_ | 📋 | "Trending on BuildHop" badge. |
+| Orynth | _TBD_ | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| SubmitMySaaS | _TBD_ | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| Toshi List | _TBD_ | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| LaunchPanda | _TBD_ | _TBD_ | _TBD_ | _TBD_ | 📋 | "Launched on LaunchPanda" badge. |
+| Huzzler | _TBD_ | _TBD_ | _TBD_ | _TBD_ | 📋 | |
+| BetaList | https://betalist.com | _TBD_ | _TBD_ | _TBD_ | 📋 | Classic; pre-launch / early-stage audience. |
+| Launching Next | https://www.launchingnext.com | _TBD_ | _TBD_ | _TBD_ | 📋 | Classic startup directory. |
+
+## Sources for more directories
+
+- [awesome-saas-directories](https://github.com/mahseema/awesome-saas-directories) — curated, aggregated list
+- [getwring.app](https://getwring.app/) — the badge track that inspired this


### PR DESCRIPTION
Adds a **launch-badge track** to the landing page (above the footer) and a tracking doc for where Munkel launches. First step toward #8.

## What's in here

- **`LaunchBadgeTrack` component** (`apps/landing/src/routes/index.tsx`) — a seamless, edge-faded marquee of launch-platform badges, placed just above the footer (modeled on the badge track at [getwring.app](https://getwring.app/)).
- **`docs/launch-platforms.md`** — single source of truth for where we launch and which badges we collect, tiered to match #8, with per-platform status (planned/submitted/live), listing URL, badge availability, and link `rel`.

## Design notes

- **Honest by default:** nothing is live yet, so each badge renders in-house as "**Launching on** <platform>" — no false "Featured on" claims. When a listing goes live we set `live: true`, point `href` at our listing, and drop the platform's **official badge** into `img`, self-hosted under `apps/landing/public/badges/` (no hot-linking → no layout shift, tracking, or availability risk).
- **Seamless marquee:** the badge list is rendered twice (duplicate via `display:contents` so the flex gap stays even) and the row scrolls exactly `-50%` for a loop with no seam. Pauses on hover, edges faded with a mask.
- **`prefers-reduced-motion`:** animation off, badges wrap statically.
- **Data-driven** from `LAUNCH_PLATFORMS`; `liveOnly` prop shrinks the strip to earned badges once launches happen.

## Verification

- `bun run typecheck` ✅
- `bun run build` ✅
- Screenshotted in dark + light mode; marquee animates, edge fade works, sits cleanly above the footer.

## Follow-ups (tracked in #8)

- Actually launch on the Tier 1 platforms.
- Verify each platform's homepage / badge / link-rel and fill in `docs/launch-platforms.md`.
- Add self-hosted official badge assets and flip rows to `live`.

Refs #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
