### PR TITLE
feat: add quick-send command palette (global hotkey)

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "54814439bf5cc7b8532ca1a714fd6fed75d275e4a0a3bb60351127afb9791973",
+  "originHash" : "9583df972fa921a9f3b65129c53167d3f7263a70b194757e485bd30dba41996b",
   "pins" : [
     {
       "identity" : "dynamicnotchkit",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "cd0b3e52d537db115ad3a9d89601f20e0bee8d27",
         "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
       }
     }
   ],

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/MrKai77/DynamicNotchKit", from: "1.1.0"),
+        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.0.0"),
     ],
     targets: [
         .target(name: "MunkelKit"),
@@ -14,6 +15,7 @@ let package = Package(
             dependencies: [
                 "MunkelKit",
                 .product(name: "DynamicNotchKit", package: "DynamicNotchKit"),
+                .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
             ],
             path: "Sources/MunkelApp"
         ),

--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -40,6 +40,7 @@ final class AppModel: ObservableObject {
     private var sessions: [String: GroupSession] = [:]
     private let notch = NotchPresenter()
     private var controlServer: ControlServer?
+    private var palette: CommandPalettePresenter?
     private var githubLoginTask: Task<Void, Never>?
     private var githubLoginGeneration = 0
     private var profileBroadcastTask: Task<Void, Never>?
@@ -58,6 +59,9 @@ final class AppModel: ObservableObject {
         let server = ControlServer(model: self)
         server.start()
         self.controlServer = server
+        // Registers the global hotkey (default ⌃⌘M) and owns the palette
+        // window — long-lived like the notch, so it survives popover churn.
+        self.palette = CommandPalettePresenter(model: self)
     }
 
     func session(for code: String) -> GroupSession? {
@@ -83,6 +87,11 @@ final class AppModel: ObservableObject {
     func send(text: String, group code: String, to memberId: String? = nil) {
         guard let session = sessions[code] else { return }
         Task { await session.sendChat(text, to: memberId) }
+    }
+
+    /// Opens the quick-send command palette (also bound to the global hotkey).
+    func openCommandPalette() {
+        palette?.show()
     }
 
     // MARK: - GitHub login (device flow)

--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -37,6 +37,16 @@ final class AppModel: ObservableObject {
     private static let relayURLKey = "relayURL"
     private static let defaultRelayURL = "wss://relay.munkel.app"
 
+    #if DEBUG
+    /// Dev-only: echo my own broadcasts into my notch (Settings toggle), so a
+    /// solo developer can see a sent message without a second member online —
+    /// the relay delivers a broadcast only to the *other* members. Default on.
+    static var devEchoBroadcasts: Bool {
+        get { (UserDefaults.standard.object(forKey: "devEchoBroadcasts") as? Bool) ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: "devEchoBroadcasts") }
+    }
+    #endif
+
     private var sessions: [String: GroupSession] = [:]
     private let notch = NotchPresenter()
     private var controlServer: ControlServer?
@@ -87,6 +97,25 @@ final class AppModel: ObservableObject {
     func send(text: String, group code: String, to memberId: String? = nil) {
         guard let session = sessions[code] else { return }
         Task { await session.sendChat(text, to: memberId) }
+        #if DEBUG
+        // Dev aid: the relay delivers a broadcast only to the *other* members,
+        // so a solo developer never sees their own message. With the Settings
+        // toggle on, echo broadcasts (to: nil) into our own notch as if they
+        // had arrived — same path the live onChat handler uses.
+        if memberId == nil, Self.devEchoBroadcasts {
+            notch.show(
+                sender: displayName,
+                avatarData: Identity.avatarData,
+                text: text,
+                isDirect: false,
+                group: code,
+                groupColor: .groupColor(index: groupCodes.firstIndex(of: code) ?? 0),
+                inMultipleGroups: groupCodes.count > 1
+            ) { [weak self] reply, _ in
+                self?.send(text: reply, group: code, to: nil)
+            }
+        }
+        #endif
     }
 
     /// Opens the quick-send command palette (also bound to the global hotkey).

--- a/apps/macos/Sources/MunkelApp/CommandPalettePanel.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPalettePanel.swift
@@ -1,0 +1,43 @@
+import AppKit
+
+/// Borderless, non-activating floating panel that hosts the command
+/// palette. Like Spotlight, it takes key focus (so the search field types)
+/// without activating the app, leaving the user's previous app frontmost.
+/// The `canBecomeKey` override mirrors DynamicNotchPanel — an NSPanel won't
+/// become key while borderless/nonactivating otherwise.
+final class CommandPalettePanel: NSPanel {
+    var onResignKey: (() -> Void)?
+
+    init(size: NSSize) {
+        super.init(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        isFloatingPanel = true
+        level = .floating
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        // No background drag: clicks in the list select rows.
+        isMovableByWindowBackground = false
+        isReleasedWhenClosed = false
+        hidesOnDeactivate = false
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        // Capture-proof like the notch and popover: the palette shows circle
+        // codes and message drafts, which must never leak into a screen
+        // share. Set on the panel directly so it holds before any content is
+        // composited (the SwiftUI `.excludedFromScreenCapture()` is backup).
+        sharingType = .none
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+
+    /// Spotlight behaviour: clicking another window/app dismisses the palette.
+    override func resignKey() {
+        super.resignKey()
+        onResignKey?()
+    }
+}

--- a/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
@@ -1,0 +1,107 @@
+import AppKit
+import KeyboardShortcuts
+import SwiftUI
+
+/// Owns the command-palette window and its global hotkey. Long-lived,
+/// created by AppModel (mirrors NotchPresenter's ownership). The panel is
+/// built fresh on each open and torn down on close, so nothing retains the
+/// SwiftUI view — which breaks the AppModel ↔︎ view reference cycle every
+/// time the palette closes (the leak DynamicNotchKit has, that we don't
+/// repeat).
+@MainActor
+final class CommandPalettePresenter {
+    private unowned let model: AppModel
+    private let state: CommandPaletteState
+    private var panel: CommandPalettePanel?
+    private var keyMonitor: Any?
+
+    private static let panelSize = NSSize(width: 640, height: 440)
+
+    init(model: AppModel) {
+        self.model = model
+        self.state = CommandPaletteState(app: model)
+        KeyboardShortcuts.onKeyDown(for: .togglePalette) { [weak self] in
+            self?.toggle()
+        }
+    }
+
+    func toggle() {
+        if panel != nil { hide() } else { show() }
+    }
+
+    func show() {
+        guard panel == nil else { return }
+        state.reset()
+
+        let panel = CommandPalettePanel(size: Self.panelSize)
+        panel.onResignKey = { [weak self] in self?.hide() }
+
+        let root = CommandPaletteView(
+            model: model,
+            state: state,
+            onClose: { [weak self] in self?.hide() }
+        )
+        panel.contentView = NSHostingView(rootView: root)
+
+        position(panel)
+        self.panel = panel
+        panel.makeKeyAndOrderFront(nil)
+        installKeyMonitor()
+    }
+
+    func hide() {
+        guard let panel else { return }
+        // Nil first so the re-entrant resignKey that orderOut triggers no-ops.
+        self.panel = nil
+        removeKeyMonitor()
+        panel.orderOut(nil)
+        state.reset()
+    }
+
+    /// Centered horizontally on the screen under the pointer, upper third —
+    /// the Spotlight position.
+    private func position(_ panel: CommandPalettePanel) {
+        let mouse = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main
+        guard let frame = screen?.visibleFrame else { return }
+        let size = Self.panelSize
+        let x = frame.midX - size.width / 2
+        let y = frame.maxY - size.height - frame.height * 0.18
+        panel.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    /// Up/down arrows move the picker selection. Installed only while the
+    /// panel is open; Return (onSubmit) and Esc (onExitCommand) stay with the
+    /// search field. Arrows are consumed (return nil) so they don't move the
+    /// text cursor. Active only in phase 1 — phase 2 has no list.
+    private func installKeyMonitor() {
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            var consumed = false
+            MainActor.assumeIsolated {
+                guard self.state.target == nil else { return }
+                switch event.keyCode {
+                case 125: // down arrow
+                    let count = self.state.filteredRecipients.count
+                    if count > 0 {
+                        self.state.selectedIndex = min(count - 1, self.state.selectedIndex + 1)
+                    }
+                    consumed = true
+                case 126: // up arrow
+                    self.state.selectedIndex = max(0, self.state.selectedIndex - 1)
+                    consumed = true
+                default:
+                    break
+                }
+            }
+            return consumed ? nil : event
+        }
+    }
+
+    private func removeKeyMonitor() {
+        if let keyMonitor {
+            NSEvent.removeMonitor(keyMonitor)
+        }
+        keyMonitor = nil
+    }
+}

--- a/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
@@ -1,0 +1,86 @@
+import Combine
+import Foundation
+
+/// A target the palette can send to: one member, or a whole circle.
+struct Recipient: Identifiable, Equatable {
+    /// Stable across circles: a member who is in two circles is two distinct
+    /// send targets. `\u{1}` can't appear in a code or member id.
+    let id: String
+    let circle: String       // join code
+    let memberId: String?    // nil = broadcast to the whole circle
+    let label: String        // display name, or "Everyone"
+    let avatar: Data?
+
+    var isEveryone: Bool { memberId == nil }
+}
+
+/// Transient palette state, owned by the presenter so it survives the
+/// SwiftUI view being rebuilt and can be mutated from the AppKit key
+/// monitor. Reads live circle/member data straight from AppModel.
+@MainActor
+final class CommandPaletteState: ObservableObject {
+    @Published var query = ""
+    @Published var selectedIndex = 0
+    /// nil → picking a recipient (phase 1); set → composing (phase 2).
+    @Published var target: Recipient?
+    @Published var message = ""
+
+    private weak var app: AppModel?
+
+    init(app: AppModel) {
+        self.app = app
+    }
+
+    /// Every send target across all joined circles: a broadcast entry per
+    /// circle, then its online members.
+    var allRecipients: [Recipient] {
+        guard let app else { return [] }
+        return app.groupCodes.flatMap { code -> [Recipient] in
+            let members = app.session(for: code)?.members ?? []
+            let everyone = Recipient(
+                id: "\(code)\u{1}*",
+                circle: code,
+                memberId: nil,
+                label: "Everyone",
+                avatar: nil
+            )
+            let people = members.map { member in
+                Recipient(
+                    id: "\(code)\u{1}\(member.id)",
+                    circle: code,
+                    memberId: member.id,
+                    label: member.label,
+                    avatar: member.avatar
+                )
+            }
+            return [everyone] + people
+        }
+    }
+
+    var filteredRecipients: [Recipient] {
+        let q = query.trimmingCharacters(in: .whitespaces)
+        guard !q.isEmpty else { return allRecipients }
+        return allRecipients.filter {
+            $0.label.localizedCaseInsensitiveContains(q)
+                || $0.circle.localizedCaseInsensitiveContains(q)
+        }
+    }
+
+    var selectedRecipient: Recipient? {
+        filteredRecipients[safe: selectedIndex]
+    }
+
+    func reset() {
+        query = ""
+        selectedIndex = 0
+        target = nil
+        message = ""
+    }
+}
+
+extension Collection {
+    /// Bounds-checked subscript — nil instead of trapping out of range.
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+
+/// The command palette: phase 1 picks a recipient across all circles, phase
+/// 2 composes the message. Return advances/sends, Esc steps back or closes.
+struct CommandPaletteView: View {
+    @ObservedObject var model: AppModel
+    @ObservedObject var state: CommandPaletteState
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let target = state.target {
+                ComposeView(target: target, state: state, send: send)
+            } else {
+                PickerView(model: model, state: state, onClose: onClose, commit: commit)
+            }
+        }
+        .frame(width: 640, height: 440)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(.white.opacity(0.08), lineWidth: 1)
+        )
+        // Capture-proof root (backup to the panel's sharingType): the palette
+        // shows circle codes, names and the draft. Stays at the root, never
+        // inside the if/else branch, or a frame could flush before exclusion.
+        .excludedFromScreenCapture()
+    }
+
+    private func commit() {
+        guard let recipient = state.selectedRecipient else { return }
+        state.target = recipient
+        state.query = ""
+        state.selectedIndex = 0
+    }
+
+    private func send() {
+        let text = state.message.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty, let target = state.target else { return }
+        model.send(text: text, group: target.circle, to: target.memberId)
+        onClose()
+    }
+}
+
+// MARK: - Phase 1: pick a recipient
+
+private struct PickerView: View {
+    @ObservedObject var model: AppModel
+    @ObservedObject var state: CommandPaletteState
+    let onClose: () -> Void
+    let commit: () -> Void
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "paperplane")
+                    .font(.title2)
+                    .foregroundStyle(.secondary)
+                TextField("Send to… (name or circle)", text: $state.query)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 22, weight: .regular))
+                    .focused($focused)
+                    .onSubmit(commit)
+                    .onExitCommand(perform: onClose)
+                    .onChange(of: state.query) { state.selectedIndex = 0 }
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 60)
+
+            Divider()
+
+            recipientList
+        }
+        .onAppear {
+            // The panel is mid makeKey on first show; a synchronous focus
+            // write is lost. Defer one tick — same trick as the notch reply.
+            Task {
+                try? await Task.sleep(for: .milliseconds(80))
+                focused = true
+            }
+        }
+        // Keep the selection in range when the list shrinks under it — a peer
+        // leaving or a logout mutates filteredRecipients with no query change,
+        // which would otherwise strand the highlight past the end.
+        .onChange(of: state.filteredRecipients.count) { _, count in
+            state.selectedIndex = min(state.selectedIndex, max(0, count - 1))
+        }
+    }
+
+    private var emptyMessage: String {
+        if model.githubUserLogin == nil {
+            return "Sign in with GitHub to use Munkel."
+        }
+        return state.query.isEmpty ? "Join a circle to send." : "No matches."
+    }
+
+    @ViewBuilder
+    private var recipientList: some View {
+        let recipients = state.filteredRecipients
+        if recipients.isEmpty {
+            VStack {
+                Spacer()
+                Text(emptyMessage)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 2) {
+                        ForEach(Array(recipients.enumerated()), id: \.element.id) { index, recipient in
+                            RecipientRow(recipient: recipient, selected: index == state.selectedIndex)
+                                .id(index)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    state.selectedIndex = index
+                                    commit()
+                                }
+                        }
+                    }
+                    .padding(8)
+                }
+                .onChange(of: state.selectedIndex) {
+                    proxy.scrollTo(state.selectedIndex, anchor: .center)
+                }
+            }
+        }
+    }
+}
+
+private struct RecipientRow: View {
+    let recipient: Recipient
+    let selected: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if recipient.isEveryone {
+                Image(systemName: "person.2.fill")
+                    .frame(width: 24, height: 24)
+                    .foregroundStyle(.secondary)
+            } else {
+                AvatarView(name: recipient.label, imageData: recipient.avatar, size: 24)
+            }
+            Text(recipient.label)
+                .font(.body)
+            Spacer()
+            Text(recipient.circle)
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(selected ? Color.accentColor.opacity(0.25) : Color.clear)
+        )
+    }
+}
+
+// MARK: - Phase 2: compose the message
+
+private struct ComposeView: View {
+    let target: Recipient
+    @ObservedObject var state: CommandPaletteState
+    let send: () -> Void
+    @FocusState private var focused: Bool
+
+    private var isEmpty: Bool {
+        state.message.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Button {
+                    state.target = nil // back to the picker
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.title3)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+
+                if target.isEveryone {
+                    Image(systemName: "person.2.fill").foregroundStyle(.secondary)
+                } else {
+                    AvatarView(name: target.label, imageData: target.avatar, size: 22)
+                }
+                Text(target.label).font(.headline)
+                Text(target.circle)
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .frame(height: 52)
+
+            Divider()
+
+            HStack(spacing: 10) {
+                TextField("Message \(target.label)…", text: $state.message)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 20))
+                    .focused($focused)
+                    .onSubmit(send)
+                    .onExitCommand { state.target = nil } // Esc → back to picker
+
+                Button(action: send) {
+                    Image(systemName: "paperplane.fill")
+                        .font(.title3)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tint)
+                .disabled(isEmpty)
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 60)
+
+            Spacer()
+        }
+        .onAppear {
+            Task {
+                try? await Task.sleep(for: .milliseconds(80))
+                focused = true
+            }
+        }
+    }
+}

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -1,3 +1,4 @@
+import KeyboardShortcuts
 import SwiftUI
 
 struct MenuView: View {
@@ -63,6 +64,10 @@ struct MenuView: View {
 
                 Divider()
 
+                paletteHotkeyRow
+
+                Divider()
+
                 githubArea
             }
         }
@@ -104,6 +109,11 @@ struct MenuView: View {
                 checkForUpdates()
             } label: {
                 Label("Check for Updates…", systemImage: "arrow.triangle.2.circlepath")
+            }
+            Button {
+                model.openCommandPalette()
+            } label: {
+                Label("Quick send…", systemImage: "paperplane")
             }
             Divider()
             Button {
@@ -166,6 +176,18 @@ struct MenuView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// Global hotkey that opens the quick-send palette from anywhere.
+    private var paletteHotkeyRow: some View {
+        HStack {
+            Image(systemName: "paperplane")
+                .foregroundStyle(.secondary)
+            Text("Quick send")
+                .font(.callout)
+            Spacer()
+            KeyboardShortcuts.Recorder(for: .togglePalette)
         }
     }
 

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -6,6 +6,9 @@ struct MenuView: View {
     @State private var joinCode = ""
     @State private var userCodeCopied = false
     @State private var groupListHeight: CGFloat = 0
+    #if DEBUG
+    @AppStorage("devEchoBroadcasts") private var devEchoBroadcasts = true
+    #endif
 
     /// Cap before the group list starts scrolling.
     private let maxGroupListHeight: CGFloat = 360
@@ -115,6 +118,10 @@ struct MenuView: View {
             } label: {
                 Label("Quick send…", systemImage: "paperplane")
             }
+            #if DEBUG
+            Divider()
+            Toggle("Echo my broadcasts to me", isOn: $devEchoBroadcasts)
+            #endif
             Divider()
             Button {
                 NSApp.terminate(nil)

--- a/apps/macos/Sources/MunkelApp/Shortcuts.swift
+++ b/apps/macos/Sources/MunkelApp/Shortcuts.swift
@@ -1,0 +1,12 @@
+import KeyboardShortcuts
+
+extension KeyboardShortcuts.Name {
+    /// Opens the quick-send command palette from anywhere. Default ⌃⌘M:
+    /// two modifiers avoid the "greedy single-modifier" trap, ⌘M alone is
+    /// Minimize, and ⌥ would clash with character entry (µ). User-rebindable
+    /// via the Recorder in the menu.
+    static let togglePalette = Self(
+        "togglePalette",
+        default: .init(.m, modifiers: [.control, .command])
+    )
+}


### PR DESCRIPTION
## Summary

A Spotlight/Raycast-style command palette to send a message to anyone in any circle from a global hotkey — no more opening the menu-bar popover to whisper.

Press **⌃⌘M** (rebindable) anywhere → a borderless, non-activating panel appears center-top on the screen under the cursor → type a name or circle, ↑/↓ to navigate, **Return** picks a recipient (Everyone or a member, across all joined circles) → type the message → **Return** sends. **Esc** steps back / closes; clicking away dismisses.

## What's included

**New files** (`apps/macos/Sources/MunkelApp/`)
- `Shortcuts.swift` — `KeyboardShortcuts.Name.togglePalette`, default ⌃⌘M
- `CommandPalettePanel.swift` — borderless `.nonactivatingPanel`, `canBecomeKey`, `sharingType=.none`
- `CommandPaletteState.swift` — recipient aggregation across circles + two-phase state
- `CommandPalettePresenter.swift` — hotkey registration, panel lifecycle, ↑/↓ key monitor, cursor positioning
- `CommandPaletteView.swift` — the picker → compose UI

**Edits**
- `Package.swift` / `Package.resolved` — adds KeyboardShortcuts 2.4.0 (statically linked; no bundle change)
- `AppModel.swift` — owns the presenter (mirrors `notch`); adds `openCommandPalette()`
- `MenuView.swift` — hotkey Recorder row + "Quick send…" menu item

## Design notes
- Sends through the existing `AppModel.send(text:group:to:)` path — same pipeline as the notch reply and the `flustr` CLI. No new transport.
- **Capture-proof** like the notch/popover: `sharingType=.none` set before the first composite + `.excludedFromScreenCapture()` at the view root (outside the phase if/else). The palette shows circle codes, member names and the draft.
- The panel is rebuilt on each open and destroyed on close, breaking the AppModel↔view reference cycle every time — deliberately avoiding the DynamicNotchKit retain leak.
- Hotkey uses Carbon `RegisterEventHotKey` (via KeyboardShortcuts) — no Accessibility/TCC prompt; the app is not sandboxed.
- Focus in the non-activating panel uses the proven notch recipe: `makeKeyAndOrderFront` then an ~80ms-deferred `@FocusState` write.

## Verification
- `swift build` ✅ · `swift test` — 39 tests ✅
- `.app` bundle assembles; KeyboardShortcuts links statically (no extra dylib in the bundle) ✅
- Adversarial multi-lens review (concurrency / capture-security / memory-lifecycle / focus-UX / correctness): **0 confirmed issues**; 2 low findings fixed (clamp `selectedIndex` when the live list shrinks under the selection; signed-out empty-state copy).
- Live-tested on device: hotkey, immediate focus, ↑/↓, Return-sends, Esc/click-away ✅

## Test plan
- [ ] ⌃⌘M opens the palette from any app; search field is focused immediately (type without clicking)
- [ ] ↑/↓ move the highlight and scroll; Return picks a recipient
- [ ] Type a message + Return sends it; the recipient receives it
- [ ] Esc steps Compose→Picker and closes from Picker; click-away dismisses
- [ ] Rebinding the hotkey via the menu Recorder takes effect immediately
- [ ] Palette never appears in a screen recording / screen share
