### PR TITLE
feat: dev-only echo of broadcasts to my notch (DEBUG toggle)

### DIFF
--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -37,6 +37,16 @@ final class AppModel: ObservableObject {
     private static let relayURLKey = "relayURL"
     private static let defaultRelayURL = "wss://relay.munkel.app"
 
+    #if DEBUG
+    /// Dev-only: echo my own broadcasts into my notch (Settings toggle), so a
+    /// solo developer can see a sent message without a second member online —
+    /// the relay delivers a broadcast only to the *other* members. Default on.
+    static var devEchoBroadcasts: Bool {
+        get { (UserDefaults.standard.object(forKey: "devEchoBroadcasts") as? Bool) ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: "devEchoBroadcasts") }
+    }
+    #endif
+
     private var sessions: [String: GroupSession] = [:]
     private let notch = NotchPresenter()
     private var controlServer: ControlServer?
@@ -87,6 +97,25 @@ final class AppModel: ObservableObject {
     func send(text: String, group code: String, to memberId: String? = nil) {
         guard let session = sessions[code] else { return }
         Task { await session.sendChat(text, to: memberId) }
+        #if DEBUG
+        // Dev aid: the relay delivers a broadcast only to the *other* members,
+        // so a solo developer never sees their own message. With the Settings
+        // toggle on, echo broadcasts (to: nil) into our own notch as if they
+        // had arrived — same path the live onChat handler uses.
+        if memberId == nil, Self.devEchoBroadcasts {
+            notch.show(
+                sender: displayName,
+                avatarData: Identity.avatarData,
+                text: text,
+                isDirect: false,
+                group: code,
+                groupColor: .groupColor(index: groupCodes.firstIndex(of: code) ?? 0),
+                inMultipleGroups: groupCodes.count > 1
+            ) { [weak self] reply, _ in
+                self?.send(text: reply, group: code, to: nil)
+            }
+        }
+        #endif
     }
 
     /// Opens the quick-send command palette (also bound to the global hotkey).

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -6,6 +6,9 @@ struct MenuView: View {
     @State private var joinCode = ""
     @State private var userCodeCopied = false
     @State private var groupListHeight: CGFloat = 0
+    #if DEBUG
+    @AppStorage("devEchoBroadcasts") private var devEchoBroadcasts = true
+    #endif
 
     /// Cap before the group list starts scrolling.
     private let maxGroupListHeight: CGFloat = 360
@@ -115,6 +118,10 @@ struct MenuView: View {
             } label: {
                 Label("Quick send…", systemImage: "paperplane")
             }
+            #if DEBUG
+            Divider()
+            Toggle("Echo my broadcasts to me", isOn: $devEchoBroadcasts)
+            #endif
             Divider()
             Button {
                 NSApp.terminate(nil)


### PR DESCRIPTION
## Summary

A dev-only convenience: echo **my own broadcasts** into my notch so a solo developer can see what a sent message looks like without a second member online. The relay delivers a broadcast only to the *other* members, so today you never see your own.

A new **`#if DEBUG`-only** Settings toggle **"Echo my broadcasts to me"** (in the gear menu, default **on**) makes `AppModel.send` replay a broadcast (`to: nil`) into the local notch via the same `notch.show` path the live `onChat` handler uses.

> Stacks on #10 (`feat/command-palette`). Base will auto-retarget to `main` once #10 merges. Review/merge **after** #10.

## Changes
- `AppModel.swift` — `#if DEBUG static var devEchoBroadcasts` (UserDefaults-backed, default on) + the echo in `send()` (broadcasts only).
- `MenuView.swift` — `#if DEBUG` `@AppStorage` + a `Toggle` in the settings menu.

## Why it's safe
- **Entirely gated behind `#if DEBUG`** — no symbol leaks into release. Verified: both `swift build` (debug) and `swift build -c release` compile clean; the echo code is absent from the release binary. `make-bundle.sh` defaults to debug, so it's present in local dev builds and gone in notarized release builds.
- **Broadcasts only** (`to: nil`) — direct messages are never echoed.
- No transport change: reuses the existing `notch.show` pipeline; the echo's reply field re-broadcasts like any notch reply.

## Test plan
- [ ] With the toggle on (default), send to "Everyone" (palette or the menu's All) → the message appears in your own notch
- [ ] Sending to a specific member does **not** echo
- [ ] Toggle off → no echo; toggle persists across relaunch
- [ ] A release build (`-c release`) shows neither the toggle nor any echo
