### PR TITLE
feat: landing announce bar, munkel terminology, and notch dev simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ xcuserdata/
 
 # Turborepo
 .turbo/
+.gstack/

--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ Starting the individual apps:
 | macOS app | `cd apps/macos && ./make-bundle.sh && open .build/Munkel.app` |
 | CLI | `bunx turbo build --filter=@munkel/cli`, then `apps/cli/dist/munkel` |
 
+Watching the notch react without a second machine: with the relay and app
+running and the app joined to a circle, `scripts/simulate-whispers.sh` joins
+that circle as a second member and whispers you a message every 30 s — handy
+for demoing or iterating on the notch UI.
+
+```sh
+scripts/simulate-whispers.sh                    # blue-table-42, every 30 s
+INTERVAL=10 scripts/simulate-whispers.sh kaffee-12 Mara
+```
+
+It sends a direct whisper to your installation `memberId` (read from the app's
+UserDefaults), falling back to a circle broadcast. Override via
+`RELAY_URL` / `CIRCLE` / `SENDER` / `INTERVAL` / `TO`. Under the hood it loops
+`apps/server/scripts/dev-send.ts`, the protocol reference sender.
+
 Deploys (need a `wrangler login` with access to the `limehq` account; CI
 deploys the landing automatically on pushes to `main` that touch it):
 

--- a/apps/cli/src/munkel.ts
+++ b/apps/cli/src/munkel.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-// munkel — whisper into your friends' notches.
+// munkel — munkel into your friends' notches.
 // Thin client: talks to the running menu-bar app over its Unix control
 // socket; the app owns the relay connections and the crypto.
 
@@ -41,7 +41,7 @@ function fail(message: string, code = 1): never {
 declare const MUNKEL_BUILD_VERSION: string
 const version = typeof MUNKEL_BUILD_VERSION === "string" ? MUNKEL_BUILD_VERSION : "0.0.0-dev"
 
-const usage = `munkel — whisper into your friends' notches
+const usage = `munkel — munkel into your friends' notches
 
   munkel <circle> <recipient|all> <message…>      Send a message
   munkel circles                                 Show your circles & members
@@ -137,6 +137,6 @@ if (response.groups) {
     console.log(`${status} ${group.code}  —  ${members}`)
   }
 } else {
-  console.log("whispered ✓")
+  console.log("munkeled ✓")
 }
 process.exit(0)

--- a/apps/cli/test/munkel.test.ts
+++ b/apps/cli/test/munkel.test.ts
@@ -50,7 +50,7 @@ test("send delivers request and confirms", async () => {
   const result = await runMunkel(["blue-table-42", "Alex", "hey", "there"], app.socketPath)
 
   expect(result.exitCode).toBe(0)
-  expect(result.stdout).toContain("whispered ✓")
+  expect(result.stdout).toContain("munkeled ✓")
   expect(app.requests).toEqual([
     { action: "send", group: "blue-table-42", to: "Alex", text: "hey there" },
   ])
@@ -122,7 +122,7 @@ test("--help prints usage with exit 0", async () => {
   const result = await runMunkel(["--help"])
 
   expect(result.exitCode).toBe(0)
-  expect(result.stdout).toContain("whisper into your friends")
+  expect(result.stdout).toContain("munkel into your friends")
 })
 
 test("too few send arguments prints usage error", async () => {

--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import {
+  ArrowRight,
   Bot,
   Check,
   ChevronDown,
@@ -10,6 +11,7 @@ import {
   Laptop,
   Lock,
   MonitorOff,
+  MonitorSmartphone,
   Moon,
   Package,
   Rocket,
@@ -44,6 +46,25 @@ function GithubIcon({ className = '' }: { className?: string }) {
       <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"></path>
       <path d="M9 18c-4.51 2-5-2-7-2"></path>
     </svg>
+  )
+}
+
+/* ---------- Announce bar: cross-platform / Windows soon ---------- */
+
+function AnnounceBar() {
+  return (
+    <a
+      className="announce"
+      href={GITHUB_URL}
+      aria-label="Munkel is going cross-platform — Windows support is coming soon"
+    >
+      <span className="announce-tag">Soon</span>
+      <span className="announce-text">
+        <MonitorSmartphone aria-hidden />
+        Going cross-platform — <strong>Windows support</strong> is on the way.
+      </span>
+      <ArrowRight className="announce-arrow" aria-hidden />
+    </a>
   )
 }
 
@@ -559,10 +580,10 @@ function Hero() {
             </div>
           </div>
           <div className="demo-caption" ref={demoHintRef} aria-hidden>
-            hover to hold a whisper open — just like the real thing
+            hover to hold a munkel open — just like the real thing
           </div>
           <div className="scroll-hint" ref={hintRef}>
-            <span>See it whisper</span>
+            <span>See it munkel</span>
             <ChevronDown aria-hidden />
           </div>
         </div>
@@ -576,15 +597,15 @@ function Hero() {
 type TermStep = { type: 'cmd'; text: string } | { type: 'out'; html: string }
 
 // Mirrors the real CLI output (apps/cli/src/munkel.ts): circles print as
-// `● code  —  members`, every successful send prints `whispered ✓`.
+// `● code  —  members`, every successful send prints `munkeled ✓`.
 const TERM_SCRIPT: TermStep[] = [
   { type: 'cmd', text: 'munkel circles' },
   { type: 'out', html: '<span class="tdot-live">●</span> blue-table-42  <span class="tdim">—</span>  Alex, Sam, Morgan' },
   { type: 'out', html: '<span class="tdot-live">●</span> project-7  <span class="tdim">—</span>  Sam, Alex' },
   { type: 'cmd', text: 'munkel blue-table-42 all "table\'s free, come down"' },
-  { type: 'out', html: '<span class="tdim">whispered ✓</span>' },
+  { type: 'out', html: '<span class="tdim">munkeled ✓</span>' },
   { type: 'cmd', text: 'munkel project-7 Sam "package for you downstairs"' },
-  { type: 'out', html: '<span class="tdim">whispered ✓</span>' },
+  { type: 'out', html: '<span class="tdim">munkeled ✓</span>' },
 ]
 
 function TerminalDemo({ onFirstSend }: { onFirstSend?: () => void }) {
@@ -629,7 +650,7 @@ function TerminalDemo({ onFirstSend }: { onFirstSend?: () => void }) {
           line.querySelector('.cursor')?.remove()
         } else {
           line.innerHTML = step.html
-          if (!sentFired && step.html.includes('whispered')) {
+          if (!sentFired && step.html.includes('munkeled')) {
             sentFired = true
             onFirstSendRef.current?.()
           }
@@ -889,6 +910,7 @@ function LaunchBadgeTrack({ liveOnly = false }: { liveOnly?: boolean }) {
 function LandingPage() {
   return (
     <>
+      <AnnounceBar />
       <Nav />
       <Hero />
 
@@ -903,7 +925,7 @@ function LandingPage() {
             </p>
             <p>
               No invites, no server-side circle state. Sign in with GitHub once, then three steps and
-              you're whispering.
+              you're Munkeling.
             </p>
           </div>
           <div className="steps">
@@ -972,7 +994,7 @@ function LandingPage() {
               <h3>Ephemeral by design</h3>
               <p>
                 The relay holds zero state: no database, no logs of content. Messages exist only in
-                flight; offline means missed, like a real whisper.
+                flight; offline means missed, like a real munkel.
               </p>
             </div>
             <div className="feature">
@@ -1022,7 +1044,7 @@ function LandingPage() {
               <h3>Works without a notch</h3>
               <p>
                 Older MacBook or external display? Messages fall back to an elegant floating panel.
-                Same whisper, different hardware.
+                Same munkel, different hardware.
               </p>
             </div>
           </div>
@@ -1034,7 +1056,7 @@ function LandingPage() {
           <div className="cli-grid">
             <div className="cli-copy">
               <div className="section-kicker">CLI</div>
-              <h2>Whisper from the shell.</h2>
+              <h2>Munkel from the shell.</h2>
               <p>
                 <span className="code">munkel</span> is a thin client over the app's Unix domain
                 socket. The app owns all crypto and relay connections, the CLI just talks.
@@ -1056,7 +1078,7 @@ function LandingPage() {
             <div className="section-kicker">Agents</div>
             <h2>LLM ready.</h2>
             <p>
-              The CLI is plain text in, plain text out. Anything that can run a shell can whisper,
+              The CLI is plain text in, plain text out. Anything that can run a shell can munkel,
               including the agent you already use.
             </p>
           </div>
@@ -1080,7 +1102,7 @@ function LandingPage() {
               <h3>Skills, ready to install</h3>
               <p>
                 Prepared skills teach your agent munkel's commands in one step. Install once and
-                your assistant knows how to whisper.
+                your assistant knows how to munkel.
               </p>
             </div>
           </div>
@@ -1106,7 +1128,7 @@ function LandingPage() {
                 <h3>Invisible to screen sharing</h3>
                 <p>
                   Presenting in Zoom, Teams, or Meet? Munkel excludes its windows from screen
-                  capture. Whispers stay on your screen, never on the shared one.
+                  capture. Munkels stay on your screen, never on the shared one.
                 </p>
               </div>
             </div>
@@ -1227,7 +1249,7 @@ function LandingPage() {
             <details>
               <summary>Can I reply from the notch?</summary>
               <p>
-                Yes — click a whisper and reply right there; the notch closes again after you
+                Yes — click a munkel and reply right there; the notch closes again after you
                 send. You can also reply from the menu-bar popover or the{' '}
                 <span className="code">munkel</span> CLI.
               </p>
@@ -1253,7 +1275,7 @@ function LandingPage() {
             </p>
             <span className="founder-sig">Built for lightweight, low-pressure messages.</span>
           </div>
-          <h2>Start whispering.</h2>
+          <h2>Start Munkeling.</h2>
           <p>
             Open source, MIT licensed. A native Swift app — no Electron — one signed &amp;
             notarized binary in your menu bar.

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -131,6 +131,37 @@ button { font-family: inherit; cursor: pointer; }
 svg.lucide { width: 16px; height: 16px; stroke-width: 1.5; }
 
 /* ---------- Nav (doubles as the Mac menu bar) ---------- */
+/* Announce bar: thin strip at the very top, scrolls away under the nav */
+.announce {
+  display: flex; align-items: center; justify-content: center;
+  gap: 0.625rem; flex-wrap: wrap;
+  padding: 0.5rem 1.25rem;
+  font-size: var(--text-sm); line-height: 1.3; color: var(--foreground);
+  text-align: center;
+  background: color-mix(in oklab, var(--brand) 12%, var(--background));
+  border-bottom: 1px solid color-mix(in oklab, var(--brand) 26%, transparent);
+  transition: background 0.2s ease;
+}
+.announce:hover { background: color-mix(in oklab, var(--brand) 18%, var(--background)); }
+.announce-tag {
+  font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--background); background: var(--brand);
+  padding: 0.125rem 0.5rem; border-radius: 999px;
+}
+.announce-text { display: inline-flex; align-items: center; gap: 0.5rem; }
+.announce-text strong { font-weight: 600; }
+.announce-text svg { width: 16px; height: 16px; color: var(--brand); flex-shrink: 0; }
+.announce-arrow {
+  width: 15px; height: 15px; color: var(--muted-foreground);
+  transition: transform 0.2s ease;
+}
+.announce:hover .announce-arrow { transform: translateX(3px); }
+@media (max-width: 560px) {
+  .announce { gap: 0.5rem; padding: 0.5rem 1rem; font-size: var(--text-xs); }
+  .announce-arrow { display: none; }
+}
+
 nav {
   position: sticky; top: 0; z-index: 100;
   height: var(--nav-h);

--- a/apps/server/scripts/dev-send.ts
+++ b/apps/server/scripts/dev-send.ts
@@ -6,6 +6,9 @@
 // Usage: bun scripts/dev-send.ts <group-code> <sender-name> <text>
 //        bun scripts/dev-send.ts --listen <group-code> <sender-name>
 //        (stays connected and prints decrypted incoming messages)
+//
+// Set TO=<memberId> to direct the chat at a single member (a "whisper")
+// instead of broadcasting to the whole group; unset means broadcast.
 
 const listenMode = process.argv[2] === '--listen';
 const positional = process.argv.slice(listenMode ? 3 : 2);
@@ -108,11 +111,13 @@ ws.onopen = async () => {
     setInterval(() => ws.send(JSON.stringify({ type: 'ping' })), 30_000);
     return;
   }
+  const to = process.env.TO;
   ws.send(JSON.stringify({
     type: 'send',
+    ...(to ? { to } : {}),
     payload: await seal({ kind: 'chat', text, sentAt: new Date().toISOString() }),
   }));
-  process.stdout.write(`sent profile + chat as "${sender}"\n`);
+  process.stdout.write(`sent profile + chat as "${sender}"${to ? ` → ${to}` : ''}\n`);
   setTimeout(() => {
     ws.close();
     process.exit(0);

--- a/scripts/simulate-whispers.sh
+++ b/scripts/simulate-whispers.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# simulate-whispers.sh — run a simulated circle member that whispers you a
+# message on a fixed interval, so the Munkel notch lights up on a schedule.
+#
+# It acts as a second member of a circle (default blue-table-42), connects to
+# the same relay as the running Munkel app, and on every tick sends one
+# encrypted chat via apps/server/scripts/dev-send.ts (the protocol reference
+# sender). With the app running and joined to the circle, each whisper slides
+# out of the notch.
+#
+# Prerequisites (the script checks the first two):
+#   - bun on PATH
+#   - the relay running          (cd apps/server && bun run dev)
+#   - the Munkel app running and joined to $CIRCLE on the same relay
+#
+# Usage:
+#   scripts/simulate-whispers.sh [circle] [sender-name]
+#
+# Env overrides:
+#   INTERVAL    seconds between whispers (default 30)
+#   RELAY_URL   relay websocket          (default ws://127.0.0.1:8787)
+#   CIRCLE      circle code              (default blue-table-42)
+#   SENDER      simulated sender name    (default Sim)
+#   TO          recipient memberId for a direct whisper. When unset the script
+#               auto-discovers the local Munkel app's own memberId from its
+#               UserDefaults and whispers you directly; if that is unavailable
+#               it falls back to a circle broadcast (which you still see).
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dev_send="$repo_root/apps/server/scripts/dev-send.ts"
+
+INTERVAL="${INTERVAL:-30}"
+RELAY_URL="${RELAY_URL:-ws://127.0.0.1:8787}"
+CIRCLE="${1:-${CIRCLE:-blue-table-42}}"
+SENDER="${2:-${SENDER:-Sim}}"
+
+command -v bun >/dev/null 2>&1 || { echo "simulate: bun not found on PATH" >&2; exit 1; }
+[[ -f "$dev_send" ]] || { echo "simulate: missing $dev_send" >&2; exit 1; }
+
+# Direct-whisper target: explicit TO wins, else the local app's own
+# installation memberId from its UserDefaults — i.e. you, whoever is signed in
+# on this machine (empty string => broadcast in dev-send).
+to="${TO:-}"
+if [[ -z "$to" ]]; then
+  to="$(defaults read dev.uq.munkel memberId 2>/dev/null || true)"
+fi
+target_desc="circle broadcast"
+[[ -n "$to" ]] && target_desc="direct whisper → ${to}"
+
+# Rotating lines so the stream feels alive rather than a repeated ping.
+lines=(
+  "Kaffee? ☕️"
+  "Bin am Tisch in der Ecke"
+  "Schau mal aus dem Fenster 🌅"
+  "Noch 5 Minuten ⏳"
+  "Lust auf Mittag?"
+  "Das Meeting ist verschoben"
+  "👀 hinter dir"
+  "Frohes Flüstern!"
+  "Gut geschlafen?"
+  "Tick vom Simulator"
+)
+
+n=0
+# INT/TERM must exit (a trap that only prints would let the loop run on,
+# ignoring Ctrl-C). The EXIT trap prints the summary exactly once.
+trap 'exit 0' INT TERM
+trap 'printf "\nsimulate: stopped after %d whisper(s).\n" "$n"' EXIT
+
+printf 'simulate: "%s" whispers you in [%s] every %ss (%s)\n' \
+  "$SENDER" "$CIRCLE" "$INTERVAL" "$target_desc"
+printf 'simulate: relay %s — Ctrl-C to stop\n' "$RELAY_URL"
+
+while true; do
+  n=$((n + 1))
+  msg="${lines[$(((n - 1) % ${#lines[@]}))]} (#$n)"
+  printf '[%s] simulate -> whisper #%d: %s\n' "$(date +%H:%M:%S)" "$n" "$msg"
+  if ! MEMBER_ID="sim-peer" TO="$to" RELAY_URL="$RELAY_URL" \
+       bun "$dev_send" "$CIRCLE" "$SENDER" "$msg" >/tmp/munkel-sim-last.log 2>&1; then
+    printf '[%s] simulate: send failed — relay up? app joined to %s? (see /tmp/munkel-sim-last.log)\n' \
+      "$(date +%H:%M:%S)" "$CIRCLE" >&2
+  fi
+  sleep "$INTERVAL"
+done

--- a/skills/munkel/SKILL.md
+++ b/skills/munkel/SKILL.md
@@ -6,7 +6,7 @@ description: Send ephemeral end-to-end-encrypted messages that appear in
   to a circle, or list Munkel circles and members.
 ---
 
-# munkel — whisper into your friends' notches
+# munkel — munkel into your friends' notches
 
 Munkel delivers ephemeral E2E-encrypted messages that slide out of the
 recipient's MacBook notch. The CLI is **send-only**: it cannot read,
@@ -47,7 +47,7 @@ names.
 
 ## Behavior and errors
 
-Success prints `whispered ✓` and exits 0.
+Success prints `munkeled ✓` and exits 0.
 
 - `Munkel app isn't running` — the app is not running; launch it with
   `open -a Munkel` (or ask the user to).


### PR DESCRIPTION
## Summary

Three small, independent improvements that were sitting as local WIP, reconciled onto current `main` (post-`v0.2.0`) and verified end-to-end:

- **feat(landing)** — a thin announce bar above the nav teasing upcoming Windows / cross-platform support, with matching styles. Coexists with the existing launch-badge track.
- **refactor + landing copy** — adopt the **"munkel" / "Munkeling"** verb instead of "whisper" across CLI output (`munkeled ✓`), usage and skill headings, and the landing-page copy + terminal demo.
- **feat(dev)** — `scripts/simulate-whispers.sh`: a notch simulator that joins a circle as a second member and sends on an interval, so the notch lights up on a schedule (demo / iterate on the notch without a second machine). Adds a `TO` env var to `apps/server/scripts/dev-send.ts` to direct a chat at a single member instead of broadcasting. Documented in the README.
- **chore** — ignore `.gstack/`.

## Test plan

Verified live against a local relay (`wrangler dev` on `:8787`), app joined to `blue-table-42`:

- [x] Branch compiles — `make-bundle.sh` → `Munkel.app`
- [x] App ↔ relay connection, control socket, and `munkel circles`
- [x] Presence round-trip (a second member shows as online)
- [x] Incoming **direct whisper** → decrypted (no errors), notch shown; correctly **not** delivered to other members
- [x] Incoming **broadcast** → decrypted, notch shown; an independent TS peer also decrypted it
- [x] **Outgoing** send/reply → decrypted by an independent TS peer (Swift↔TS crypto interop, both directions)
- [x] Command palette (`⌥M`) opens & sends — confirmed visually
- [x] `bun run typecheck` (landing + cli + server) and CLI `bun test` (10/0) green locally

The full Swift Kit `swift test` suite + server unit/e2e run as the required CI checks on this PR.
