### PR TITLE
feat(cli): auto-start the Munkel app when its socket is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ munkel blue-table-42 all "coffee?"  # circle broadcast
 
 The CLI is a thin client: it talks to the running app over
 `~/Library/Application Support/Munkel/control.sock` (newline-delimited
-JSON; see `ControlProtocol.swift`, mirrored in `apps/cli/src/munkel.ts`). The
+JSON; see `ControlProtocol.swift`, mirrored in `apps/cli/src/munkel.ts`). If
+the app isn't running, the CLI launches it in the background (`open -g -b
+dev.uq.munkel`) and waits for the socket before sending. The
 socket path can be overridden via `MUNKEL_SOCKET` (used by the tests). The
 app resolves circle-code prefixes and recipient display names, and owns all
 crypto and relay connections — ideal substrate for scripting and agent

--- a/apps/cli/src/munkel.ts
+++ b/apps/cli/src/munkel.ts
@@ -92,9 +92,8 @@ function feed(text: string) {
   }
 }
 
-let socket
-try {
-  socket = await Bun.connect({
+function connectOnce() {
+  return Bun.connect({
     unix: socketPath,
     socket: {
       data(_socket, data) {
@@ -107,9 +106,54 @@ try {
         resolve(received)
       },
     },
-  })
-} catch {
-  fail(`Munkel app isn't running — start it first (socket: ${socketPath})`)
+  }).catch(() => null)
+}
+
+// Ask macOS to launch the menu-bar app. `open -g` brings it up in the
+// background without stealing focus from the terminal; the bundle id is
+// stamped by make-bundle.sh. MUNKEL_LAUNCH_CMD overrides the command (used
+// by the tests to stand up a fake app).
+async function launchApp(): Promise<void> {
+  const override = process.env.MUNKEL_LAUNCH_CMD
+  const command = override ? ["sh", "-c", override] : ["open", "-g", "-b", "dev.uq.munkel"]
+  const proc = Bun.spawn(command, { stdout: "ignore", stderr: "pipe" })
+  if ((await proc.exited) !== 0) {
+    const detail = (await new Response(proc.stderr).text()).trim()
+    fail(
+      `couldn't start the Munkel app${detail ? ` (${detail})` : ""} — ` +
+        `install it with: brew install limehq/tap/munkel`,
+    )
+  }
+}
+
+// The app's control socket binds in AppModel.init(), so it appears shortly
+// after launch — poll until it's reachable or we give up.
+async function waitForSocket(timeoutMs = 8000, intervalMs = 150) {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const socket = await connectOnce()
+    if (socket) return socket
+    if (Date.now() >= deadline) return null
+    await Bun.sleep(intervalMs)
+  }
+}
+
+let socket = await connectOnce()
+if (!socket) {
+  // A custom MUNKEL_SOCKET points at a specific server we shouldn't try to
+  // spawn; only auto-launch the installed app on the default path (the
+  // tests opt back in by setting MUNKEL_LAUNCH_CMD).
+  const autoLaunch =
+    process.env.MUNKEL_SOCKET === undefined || process.env.MUNKEL_LAUNCH_CMD !== undefined
+  if (!autoLaunch) {
+    fail(`Munkel app isn't running — start it first (socket: ${socketPath})`)
+  }
+  console.error("munkel: starting the Munkel app…")
+  await launchApp()
+  socket = await waitForSocket()
+  if (!socket) {
+    fail("started the Munkel app but its control socket never came up")
+  }
 }
 
 socket.write(JSON.stringify(request) + "\n")

--- a/apps/cli/test/munkel.test.ts
+++ b/apps/cli/test/munkel.test.ts
@@ -104,11 +104,60 @@ test("invalid response is rejected", async () => {
   expect(result.stderr).toContain("No valid response")
 })
 
-test("missing app yields a helpful error", async () => {
+test("custom socket with no app yields a helpful error (no auto-launch)", async () => {
+  // A custom MUNKEL_SOCKET (set by runMunkel) is treated as "point at this
+  // server"; the CLI must not try to spawn the installed app.
   const result = await runMunkel(["blue-table-42", "all", "hi"])
 
   expect(result.exitCode).toBe(1)
   expect(result.stderr).toContain("Munkel app isn't running")
+})
+
+test("auto-launches the app when its socket is down", async () => {
+  const socketPath = join(
+    tmpdir(),
+    `munkel-launch-${process.pid}-${Math.random().toString(36).slice(2)}.sock`,
+  )
+  // Stands in for `open -b dev.uq.munkel`: backgrounds a fake app that binds
+  // the socket a moment later, so the CLI exercises its launch + wait + retry.
+  const launcher = join(
+    tmpdir(),
+    `munkel-launcher-${process.pid}-${Math.random().toString(36).slice(2)}.ts`,
+  )
+  await Bun.write(
+    launcher,
+    [
+      "const server = Bun.listen({",
+      "  unix: process.argv[2],",
+      "  socket: {",
+      "    data(socket) {",
+      '      socket.write(JSON.stringify({ ok: true, groups: [] }) + "\\n")',
+      "      socket.end()",
+      "    },",
+      "  },",
+      "})",
+      "setTimeout(() => server.stop(true), 5000)",
+    ].join("\n"),
+  )
+
+  const proc = Bun.spawn(["bun", cliPath, "circles"], {
+    env: {
+      ...process.env,
+      MUNKEL_SOCKET: socketPath,
+      MUNKEL_LAUNCH_CMD: `bun ${launcher} ${socketPath} &`,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  expect(exitCode).toBe(0)
+  expect(stderr).toContain("starting the Munkel app")
+  expect(stdout).toContain("No circles yet")
 })
 
 test("no arguments prints usage with exit 64", async () => {

--- a/skills/munkel/SKILL.md
+++ b/skills/munkel/SKILL.md
@@ -15,8 +15,9 @@ Munkel.app, which owns circles, crypto, and the relay connection.
 
 ## Requirements
 
-- macOS with Munkel.app installed and **running**:
-  `brew install limehq/tap/munkel`, then `open -a Munkel`.
+- macOS with Munkel.app installed: `brew install limehq/tap/munkel`. If the
+  app isn't running, the CLI launches it automatically (in the background)
+  and waits for it before sending — no need to `open -a Munkel` first.
 - The user must already be in a circle — circles are created/joined in the
   app's menu-bar UI, not the CLI.
 
@@ -49,8 +50,11 @@ names.
 
 Success prints `munkeled ✓` and exits 0.
 
-- `Munkel app isn't running` — the app is not running; launch it with
-  `open -a Munkel` (or ask the user to).
+- The CLI auto-starts Munkel.app if it isn't running and waits for it. A
+  `couldn't start the Munkel app` error means the launch itself failed —
+  the app likely isn't installed (`brew install limehq/tap/munkel`).
+- `Munkel app isn't running` only appears when a custom `MUNKEL_SOCKET` is
+  set (auto-launch is skipped for custom sockets).
 - Unknown circle / recipient errors come from the app; re-check with
   `munkel circles`.
 - Exit 64 means a usage error (wrong arguments).


### PR DESCRIPTION
## What

When `munkel <cmd>` runs and the app isn't up, the CLI now **launches Munkel.app in the background and waits for its control socket** before sending — instead of failing with "Munkel app isn't running".

## How

- `connectOnce()` — single connect attempt, returns the socket or `null`.
- On failure → `launchApp()` runs `open -g -b dev.uq.munkel` (background, no focus steal; bundle id from `make-bundle.sh`).
- `waitForSocket()` polls (150 ms / 8 s timeout) until `AppModel.init()` binds the socket, then does the normal roundtrip.

### Guards & errors
- Auto-launch only fires on the **default socket**. A custom `MUNKEL_SOCKET` (= "point at this server") still errors with `Munkel app isn't running`; tests opt back in via the new `MUNKEL_LAUNCH_CMD` seam.
- `open` failure → `couldn't start the Munkel app … brew install limehq/tap/munkel` (app not installed).
- Progress note goes to **stderr** so stdout (e.g. `munkel circles`) stays clean.

## Docs
`skills/munkel/SKILL.md` and `README.md` updated for the auto-start behavior.

## Test plan
- [x] `bun test` — 11 pass / 0 fail (incl. new `auto-launches the app when its socket is down`)
- [x] `tsc --noEmit` — clean
- [ ] Manual: quit Munkel.app, run `munkel circles`, confirm it relaunches and lists circles

🤖 Generated with [Claude Code](https://claude.com/claude-code)