### PR TITLE
fix(macos): activate app before showing the menu-bar popover

### DIFF
--- a/apps/macos/Sources/MunkelApp/MunkelApp.swift
+++ b/apps/macos/Sources/MunkelApp/MunkelApp.swift
@@ -48,6 +48,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         if popover.isShown {
             popover.performClose(sender)
         } else if Date().timeIntervalSince(lastClose) > 0.2 {
+            // A status-item click does not activate an accessory (LSUIElement)
+            // app, and a transient popover shown by an inactive app dismisses
+            // itself on the very next event — so it flickers open and shut.
+            // Activating first makes the popover's window key for real and
+            // keeps it open until the user clicks away.
+            NSApp.activate(ignoringOtherApps: true)
             popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
             let window = popover.contentViewController?.view.window
             window?.makeKey()


### PR DESCRIPTION
## Summary

The menu-bar popover flickered open and shut on click — clicking the status item opened it, then it immediately dismissed itself, so the menu was unusable.

**Root cause:** a status-item click does not activate an accessory (`LSUIElement`) app, and a transient `NSPopover` shown by an inactive app dismisses itself on the very next event. Reliably reproducible on macOS 26 (Tahoe).

**Fix:** call `NSApp.activate(ignoringOtherApps:)` before `popover.show(...)`, so the popover's window becomes key for real and stays open until the user clicks away. This matches the activation `MenuView` already performs for *About* / *Check for Updates*.

## Test plan

- [ ] Click the menu-bar bubble icon → popover opens and **stays open** until clicking away or clicking the icon again.
- [ ] Click the icon while open → closes, no reopen flicker.
- [ ] Reopen after closing still works.