### PR TITLE
fix(macos): bundle SwiftPM resources into the .app

### DIFF
--- a/apps/macos/make-bundle.sh
+++ b/apps/macos/make-bundle.sh
@@ -32,6 +32,18 @@ mkdir -p "$BUNDLE/Contents/MacOS"
 
 cp "$BIN_PATH/munkel" "$BUNDLE/Contents/MacOS/Munkel"
 
+# SwiftPM emits each package's resources as a *.bundle next to the binary.
+# They have to ride inside the .app: KeyboardShortcuts (and any other resourced
+# dependency) loads them at runtime through Bundle.module, which resolves
+# relative to Bundle.main.resourceURL = Contents/Resources. Without them the
+# first render of KeyboardShortcuts.Recorder trips Bundle.module's fatalError
+# and the whole app traps (EXC_BREAKPOINT). Copy before codesign so the outer
+# signature seals them. (N) = zsh null-glob so an empty match can't abort set -e.
+mkdir -p "$BUNDLE/Contents/Resources"
+for res in "$BIN_PATH"/*.bundle(N); do
+  cp -R "$res" "$BUNDLE/Contents/Resources/"
+done
+
 cat > "$BUNDLE/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">


### PR DESCRIPTION
## Summary

Opening the menu-bar popover crashed the whole app — it looked like the menu "closed" on click. This is the real fix for that crash. **0.4.1 (#20) did not fix it**: that change activated the app before showing the popover, but the popover was never the problem.

**Root cause (packaging):** `make-bundle.sh` copied only the executable into `Munkel.app`, omitting the SwiftPM-generated resource bundles — notably `KeyboardShortcuts_KeyboardShortcuts.bundle`. The first time SwiftUI renders `KeyboardShortcuts.Recorder` (the "Quick send" hotkey row), the library's `Bundle.module` accessor searches `Bundle.main.resourceURL` and `fatalError`s when the bundle isn't there → `EXC_BREAKPOINT`/`SIGTRAP`, taking down the whole app. This shipped in every release built by this script (0.4.0 and 0.4.1).

Crash backtrace (top frames):
```
_assertionFailure
closure #1 in static var Bundle.module
KeyboardShortcuts.RecorderCocoa.init(for:onChange:)
makeNSView … conformance KeyboardShortcuts._Recorder
```

## Fix

Copy every `*.bundle` next to the built binary into `Contents/Resources/` before codesigning, so each package's `Bundle.module` resolves at runtime via `Bundle.main.resourceURL`.

## Verification

- Host-arch **and** universal (`MUNKEL_ARCHS='arm64 x86_64'`, the CI release path) both produce `Contents/Resources/KeyboardShortcuts_KeyboardShortcuts.bundle`; `lipo` shows `x86_64 arm64`; `codesign --verify --deep --strict` passes.
- Ran the signed build and opened the menu from the status item: opens, **stays open, no crash** (crash-report count unchanged).

## Note

The `NSApp.activate(…)` added in #20 is now redundant (the menu opens and stays open without it) but harmless — left in place. Can revert separately if preferred.