### PR TITLE
build(macos): bundle the app with Swift Bundler

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,7 +43,8 @@ Pushing a tag `v<version>` runs `.github/workflows/release.yml`:
 
 1. `scripts/build-release.sh <version>` — orchestration only. Each app
    builds itself via its `build:release` workspace script:
-   `@munkel/macos` (universal SPM build via `--arch` flags, wrapped by
+   `@munkel/macos` (universal build via [Swift Bundler](https://github.com/moreSwift/swift-bundler),
+   pinned and built on demand by `scripts/ensure-swift-bundler.sh`, wrapped by
    `make-bundle.sh`) and `@munkel/cli` (two `bun build --compile` targets
    + `lipo`, version stamped via `--define`). The root script stages
    `Munkel.app` + `bin/munkel`, signs with Developer ID + hardened runtime

--- a/apps/macos/Bundler.toml
+++ b/apps/macos/Bundler.toml
@@ -1,0 +1,16 @@
+# Swift Bundler config for the Munkel menu-bar app. make-bundle.sh injects the
+# real CFBundleShortVersionString at build time (from MUNKEL_VERSION) through a
+# throwaway copy of this file, so the version below is only a placeholder.
+format_version = 2
+
+[apps.Munkel]
+product = "munkel"
+version = "0.0.0"
+identifier = "dev.uq.munkel"
+
+# Accessory (menu-bar) app: no Dock icon. Swift Bundler generates the base
+# Info.plist; these entries are merged on top.
+[apps.Munkel.plist]
+LSUIElement = true
+LSMinimumSystemVersion = "14.0"
+NSHighResolutionCapable = true

--- a/apps/macos/make-bundle.sh
+++ b/apps/macos/make-bundle.sh
@@ -1,78 +1,59 @@
 #!/bin/zsh
-# Wraps the SPM-built binary into a minimal .app bundle so macOS treats it
-# as a real menu-bar app (status item, stable UserDefaults domain, TCC).
+# Bundles the SwiftPM executable into a signed Munkel.app via Swift Bundler.
 #
-# Env overrides (all optional, defaults preserve local dev behavior):
+# Swift Bundler (pinned, built on demand by scripts/ensure-swift-bundler.sh)
+# assembles the .app from Bundler.toml: it embeds the SwiftPM resource bundles
+# (KeyboardShortcuts'), the Info.plist, and any dynamic libraries. The previous
+# hand-rolled version copied only the executable and silently dropped the
+# resource bundle, which crashed the app the moment its menu opened.
+#
+# Contract is unchanged, so build-release.sh / package.json / docs keep working:
+#   $1                 build configuration: debug (default) | release
 #   MUNKEL_VERSION     CFBundleShortVersionString (default 0.1.0)
-#   MUNKEL_ARCHS       space-separated archs for a universal build,
-#                      e.g. "arm64 x86_64" (default: host arch only)
-#   CODESIGN_IDENTITY  signing identity (default "-" = ad-hoc; release
-#                      builds pass "Developer ID Application: ...")
+#   MUNKEL_ARCHS       space-separated archs, e.g. "arm64 x86_64" (default: host)
+#   CODESIGN_IDENTITY  signing identity ("-" = ad-hoc, the default)
+# Output: .build/Munkel.app
 set -euo pipefail
 
 cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
 
 CONFIG="${1:-debug}"
 BUNDLE=".build/Munkel.app"
 VERSION="${MUNKEL_VERSION:-0.1.0}"
 IDENTITY="${CODESIGN_IDENTITY:--}"
 
-ARCH_FLAGS=()
+SWIFT_BUNDLER="$("$REPO_ROOT/scripts/ensure-swift-bundler.sh")"
+
+# Inject the version through a throwaway config so the tracked Bundler.toml never
+# carries a release-specific number (Swift Bundler has no --version override).
+CONFIG_DIR="$(mktemp -d)"
+trap 'rm -rf "$CONFIG_DIR"' EXIT
+sed "s/^version = .*/version = \"$VERSION\"/" Bundler.toml > "$CONFIG_DIR/Bundler.toml"
+
+# One --arch per requested architecture (none = host arch). The release passes
+# "arm64 x86_64" for a universal build.
+arch_flags=()
 for arch in ${=MUNKEL_ARCHS:-}; do
-  ARCH_FLAGS+=(--arch "$arch")
+  arch_flags+=(--arch "$arch")
 done
 
-swift build -c "$CONFIG" "${ARCH_FLAGS[@]}"
-# With --arch flags SPM routes through XCBuild and the product lands in
-# .build/apple/Products/ instead of .build/<config>/ — resolve either way.
-BIN_PATH="$(swift build -c "$CONFIG" "${ARCH_FLAGS[@]}" --show-bin-path)"
+"$SWIFT_BUNDLER" bundle \
+  --config-file "$CONFIG_DIR/Bundler.toml" \
+  --configuration "$CONFIG" \
+  --scratch-path .build \
+  "${arch_flags[@]}"
 
+# Swift Bundler writes to .build/bundler/apps/Munkel/Munkel.app; move it to the
+# path the rest of the pipeline (build-release.sh, README) expects.
 rm -rf "$BUNDLE"
-mkdir -p "$BUNDLE/Contents/MacOS"
+/usr/bin/ditto ".build/bundler/apps/Munkel/Munkel.app" "$BUNDLE"
 
-cp "$BIN_PATH/munkel" "$BUNDLE/Contents/MacOS/Munkel"
-
-# SwiftPM emits each package's resources as a *.bundle next to the binary.
-# They have to ride inside the .app: KeyboardShortcuts (and any other resourced
-# dependency) loads them at runtime through Bundle.module, which resolves
-# relative to Bundle.main.resourceURL = Contents/Resources. Without them the
-# first render of KeyboardShortcuts.Recorder trips Bundle.module's fatalError
-# and the whole app traps (EXC_BREAKPOINT). Copy before codesign so the outer
-# signature seals them. (N) = zsh null-glob so an empty match can't abort set -e.
-mkdir -p "$BUNDLE/Contents/Resources"
-for res in "$BIN_PATH"/*.bundle(N); do
-  cp -R "$res" "$BUNDLE/Contents/Resources/"
-done
-
-cat > "$BUNDLE/Contents/Info.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>CFBundleExecutable</key>
-	<string>Munkel</string>
-	<key>CFBundleIdentifier</key>
-	<string>dev.uq.munkel</string>
-	<key>CFBundleName</key>
-	<string>Munkel</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>${VERSION}</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>14.0</string>
-	<key>LSUIElement</key>
-	<true/>
-	<key>NSHighResolutionCapable</key>
-	<true/>
-</dict>
-</plist>
-PLIST
-
+# Swift Bundler ad-hoc signs; re-sign with our identity (hardened runtime +
+# secure timestamp are notarization prerequisites) or a clean ad-hoc signature.
 if [[ "$IDENTITY" == "-" ]]; then
   codesign --force --sign - "$BUNDLE" >/dev/null 2>&1 || true
 else
-  # Hardened runtime + secure timestamp are notarization prerequisites.
   codesign --force --options runtime --timestamp --sign "$IDENTITY" "$BUNDLE"
 fi
 

--- a/scripts/ensure-swift-bundler.sh
+++ b/scripts/ensure-swift-bundler.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Builds a pinned Swift Bundler and prints the path to its binary on stdout.
+#
+# Swift Bundler turns the SwiftPM executable into a real .app — embedding the
+# SwiftPM resource bundles, the Info.plist, and any dynamic libraries — which
+# the previous hand-rolled bundler silently dropped (crashing the app the moment
+# its menu opened). It has no usable tagged release (the newest tag predates the
+# Bundler.toml format), so we pin a reviewed commit on main and build from
+# source. The build is cached under the user cache dir, so only the first run on
+# a machine (and CI's first release on the self-hosted runner) pays the compile.
+#
+# All diagnostics go to stderr; stdout is exactly the binary path, so callers do:
+#   SWIFT_BUNDLER="$(scripts/ensure-swift-bundler.sh)"
+set -euo pipefail
+
+PIN="59a150488e92beb049d775736047e62d5be23323"
+REPO="https://github.com/moreSwift/swift-bundler"
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/munkel/swift-bundler/$PIN"
+BIN="$CACHE_DIR/swift-bundler"
+
+if [[ -x "$BIN" ]]; then
+  echo "$BIN"
+  exit 0
+fi
+
+echo "ensure-swift-bundler: building pinned Swift Bundler ${PIN:0:12} (first run on this machine)…" >&2
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+git -C "$work" init -q
+git -C "$work" remote add origin "$REPO"
+# Fetch only the pinned commit (GitHub allows fetching a SHA directly).
+git -C "$work" fetch -q --depth 1 origin "$PIN"
+git -C "$work" checkout -q FETCH_HEAD
+swift build --package-path "$work" -c release >&2
+mkdir -p "$CACHE_DIR"
+cp "$work/.build/release/swift-bundler" "$BIN"
+echo "$BIN"


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `.app` assembly in `make-bundle.sh` with [Swift Bundler](https://github.com/moreSwift/swift-bundler): the bundle is now built declaratively from `Bundler.toml` instead of by copying files by hand.

The hand-rolled script copied only the executable and silently dropped KeyboardShortcuts' SwiftPM resource bundle — which crashed the app (`Bundle.module` `fatalError` / `EXC_BREAKPOINT`) the moment its menu opened. #22 patched that reactively by hand-copying `*.bundle`; this removes the whole class of "forgot to copy X" packaging bugs by letting the tool that understands SwiftPM products do the bundling (resources, Info.plist, dynamic libs, PkgInfo).

## What changed

- **`apps/macos/Bundler.toml`** (new): declarative app config — `identifier = "dev.uq.munkel"`, `LSUIElement`, `LSMinimumSystemVersion`, `NSHighResolutionCapable`. Replaces the inline Info.plist heredoc.
- **`scripts/ensure-swift-bundler.sh`** (new): builds a pinned Swift Bundler on demand, cached under `$XDG_CACHE_HOME` (only the first build on a machine pays the compile). Swift Bundler has no usable tagged release — the newest tag predates the `Bundler.toml` format — so it's pinned to a reviewed `main` commit (`59a1504`).
- **`apps/macos/make-bundle.sh`**: thin wrapper. **Same contract** (env `MUNKEL_VERSION` / `MUNKEL_ARCHS` / `CODESIGN_IDENTITY`, output `.build/Munkel.app`), so `build-release.sh`, `package.json`, and the docs are unchanged. Version is injected via a throwaway config copy; Developer ID + hardened-runtime + secure-timestamp signing stays a post-step (Swift Bundler can't add those).
- **`RELEASING.md`**: accuracy.

## Verification (all green locally)

| Path | Result |
|---|---|
| Dev (ad-hoc, host arch) | resource bundle ✓ · `LSUIElement` ✓ · version injected ✓ · ad-hoc signed ✓ |
| Release (universal, Developer ID) | `x86_64 arm64` ✓ · hardened runtime ✓ · `codesign --verify --deep --strict` valid ✓ |
| Full `build-release.sh 0.0.0-dev` | macOS + CLI build, staging, smoke test, zip — exit 0 ✓ |

## Notes

- **CI builds Swift Bundler on the first release** (self-hosted runner compiles it once, cached afterward). No manual setup.
- Swift Bundler prints a benign warning ("SwiftPM has multiple bugs related to universal builds… try `--xcodebuild`") — the universal build succeeds anyway (`lipo` shows both slices). If a future universal build ever breaks, the documented fix is `--xcodebuild` in `make-bundle.sh`.
- `build:` commit — no version bump intended; no user-facing change (0.4.2 already ships the resource fix).