### PR TITLE
feat(release): embed CLI in app bundle, ship a DMG download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
-# Tag push (v0.2.0) → universal build → Developer ID signing → notarization
-# → stapling → GitHub release → cask bump in limehq/homebrew-tap.
+# Tag push (v0.2.0) → universal build (app with the munkel CLI embedded) →
+# Developer ID signing → notarization → staple app → drag-to-Applications DMG →
+# notarize + staple DMG → GitHub release → cask bump in limehq/homebrew-tap.
 #
 # Required repository secrets (see RELEASING.md for how to create each):
 #   MACOS_CERTIFICATE_P12       base64 of the Developer ID Application .p12
@@ -61,7 +62,7 @@ jobs:
           security list-keychains -d user -s build.keychain login.keychain
           rm cert.p12
 
-      - name: Build, sign, zip
+      - name: Build & sign app
         env:
           CODESIGN_IDENTITY: ${{ vars.CODESIGN_IDENTITY }}
         run: |
@@ -69,50 +70,57 @@ jobs:
           scripts/build-release.sh "$VERSION"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - name: Notarize and staple
+      - name: Notarize, staple, and build DMG
         env:
           API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
           API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
         run: |
           echo "$API_KEY_P8" | base64 --decode > AuthKey.p8
-          xcrun notarytool submit "dist/Munkel-$VERSION.zip" \
-            --key AuthKey.p8 --key-id "$API_KEY_ID" \
-            --issuer "$API_ISSUER_ID" --wait
-          rm AuthKey.p8
-          # A zip cannot be stapled — staple the .app, then re-zip. The bare
-          # CLI binary cannot be stapled either; Gatekeeper checks its
-          # notarization ticket online, which is normal for cask binaries.
+          notarize() {
+            xcrun notarytool submit "$1" \
+              --key AuthKey.p8 --key-id "$API_KEY_ID" \
+              --issuer "$API_ISSUER_ID" --wait
+          }
+          # Notarize the app (submitted as a zip — notarytool needs a container),
+          # then staple the ticket onto the .app so it launches offline once
+          # dragged out of the DMG. The embedded munkel CLI is covered by the
+          # same notarization and staple — no online check, unlike a bare binary.
+          notarize "dist/Munkel-$VERSION.zip"
           xcrun stapler staple dist/stage/Munkel.app
           spctl -a -vv dist/stage/Munkel.app
-          cd dist/stage
-          /usr/bin/ditto -c -k . "../Munkel-$VERSION.zip"
+          # Build the drag-to-Applications DMG from the stapled app, then
+          # notarize and staple the DMG itself so it opens without a warning.
+          scripts/build-dmg.sh "$VERSION"
+          notarize "dist/Munkel-$VERSION.dmg"
+          xcrun stapler staple "dist/Munkel-$VERSION.dmg"
+          rm AuthKey.p8
 
       - name: Checksum release artifact
-        run: shasum -a 256 "dist/Munkel-$VERSION.zip" | tee "dist/Munkel-$VERSION.zip.sha256"
+        run: shasum -a 256 "dist/Munkel-$VERSION.dmg" | tee "dist/Munkel-$VERSION.dmg.sha256"
 
       - name: Attest release artifact
         id: attest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: dist/Munkel-${{ env.VERSION }}.zip
+          subject-path: dist/Munkel-${{ env.VERSION }}.dmg
 
       - name: Publish provenance bundle as a release asset
         # The attestation also lands in GitHub's attestation store, but consumers
         # (and OpenSSF Scorecard) only see release assets — ship the Sigstore
-        # bundle alongside the zip so the release is verifiably signed offline.
-        run: cp "${{ steps.attest.outputs.bundle-path }}" "dist/Munkel-$VERSION.zip.sigstore.json"
+        # bundle alongside the DMG so the release is verifiably signed offline.
+        run: cp "${{ steps.attest.outputs.bundle-path }}" "dist/Munkel-$VERSION.dmg.sigstore.json"
 
       - name: Upload artifact to GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           # release-please already created the release with changelog notes;
-          # this only attaches the zip (softprops upserts by tag).
+          # this only attaches the DMG (softprops upserts by tag).
           tag_name: ${{ github.ref_name }}
           files: |
-            dist/Munkel-${{ env.VERSION }}.zip
-            dist/Munkel-${{ env.VERSION }}.zip.sha256
-            dist/Munkel-${{ env.VERSION }}.zip.sigstore.json
+            dist/Munkel-${{ env.VERSION }}.dmg
+            dist/Munkel-${{ env.VERSION }}.dmg.sha256
+            dist/Munkel-${{ env.VERSION }}.dmg.sigstore.json
 
       - name: Bump cask in homebrew-tap
         env:
@@ -122,7 +130,7 @@ jobs:
             echo "::warning::TAP_GITHUB_TOKEN not set — skipping cask bump (tap repo not wired up yet)"
             exit 0
           fi
-          SHA256="$(shasum -a 256 "dist/Munkel-$VERSION.zip" | awk '{print $1}')"
+          SHA256="$(shasum -a 256 "dist/Munkel-$VERSION.dmg" | awk '{print $1}')"
           git clone "https://x-access-token:$GH_TOKEN@github.com/limehq/homebrew-tap.git" tap
           mkdir -p tap/Casks
           scripts/build-brew-cask.sh "$VERSION" "$SHA256" tap/Casks/munkel.rb

--- a/README.md
+++ b/README.md
@@ -19,15 +19,24 @@ Website: **[munkel.app](https://munkel.app)**
 
 ## Install
 
-After the first public release is published:
+**Homebrew** — app plus the `munkel` CLI:
 
 ```sh
 brew install limehq/tap/munkel
 open -a Munkel
 ```
 
-The cask installs `Munkel.app` and the `munkel` CLI. Until a release artifact is
-available, build locally from source:
+The cask installs `Munkel.app` and symlinks the bundled `munkel` CLI onto your
+`PATH`.
+
+**Direct download** — app only: grab `Munkel-<version>.dmg` from the
+[latest release](https://github.com/limehq/munkel/releases/latest) and drag
+`Munkel.app` into Applications. The `munkel` CLI ships inside the app; to put it
+on your `PATH`, open Munkel and choose **Install Command Line Tool…** from the
+menu-bar gear menu. (The CLI talks to the running app, so it needs the app
+either way.)
+
+Or build locally from source:
 
 ```sh
 bun install

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,24 +1,35 @@
-# Releasing Munkel via Homebrew
+# Releasing Munkel
 
-End-user install (after the first release is published):
+Two install paths, **one artifact** — the `munkel` CLI is embedded inside the
+app bundle (`Munkel.app/Contents/Resources/munkel`), so there is nothing
+separate to download or version:
 
 ```sh
 brew install limehq/tap/munkel      # taps automatically, installs app + CLI
 ```
 
-The cask puts `Munkel.app` into `/Applications` and symlinks the `munkel`
-CLI into `$(brew --prefix)/bin`. One artifact, one command.
+The cask puts `Munkel.app` into `/Applications` and symlinks the embedded
+`munkel` CLI into `$(brew --prefix)/bin` (the `binary` stanza points at the
+binary inside the bundle).
+
+Direct download: the `Munkel-<version>.dmg` release asset is a classic
+drag-to-Applications image. It carries the CLI too, but inert — DMG users put
+`munkel` on their PATH from the app's **Install Command Line Tool…** menu
+(`Sources/MunkelApp/CLIInstaller.swift`), which symlinks the embedded binary
+into `/usr/local/bin` after one admin prompt. The CLI talks to the running app
+over a Unix socket, so it is useless without the app either way — hence no
+standalone CLI distribution.
 
 ## Versioning
 
-One **SemVer product version** for the whole artifact — app and CLI ship
-together in one zip and are version-locked by design (the CLI talks to the
-app's control socket), so they never get separate numbers. The
+One **SemVer product version** for the whole artifact — app and embedded CLI
+ship together in one bundle and are version-locked by design (the CLI talks to
+the app's control socket), so they never get separate numbers. The
 **git tag is the single source of truth**; nothing is hardcoded:
 
 | Where the number lands | How it gets there |
 |---|---|
-| `Munkel-<version>.zip` | release workflow, from the tag |
+| `Munkel-<version>.dmg` | release workflow, from the tag |
 | `Munkel.app` → `CFBundleShortVersionString` | `make-bundle.sh` via `MUNKEL_VERSION` |
 | `munkel --version` | `bun build --define MUNKEL_BUILD_VERSION` |
 | cask `version "<version>"` | `scripts/build-brew-cask.sh` |
@@ -46,17 +57,25 @@ Pushing a tag `v<version>` runs `.github/workflows/release.yml`:
    `@munkel/macos` (universal build via [Swift Bundler](https://github.com/moreSwift/swift-bundler),
    pinned and built on demand by `scripts/ensure-swift-bundler.sh`, wrapped by
    `make-bundle.sh`) and `@munkel/cli` (two `bun build --compile` targets
-   + `lipo`, version stamped via `--define`). The root script stages
-   `Munkel.app` + `bin/munkel`, signs with Developer ID + hardened runtime
-   (CLI needs `apps/cli/entitlements.plist` — Bun executables crash under
-   the hardened runtime without the JIT entitlements), verifies the
-   version stamp, and ditto-zips. Deliberately **not** routed through
-   turbo: release artifacts must never come out of a cache.
-2. `notarytool submit --wait` on the zip, `stapler staple` on the `.app`
-   (zips and bare CLI binaries cannot be stapled), re-zip with `ditto`.
-3. GitHub release with `Munkel-<version>.zip`.
-4. `scripts/build-brew-cask.sh` renders `Casks/munkel.rb` with the new
-   version + sha256 and pushes it to `limehq/homebrew-tap`.
+   + `lipo`, version stamped via `--define`). The root script copies the CLI
+   into `Munkel.app/Contents/Resources/munkel`, then signs **inside-out** with
+   Developer ID + hardened runtime — the CLI first (with
+   `apps/cli/entitlements.plist`; Bun executables crash under the hardened
+   runtime without the JIT entitlements), then the outer bundle **without**
+   `--deep` so the app seal records the CLI's signature instead of clobbering
+   its entitlements. It verifies the version stamp by running the embedded
+   binary, then ditto-zips the app for notarytool. Deliberately **not** routed
+   through turbo: release artifacts must never come out of a cache.
+2. `notarytool submit --wait` on the app zip, `stapler staple` on the `.app`
+   (the embedded CLI is covered by the same notarization + staple — no online
+   Gatekeeper check, unlike a bare binary).
+3. `scripts/build-dmg.sh <version>` packages the stapled app into the
+   drag-to-Applications `Munkel-<version>.dmg` (plain `hdiutil`: app +
+   `/Applications` symlink, so it runs headless on CI). The DMG is then
+   notarized and stapled too, so it opens without a warning.
+4. GitHub release with `Munkel-<version>.dmg` (+ `.sha256` + Sigstore bundle).
+5. `scripts/build-brew-cask.sh` renders `Casks/munkel.rb` with the new
+   version + DMG sha256 and pushes it to `limehq/homebrew-tap`.
 
 ## One-time setup checklist
 
@@ -87,7 +106,10 @@ shape of the setup, not publish operational details.
 
 ```sh
 scripts/build-release.sh 0.0.0-dev
-# → dist/Munkel-0.0.0-dev.zip with Munkel.app + bin/munkel (ad-hoc signed)
+# → dist/stage/Munkel.app (ad-hoc signed, munkel CLI embedded in Resources/)
+# → dist/Munkel-0.0.0-dev.zip (notarytool submission container)
+scripts/build-dmg.sh 0.0.0-dev
+# → dist/Munkel-0.0.0-dev.dmg (drag-to-Applications image)
 ```
 
 Validate a rendered cask:

--- a/apps/macos/Sources/MunkelApp/CLIInstaller.swift
+++ b/apps/macos/Sources/MunkelApp/CLIInstaller.swift
@@ -1,0 +1,96 @@
+import AppKit
+import Foundation
+
+/// Installs the `munkel` command line tool that ships inside the app bundle.
+///
+/// The CLI is a companion to the app — it talks to the running menu-bar app over
+/// a Unix domain socket and is useless on its own — so it lives at
+/// `Munkel.app/Contents/Resources/munkel` rather than as a standalone download.
+/// Homebrew symlinks it onto PATH automatically (the cask `binary` stanza);
+/// everyone who grabbed the DMG opts in here.
+enum CLIInstaller {
+    /// Standard Unix bin that's on the default macOS PATH. Writing there needs
+    /// admin, so installation goes through one authorization prompt.
+    private static let symlink = "/usr/local/bin/munkel"
+
+    /// The CLI binary embedded in this app bundle, if present.
+    static var embeddedBinary: URL? {
+        Bundle.main.url(forResource: "munkel", withExtension: nil)
+    }
+
+    /// True when the symlink already resolves to this bundle's embedded CLI
+    /// (e.g. a Homebrew install, or a previous run of this installer).
+    static var isInstalled: Bool {
+        guard let embedded = embeddedBinary,
+              let target = try? FileManager.default.destinationOfSymbolicLink(atPath: symlink)
+        else { return false }
+        let resolved = (target as NSString).isAbsolutePath
+            ? target
+            : (symlink as NSString).deletingLastPathComponent + "/" + target
+        return URL(fileURLWithPath: resolved).resolvingSymlinksInPath()
+            == embedded.resolvingSymlinksInPath()
+    }
+
+    /// Menu entry point: explain the situation, then symlink the embedded CLI
+    /// onto PATH with a single administrator prompt.
+    @MainActor
+    static func installFromMenu() {
+        NSApp.activate(ignoringOtherApps: true)
+
+        guard let source = embeddedBinary else {
+            alert(style: .warning,
+                  title: "Command line tool unavailable",
+                  message: "The munkel command is missing from this app bundle. "
+                      + "Reinstall Munkel and try again.")
+            return
+        }
+
+        if isInstalled {
+            alert(style: .informational,
+                  title: "Command line tool already installed",
+                  message: "Run munkel in your terminal. The Munkel app must be "
+                      + "running for commands to go through.")
+            return
+        }
+
+        // Hand the path to AppleScript as a string literal (escape only the
+        // characters AppleScript cares about), then let `quoted form of` build
+        // the shell-safe argument — this avoids brittle nested shell quoting.
+        let appleEscaped = source.path
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let script = """
+        set src to "\(appleEscaped)"
+        do shell script "mkdir -p /usr/local/bin && ln -sf " & quoted form of src & \
+        " /usr/local/bin/munkel" with administrator privileges
+        """
+
+        var errorInfo: NSDictionary?
+        NSAppleScript(source: script)?.executeAndReturnError(&errorInfo)
+
+        if let errorInfo {
+            // -128 is "user cancelled the auth dialog" — leave silently.
+            if (errorInfo[NSAppleScript.errorNumber] as? Int) == -128 { return }
+            alert(style: .warning,
+                  title: "Couldn't install the command",
+                  message: (errorInfo[NSAppleScript.errorMessage] as? String)
+                      ?? "Installing /usr/local/bin/munkel failed.")
+            return
+        }
+
+        alert(style: .informational,
+              title: "Command line tool installed",
+              message: "Run munkel in a new terminal session. The Munkel app "
+                  + "must be running for commands to go through.")
+    }
+
+    @MainActor
+    private static func alert(style: NSAlert.Style, title: String, message: String) {
+        let panel = NSAlert()
+        panel.alertStyle = style
+        panel.messageText = title
+        panel.informativeText = message
+        panel.addButton(withTitle: "OK")
+        panel.runModal()
+    }
+}

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -118,6 +118,11 @@ struct MenuView: View {
             } label: {
                 Label("Quick send…", systemImage: "paperplane")
             }
+            Button {
+                CLIInstaller.installFromMenu()
+            } label: {
+                Label("Install Command Line Tool…", systemImage: "terminal")
+            }
             #if DEBUG
             Divider()
             Toggle("Echo my broadcasts to me", isOn: $devEchoBroadcasts)

--- a/scripts/build-brew-cask.sh
+++ b/scripts/build-brew-cask.sh
@@ -15,7 +15,7 @@ cask "munkel" do
   version "$VERSION"
   sha256 "$SHA256"
 
-  url "https://github.com/limehq/munkel/releases/download/v#{version}/Munkel-#{version}.zip",
+  url "https://github.com/limehq/munkel/releases/download/v#{version}/Munkel-#{version}.dmg",
       verified: "github.com/limehq/munkel/"
   name "Munkel"
   desc "Ephemeral whispers that slide out of the MacBook notch"
@@ -29,7 +29,9 @@ cask "munkel" do
   depends_on macos: :sonoma
 
   app "Munkel.app"
-  binary "bin/munkel"
+  # The munkel CLI ships inside the app bundle; expose it on PATH for Homebrew
+  # users. DMG users opt in from the app's "Install Command Line Tool" menu.
+  binary "#{appdir}/Munkel.app/Contents/Resources/munkel"
 
   uninstall quit: "dev.uq.munkel"
 

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Packages the staged, signed + stapled Munkel.app into the drag-to-Applications
+# DMG that the website links to and the Homebrew cask installs from.
+#
+# Uses hdiutil (not create-dmg) so it runs headless on CI with no extra
+# dependency and no window-server/AppleScript step: the image is a plain folder
+# holding Munkel.app beside an /Applications symlink — the classic "drag the app
+# onto Applications" window.
+#
+# Run AFTER scripts/build-release.sh and stapling, so the .app inside carries
+# its notarization ticket and launches offline once dragged out.
+#
+# Usage: scripts/build-dmg.sh <version>
+set -euo pipefail
+
+VERSION="${1:?usage: build-dmg.sh <version>}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIST="$ROOT/dist"
+APP="$DIST/stage/Munkel.app"
+DMG="$DIST/Munkel-$VERSION.dmg"
+
+[[ -d "$APP" ]] || { echo "missing $APP — run build-release.sh first" >&2; exit 1; }
+
+# Lay out the image contents in a scratch dir: the app plus an Applications
+# alias so the open DMG shows the drag target.
+CONTENTS="$(mktemp -d)"
+trap 'rm -rf "$CONTENTS"' EXIT
+/usr/bin/ditto "$APP" "$CONTENTS/Munkel.app"
+ln -s /Applications "$CONTENTS/Applications"
+
+rm -f "$DMG"
+hdiutil create \
+  -volname "Munkel" \
+  -srcfolder "$CONTENTS" \
+  -fs HFS+ \
+  -format UDZO \
+  -ov \
+  "$DMG"
+
+echo "built $DMG"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,28 +1,43 @@
 #!/bin/bash
-# Assembles the universal release artifact for Homebrew distribution.
-# Each app builds itself (`build:release` workspace scripts); this script
-# only orchestrates: stage layout, Developer ID signing, ditto zip.
+# Assembles the signed, notarization-ready Munkel.app for distribution.
 #
-#   dist/stage/Munkel.app    universal menu-bar app   (apps/macos)
-#   dist/stage/bin/munkel    universal Bun CLI        (apps/cli)
-#   dist/Munkel-<ver>.zip    cask layout: `app "Munkel.app"` + `binary "bin/munkel"`
+# The munkel CLI is embedded INSIDE the app bundle (Contents/Resources/munkel)
+# rather than shipped as a loose sibling binary, so one artifact serves every
+# install path:
+#
+#   * Homebrew exposes the CLI automatically — the cask symlinks the embedded
+#     binary onto PATH (see scripts/build-brew-cask.sh).
+#   * Direct DMG users get the app only; they opt into the CLI from the app's
+#     own "Install Command Line Tool" menu (Sources/MunkelApp/CLIInstaller.swift).
+#
+# The CLI is a companion to the app (it talks to the running app over a Unix
+# socket and is useless on its own), so it has no standalone distribution.
+#
+# Layout produced:
+#   dist/stage/Munkel.app                              universal app, signed
+#   dist/stage/Munkel.app/Contents/Resources/munkel    universal Bun CLI
+#   dist/Munkel-<ver>.zip                              app zipped for notarytool
+#                                                      submission only — the
+#                                                      published asset is the DMG
+#                                                      (scripts/build-dmg.sh)
 #
 # Usage: scripts/build-release.sh <version>
 #
 # Env:
-#   CODESIGN_IDENTITY  "Developer ID Application: ..." — when set, both
-#                      binaries are signed with hardened runtime; unset
-#                      builds stay ad-hoc signed (local smoke testing).
+#   CODESIGN_IDENTITY  "Developer ID Application: ..." — when set, the embedded
+#                      CLI and the app are signed inside-out with hardened
+#                      runtime; unset stays ad-hoc signed (local smoke testing).
 set -euo pipefail
 
 VERSION="${1:?usage: build-release.sh <version>}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DIST="$ROOT/dist"
 STAGE="$DIST/stage"
+APP="$STAGE/Munkel.app"
 IDENTITY="${CODESIGN_IDENTITY:-}"
 
 rm -rf "$DIST"
-mkdir -p "$STAGE/bin"
+mkdir -p "$STAGE"
 
 cd "$ROOT"
 bun install --frozen-lockfile
@@ -32,25 +47,36 @@ bun install --frozen-lockfile
 (cd apps/macos && MUNKEL_VERSION="$VERSION" CODESIGN_IDENTITY="${IDENTITY:--}" bun run build:release)
 (cd apps/cli && MUNKEL_VERSION="$VERSION" bun run build:release)
 
-cp -R "$ROOT/apps/macos/.build/Munkel.app" "$STAGE/Munkel.app"
-cp "$ROOT/apps/cli/dist/release/munkel" "$STAGE/bin/munkel"
+cp -R "$ROOT/apps/macos/.build/Munkel.app" "$APP"
+
+# Embed the CLI as a bundle resource. It must be signed and sealed as part of
+# the app, so copy it in BEFORE signing.
+mkdir -p "$APP/Contents/Resources"
+cp "$ROOT/apps/cli/dist/release/munkel" "$APP/Contents/Resources/munkel"
+chmod +x "$APP/Contents/Resources/munkel"
 
 if [[ -n "$IDENTITY" ]]; then
+  # Inside-out signing: the nested CLI first (with its own JIT entitlements),
+  # then the outer bundle WITHOUT --deep — so the app seal records the CLI's
+  # signature instead of clobbering its entitlements with the app's.
   codesign --force --options runtime --timestamp \
     --entitlements "$ROOT/apps/cli/entitlements.plist" \
-    --sign "$IDENTITY" "$STAGE/bin/munkel"
-  codesign --verify --deep --strict "$STAGE/Munkel.app"
-  codesign --verify --strict "$STAGE/bin/munkel"
+    --sign "$IDENTITY" "$APP/Contents/Resources/munkel"
+  codesign --force --options runtime --timestamp \
+    --sign "$IDENTITY" "$APP"
+  codesign --verify --deep --strict "$APP"
+  codesign --verify --strict "$APP/Contents/Resources/munkel"
 fi
 
 # Smoke test: broken lipo/codesign/--define combinations fail right here.
-STAMPED="$("$STAGE/bin/munkel" --version)"
+STAMPED="$("$APP/Contents/Resources/munkel" --version)"
 [[ "$STAMPED" == "$VERSION" ]] \
   || { echo "version stamp mismatch: binary says '$STAMPED', expected '$VERSION'" >&2; exit 1; }
 
-# ditto, not zip: preserves bundle structure and symlinks, which the
-# notary scan requires. Zip root = Munkel.app + bin/ (the cask layout).
+# ditto, not zip: preserves the bundle structure and symlinks the notary scan
+# requires. This zip is only the notarytool submission container; the published
+# artifact is the DMG (scripts/build-dmg.sh).
 cd "$STAGE"
-/usr/bin/ditto -c -k . "$DIST/Munkel-$VERSION.zip"
+/usr/bin/ditto -c -k --keepParent "Munkel.app" "$DIST/Munkel-$VERSION.zip"
 
-echo "built $DIST/Munkel-$VERSION.zip"
+echo "built $APP and $DIST/Munkel-$VERSION.zip"


### PR DESCRIPTION
## Why

Two install paths that diverged on the CLI would confuse users: Homebrew shipped the `munkel` CLI, a direct download wouldn't, and a separate "CLI-only" download would be useless — the CLI talks to the app over a Unix socket and can't run on its own.

This makes the CLI a **companion that lives inside the app**. There's one mental model: the CLI is always in the bundle; the only question is whether it's on your `PATH`. Homebrew flips that switch automatically; DMG users flip it with one click.

## What

The `munkel` CLI now ships inside `Munkel.app/Contents/Resources/munkel` instead of as a loose sibling binary, so a single artifact serves every path:

- **Homebrew** — installs the app and symlinks the embedded CLI onto `PATH` (cask `binary` points into the bundle, VS Code pattern).
- **Direct download** — a drag-to-Applications `.dmg` (app only). DMG users opt into the CLI from the new **Install Command Line Tool…** menu item, which symlinks the embedded binary into `/usr/local/bin` after one admin prompt.

No standalone CLI distribution — it needs the app either way.

### Release pipeline
- `build-release.sh` embeds the CLI, then signs **inside-out** (CLI with its JIT entitlements first, then the bundle *without* `--deep` so the app seal records the CLI's signature instead of clobbering its entitlements) and zips the app for notarytool.
- `build-dmg.sh` (new) packages the stapled app into the DMG via `hdiutil` — headless-safe on CI (app + `/Applications` symlink, no `create-dmg` dependency).
- `release.yml` notarizes + staples the app, builds the DMG, then notarizes + staples the DMG; publishes the DMG (+ `.sha256` + Sigstore bundle). Bonus: the embedded CLI is now covered by the app's staple, so no online Gatekeeper check (unlike the old bare binary).
- `build-brew-cask.sh` points the cask at the `.dmg` and the embedded binary.

## Test plan

- [x] Swift compiles (`swift build`)
- [x] Ad-hoc `build-release.sh` — CLI embedded, runs from inside the bundle, version smoke-test passes
- [x] **Signed** `build-release.sh` with real Developer ID — `codesign --verify --deep --strict` passes; embedded CLI keeps Hardened Runtime + secure timestamp + all three JIT entitlements; Gatekeeper rejects only for *Unnotarized Developer ID* (expected locally)
- [x] `build-dmg.sh` — DMG mounts as `Munkel` with `Munkel.app` + `Applications` alias; CLI present inside
- [x] `build-brew-cask.sh` renders with `.dmg` url + `binary` into the bundle
- [ ] Notarization end-to-end (needs App Store Connect API key) → `spctl … accepted` after staple
- [ ] In-app **Install Command Line Tool…** → `munkel` on PATH, talks to the running app
- [ ] Homebrew install from the published DMG symlinks the CLI

## Notes
- First live release notarizes **twice** (app + DMG); watch alongside the existing `bun#29361` codesign caveat in `release.yml`.
- Landing-page FAQ copy (zip→DMG, "Where's the munkel CLI?") is intentionally **not** in this PR — it ships with the separate landing/font work in progress.