### PR TITLE
feat(macos): rework recipient picking + UI polish

### DIFF
--- a/apps/macos/Sources/MunkelApp/CommandPalettePanel.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPalettePanel.swift
@@ -20,8 +20,10 @@ final class CommandPalettePanel: NSPanel {
         isOpaque = false
         backgroundColor = .clear
         hasShadow = true
-        // No background drag: clicks in the list select rows.
-        isMovableByWindowBackground = false
+        // Draggable like Spotlight: dragging empty background moves the
+        // panel, while clicks on the chips/field still register (AppKit only
+        // starts a window drag past the drag threshold, not on a click).
+        isMovableByWindowBackground = true
         isReleasedWhenClosed = false
         hidesOnDeactivate = false
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]

--- a/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
@@ -15,7 +15,8 @@ final class CommandPalettePresenter {
     private var panel: CommandPalettePanel?
     private var keyMonitor: Any?
 
-    private static let panelSize = NSSize(width: 640, height: 440)
+    /// Fixed width; height follows the SwiftUI content (preferredContentSize).
+    private static let panelWidth: CGFloat = 380
 
     init(model: AppModel) {
         self.model = model
@@ -33,7 +34,7 @@ final class CommandPalettePresenter {
         guard panel == nil else { return }
         state.reset()
 
-        let panel = CommandPalettePanel(size: Self.panelSize)
+        let panel = CommandPalettePanel(size: NSSize(width: Self.panelWidth, height: 200))
         panel.onResignKey = { [weak self] in self?.hide() }
 
         let root = CommandPaletteView(
@@ -41,7 +42,13 @@ final class CommandPalettePresenter {
             state: state,
             onClose: { [weak self] in self?.hide() }
         )
-        panel.contentView = NSHostingView(rootView: root)
+        // Hosting controller with preferredContentSize so the panel resizes
+        // to the (fixed-width, content-height) SwiftUI layout — compact for
+        // a couple of circles, capped by the view's own maxHeight.
+        let controller = NSHostingController(rootView: root)
+        controller.sizingOptions = [.preferredContentSize]
+        panel.contentViewController = controller
+        panel.layoutIfNeeded()
 
         position(panel)
         self.panel = panel
@@ -64,34 +71,32 @@ final class CommandPalettePresenter {
         let mouse = NSEvent.mouseLocation
         let screen = NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main
         guard let frame = screen?.visibleFrame else { return }
-        let size = Self.panelSize
+        let size = panel.frame.size
         let x = frame.midX - size.width / 2
         let y = frame.maxY - size.height - frame.height * 0.18
         panel.setFrameOrigin(NSPoint(x: x, y: y))
     }
 
-    /// Up/down arrows move the picker selection. Installed only while the
-    /// panel is open; Return (onSubmit) and Esc (onExitCommand) stay with the
-    /// search field. Arrows are consumed (return nil) so they don't move the
-    /// text cursor. Active only in phase 1 — phase 2 has no list.
+    /// Arrow keys are a full D-pad over the target chips while the message
+    /// field keeps focus: left/right within a circle, up/down between
+    /// circles. All four are consumed (return nil) so they don't move the
+    /// text cursor. Return (onSubmit) sends and Esc (onExitCommand) closes.
     private func installKeyMonitor() {
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
             var consumed = false
             MainActor.assumeIsolated {
-                guard self.state.target == nil else { return }
+                let dir: CommandPaletteState.Direction?
                 switch event.keyCode {
-                case 125: // down arrow
-                    let count = self.state.filteredRecipients.count
-                    if count > 0 {
-                        self.state.selectedIndex = min(count - 1, self.state.selectedIndex + 1)
-                    }
+                case 123: dir = .left
+                case 124: dir = .right
+                case 125: dir = .down
+                case 126: dir = .up
+                default: dir = nil
+                }
+                if let dir {
+                    self.state.move(dir)
                     consumed = true
-                case 126: // up arrow
-                    self.state.selectedIndex = max(0, self.state.selectedIndex - 1)
-                    consumed = true
-                default:
-                    break
                 }
             }
             return consumed ? nil : event

--- a/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
@@ -17,12 +17,12 @@ struct Recipient: Identifiable, Equatable {
 /// Transient palette state, owned by the presenter so it survives the
 /// SwiftUI view being rebuilt and can be mutated from the AppKit key
 /// monitor. Reads live circle/member data straight from AppModel.
+///
+/// Single phase: pick a target chip (↑↓ or click) and type in the message
+/// field — both live in one compact view, mirroring the in-app circle card.
 @MainActor
 final class CommandPaletteState: ObservableObject {
-    @Published var query = ""
     @Published var selectedIndex = 0
-    /// nil → picking a recipient (phase 1); set → composing (phase 2).
-    @Published var target: Recipient?
     @Published var message = ""
 
     private weak var app: AppModel?
@@ -31,9 +31,10 @@ final class CommandPaletteState: ObservableObject {
         self.app = app
     }
 
-    /// Every send target across all joined circles: a broadcast entry per
-    /// circle, then its online members.
-    var allRecipients: [Recipient] {
+    /// Every send target across all joined circles, in circle order: a
+    /// broadcast entry per circle, then its online members. The flat order
+    /// is what ↑↓ navigates and what `selectedIndex` points into.
+    var recipients: [Recipient] {
         guard let app else { return [] }
         return app.groupCodes.flatMap { code -> [Recipient] in
             let members = app.session(for: code)?.members ?? []
@@ -57,24 +58,66 @@ final class CommandPaletteState: ObservableObject {
         }
     }
 
-    var filteredRecipients: [Recipient] {
-        let q = query.trimmingCharacters(in: .whitespaces)
-        guard !q.isEmpty else { return allRecipients }
-        return allRecipients.filter {
-            $0.label.localizedCaseInsensitiveContains(q)
-                || $0.circle.localizedCaseInsensitiveContains(q)
-        }
-    }
-
     var selectedRecipient: Recipient? {
-        filteredRecipients[safe: selectedIndex]
+        recipients[safe: selectedIndex]
     }
 
     func reset() {
-        query = ""
         selectedIndex = 0
-        target = nil
         message = ""
+    }
+
+    // MARK: - D-pad navigation
+
+    enum Direction { case left, right, up, down }
+
+    /// Flat-index ranges, one per circle, in display order.
+    private var circleRanges: [Range<Int>] {
+        var ranges: [Range<Int>] = []
+        let r = recipients
+        var i = 0
+        while i < r.count {
+            let circle = r[i].circle
+            var j = i
+            while j < r.count, r[j].circle == circle { j += 1 }
+            ranges.append(i..<j)
+            i = j
+        }
+        return ranges
+    }
+
+    /// Left/right move within the current circle; up/down jump to the
+    /// adjacent circle keeping the column (clamped). With a single circle
+    /// all four arrows move within it.
+    func move(_ dir: Direction) {
+        let ranges = circleRanges
+        guard !ranges.isEmpty,
+              let row = ranges.firstIndex(where: { $0.contains(selectedIndex) })
+        else { return }
+        let here = ranges[row]
+        let col = selectedIndex - here.lowerBound
+        let single = ranges.count <= 1
+
+        switch dir {
+        case .left:
+            selectedIndex = max(here.lowerBound, selectedIndex - 1)
+        case .right:
+            selectedIndex = min(here.upperBound - 1, selectedIndex + 1)
+        case .up:
+            if single {
+                selectedIndex = max(here.lowerBound, selectedIndex - 1)
+            } else {
+                let target = ranges[max(0, row - 1)]
+                selectedIndex = target.lowerBound + min(col, target.count - 1)
+            }
+        case .down:
+            if single {
+                selectedIndex = min(here.upperBound - 1, selectedIndex + 1)
+            } else {
+                let target = ranges[min(ranges.count - 1, row + 1)]
+                selectedIndex = target.lowerBound + min(col, target.count - 1)
+            }
+        }
     }
 }
 

--- a/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
@@ -1,21 +1,26 @@
 import SwiftUI
 
-/// The command palette: phase 1 picks a recipient across all circles, phase
-/// 2 composes the message. Return advances/sends, Esc steps back or closes.
+/// Compact, app-like quick-send palette: circle sections with globe/avatar
+/// target chips, a message field pinned at the bottom. ↑↓ or click picks the
+/// target, typing composes, Return sends, Esc closes.
 struct CommandPaletteView: View {
     @ObservedObject var model: AppModel
     @ObservedObject var state: CommandPaletteState
     let onClose: () -> Void
 
+    @FocusState private var focused: Bool
+    @State private var listHeight: CGFloat = 0
+
+    private let width: CGFloat = 380
+    private let maxListHeight: CGFloat = 360
+
     var body: some View {
         VStack(spacing: 0) {
-            if let target = state.target {
-                ComposeView(target: target, state: state, send: send)
-            } else {
-                PickerView(model: model, state: state, onClose: onClose, commit: commit)
-            }
+            content
+            Divider()
+            composer
         }
-        .frame(width: 640, height: 440)
+        .frame(width: width)
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay(
@@ -23,56 +28,8 @@ struct CommandPaletteView: View {
                 .strokeBorder(.white.opacity(0.08), lineWidth: 1)
         )
         // Capture-proof root (backup to the panel's sharingType): the palette
-        // shows circle codes, names and the draft. Stays at the root, never
-        // inside the if/else branch, or a frame could flush before exclusion.
+        // shows circle codes, names and the draft.
         .excludedFromScreenCapture()
-    }
-
-    private func commit() {
-        guard let recipient = state.selectedRecipient else { return }
-        state.target = recipient
-        state.query = ""
-        state.selectedIndex = 0
-    }
-
-    private func send() {
-        let text = state.message.trimmingCharacters(in: .whitespaces)
-        guard !text.isEmpty, let target = state.target else { return }
-        model.send(text: text, group: target.circle, to: target.memberId)
-        onClose()
-    }
-}
-
-// MARK: - Phase 1: pick a recipient
-
-private struct PickerView: View {
-    @ObservedObject var model: AppModel
-    @ObservedObject var state: CommandPaletteState
-    let onClose: () -> Void
-    let commit: () -> Void
-    @FocusState private var focused: Bool
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 10) {
-                Image(systemName: "paperplane")
-                    .font(.title2)
-                    .foregroundStyle(.secondary)
-                TextField("Send to… (name or circle)", text: $state.query)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 22, weight: .regular))
-                    .focused($focused)
-                    .onSubmit(commit)
-                    .onExitCommand(perform: onClose)
-                    .onChange(of: state.query) { state.selectedIndex = 0 }
-            }
-            .padding(.horizontal, 20)
-            .frame(height: 60)
-
-            Divider()
-
-            recipientList
-        }
         .onAppear {
             // The panel is mid makeKey on first show; a synchronous focus
             // write is lost. Defer one tick — same trick as the notch reply.
@@ -81,151 +38,231 @@ private struct PickerView: View {
                 focused = true
             }
         }
-        // Keep the selection in range when the list shrinks under it — a peer
-        // leaving or a logout mutates filteredRecipients with no query change,
-        // which would otherwise strand the highlight past the end.
-        .onChange(of: state.filteredRecipients.count) { _, count in
+        // Keep the selection in range when the list shrinks under it (a peer
+        // leaving or logout mutates recipients with no user action).
+        .onChange(of: state.recipients.count) { _, count in
             state.selectedIndex = min(state.selectedIndex, max(0, count - 1))
         }
+    }
+
+    // MARK: - Target chips, grouped by circle
+
+    @ViewBuilder
+    private var content: some View {
+        if state.recipients.isEmpty {
+            Text(emptyMessage)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 28)
+                .padding(.horizontal, 16)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        ForEach(sections, id: \.circle) { section in
+                            circleSection(section)
+                        }
+                    }
+                    // Without full-width leading, the VStack shrinks to its
+                    // widest row and the ScrollView centers it — which reads
+                    // as a big left gap no padding can fix.
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 12)
+                    .background(
+                        GeometryReader { geo in
+                            Color.clear.preference(key: ListHeightKey.self, value: geo.size.height)
+                        }
+                    )
+                }
+                // Height nil until measured: a 0 would collapse the list to
+                // an invisible strip inside the preferredContentSize panel
+                // (same trick as the in-app menu's circle list).
+                .frame(height: listHeight == 0 ? nil : min(listHeight, maxListHeight))
+                .onPreferenceChange(ListHeightKey.self) { listHeight = $0 }
+                .onChange(of: state.selectedIndex) {
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        proxy.scrollTo(state.selectedIndex, anchor: .center)
+                    }
+                }
+            }
+        }
+    }
+
+    private func circleSection(_ section: Section) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(model.session(for: section.circle)?.isConnected == true ? Color.green : Color.orange)
+                    .frame(width: 7, height: 7)
+                Text(section.circle)
+                    .font(.system(.caption, design: .monospaced).weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            FlowLayout(spacing: 6) {
+                ForEach(section.items, id: \.index) { item in
+                    chip(item.recipient, index: item.index)
+                        .id(item.index)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func chip(_ recipient: Recipient, index: Int) -> some View {
+        let selected = index == state.selectedIndex
+        return Button {
+            state.selectedIndex = index
+            focused = true
+        } label: {
+            HStack(spacing: 5) {
+                if recipient.isEveryone {
+                    Image(systemName: "globe")
+                        .font(.system(size: 12))
+                        .frame(width: 18, height: 18)
+                } else {
+                    AvatarView(name: recipient.label, imageData: recipient.avatar, size: 18)
+                }
+                Text(recipient.isEveryone ? "Everyone" : recipient.label)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+            }
+            .padding(.leading, 4)
+            .padding(.trailing, 9)
+            .padding(.vertical, 4)
+            .background(
+                Capsule().fill(selected ? Color.accentColor.opacity(0.25) : Color.primary.opacity(0.06))
+            )
+            .overlay(
+                Capsule().strokeBorder(Color.accentColor, lineWidth: selected ? 1.5 : 0)
+            )
+        }
+        .buttonStyle(.plain)
+        // Tab stays on the message field — chips are reached with arrows.
+        .focusable(false)
+        .animation(.spring(duration: 0.2), value: selected)
+    }
+
+    // MARK: - Composer
+
+    private var composer: some View {
+        HStack(spacing: 10) {
+            TextField(placeholder, text: $state.message)
+                .textFieldStyle(.plain)
+                .font(.system(size: 15))
+                .focused($focused)
+                .onSubmit(send)
+                .onExitCommand(perform: onClose)
+
+            Button(action: send) {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: 15))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.tint)
+            .focusable(false)
+            .disabled(isEmpty || state.selectedRecipient == nil)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 48)
+    }
+
+    // MARK: - Derived
+
+    private var isEmpty: Bool {
+        state.message.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private var placeholder: String {
+        guard let r = state.selectedRecipient else { return "Message…" }
+        return r.isEveryone ? "Message everyone in \(r.circle)…" : "Message \(r.label)…"
     }
 
     private var emptyMessage: String {
         if model.githubUserLogin == nil {
             return "Sign in with GitHub to use Munkel."
         }
-        return state.query.isEmpty ? "Join a circle to send." : "No matches."
+        return "Join a circle to send."
     }
 
-    @ViewBuilder
-    private var recipientList: some View {
-        let recipients = state.filteredRecipients
-        if recipients.isEmpty {
-            VStack {
-                Spacer()
-                Text(emptyMessage)
-                    .foregroundStyle(.secondary)
-                Spacer()
-            }
-            .frame(maxWidth: .infinity)
-        } else {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(spacing: 2) {
-                        ForEach(Array(recipients.enumerated()), id: \.element.id) { index, recipient in
-                            RecipientRow(recipient: recipient, selected: index == state.selectedIndex)
-                                .id(index)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    state.selectedIndex = index
-                                    commit()
-                                }
-                        }
-                    }
-                    .padding(8)
-                }
-                .onChange(of: state.selectedIndex) {
-                    proxy.scrollTo(state.selectedIndex, anchor: .center)
-                }
-            }
-        }
-    }
-}
+    /// Recipients chunked back into per-circle sections, each item carrying
+    /// its flat index (so chips stay in sync with ↑↓ / selectedIndex).
+    private struct Section { let circle: String; var items: [(index: Int, recipient: Recipient)] }
 
-private struct RecipientRow: View {
-    let recipient: Recipient
-    let selected: Bool
-
-    var body: some View {
-        HStack(spacing: 10) {
-            if recipient.isEveryone {
-                Image(systemName: "person.2.fill")
-                    .frame(width: 24, height: 24)
-                    .foregroundStyle(.secondary)
+    private var sections: [Section] {
+        var result: [Section] = []
+        for (index, recipient) in state.recipients.enumerated() {
+            if result.last?.circle == recipient.circle {
+                result[result.count - 1].items.append((index, recipient))
             } else {
-                AvatarView(name: recipient.label, imageData: recipient.avatar, size: 24)
+                result.append(Section(circle: recipient.circle, items: [(index, recipient)]))
             }
-            Text(recipient.label)
-                .font(.body)
-            Spacer()
-            Text(recipient.circle)
-                .font(.system(.callout, design: .monospaced))
-                .foregroundStyle(.secondary)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(selected ? Color.accentColor.opacity(0.25) : Color.clear)
-        )
+        return result
+    }
+
+    private func send() {
+        let text = state.message.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty, let r = state.selectedRecipient else { return }
+        model.send(text: text, group: r.circle, to: r.memberId)
+        onClose()
     }
 }
 
-// MARK: - Phase 2: compose the message
+private struct ListHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
 
-private struct ComposeView: View {
-    let target: Recipient
-    @ObservedObject var state: CommandPaletteState
-    let send: () -> Void
-    @FocusState private var focused: Bool
+/// Minimal wrapping layout for the target chips — flows left-to-right and
+/// wraps to the next line when a row is full.
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
 
-    private var isEmpty: Bool {
-        state.message.trimmingCharacters(in: .whitespaces).isEmpty
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var totalHeight: CGFloat = 0
+        var totalWidth: CGFloat = 0
+
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if rowWidth > 0, rowWidth + spacing + size.width > maxWidth {
+                totalHeight += rowHeight + spacing
+                totalWidth = max(totalWidth, rowWidth)
+                rowWidth = size.width
+                rowHeight = size.height
+            } else {
+                rowWidth += (rowWidth > 0 ? spacing : 0) + size.width
+                rowHeight = max(rowHeight, size.height)
+            }
+        }
+        totalHeight += rowHeight
+        totalWidth = max(totalWidth, rowWidth)
+        return CGSize(width: totalWidth, height: totalHeight)
     }
 
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 10) {
-                Button {
-                    state.target = nil // back to the picker
-                } label: {
-                    Image(systemName: "chevron.left")
-                        .font(.title3)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
 
-                if target.isEveryone {
-                    Image(systemName: "person.2.fill").foregroundStyle(.secondary)
-                } else {
-                    AvatarView(name: target.label, imageData: target.avatar, size: 22)
-                }
-                Text(target.label).font(.headline)
-                Text(target.circle)
-                    .font(.system(.callout, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                Spacer()
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
             }
-            .padding(.horizontal, 16)
-            .frame(height: 52)
-
-            Divider()
-
-            HStack(spacing: 10) {
-                TextField("Message \(target.label)…", text: $state.message)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 20))
-                    .focused($focused)
-                    .onSubmit(send)
-                    .onExitCommand { state.target = nil } // Esc → back to picker
-
-                Button(action: send) {
-                    Image(systemName: "paperplane.fill")
-                        .font(.title3)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.tint)
-                .disabled(isEmpty)
-            }
-            .padding(.horizontal, 20)
-            .frame(height: 60)
-
-            Spacer()
-        }
-        .onAppear {
-            Task {
-                try? await Task.sleep(for: .milliseconds(80))
-                focused = true
-            }
+            view.place(at: CGPoint(x: x, y: y), anchor: .topLeading, proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
         }
     }
 }

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -11,7 +11,8 @@ struct MenuView: View {
     #endif
 
     /// Cap before the group list starts scrolling.
-    private let maxGroupListHeight: CGFloat = 360
+    // A fourth circle card peeks in cut off, hinting the list scrolls.
+    private let maxGroupListHeight: CGFloat = 400
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -362,86 +362,194 @@ struct GroupSectionView: View {
     let code: String
 
     @State private var draft = ""
+    /// Selected send target; nil = everyone (the globe). Default everyone.
     @State private var recipient: String?
+    /// Transient "Sent to …" confirmation, cleared after a short delay.
+    @State private var sentNotice: String?
+    @State private var sentNoticeToken = 0
+    @FocusState private var fieldFocused: Bool
+
+    private let targetSize: CGFloat = 26
 
     var body: some View {
         // Re-renders on presenceVersion bumps via the EnvironmentObject.
         let session = model.session(for: code)
         let members = session?.members ?? []
 
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Circle()
-                    .fill(session?.isConnected == true ? Color.green : Color.orange)
-                    .frame(width: 8, height: 8)
-                Text(code)
-                    .font(.system(.subheadline, design: .monospaced).weight(.semibold))
-                Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(code, forType: .string)
-                } label: {
-                    Image(systemName: "doc.on.doc")
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .help("Copy code")
-                Spacer()
-                Button {
-                    model.leave(code: code)
-                } label: {
-                    Image(systemName: "rectangle.portrait.and.arrow.right")
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .help("Leave circle")
-            }
-
-            if members.isEmpty {
-                Text("No one else online")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else {
-                HStack(spacing: 6) {
-                    HStack(spacing: -5) {
-                        ForEach(members.prefix(8)) { member in
-                            AvatarView(name: member.label, imageData: member.avatar, size: 16)
-                        }
-                    }
-                    Text(members.map(\.label).joined(separator: ", "))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                }
-            }
-
-            HStack(spacing: 6) {
-                Picker("", selection: $recipient) {
-                    Text("All").tag(String?.none)
-                    ForEach(members) { member in
-                        Text(member.label).tag(String?.some(member.id))
-                    }
-                }
-                .labelsHidden()
-                .frame(width: 90)
-
-                TextField("Message…", text: $draft)
-                    .frostedField()
-                    .onSubmit(sendTapped)
-
-                Button(action: sendTapped) {
-                    Image(systemName: "paperplane.fill")
-                }
-                .disabled(draft.trimmingCharacters(in: .whitespaces).isEmpty)
-            }
+        VStack(alignment: .leading, spacing: 8) {
+            header(connected: session?.isConnected == true)
+            recipientRow(members: members)
+            messageRow(members: members)
         }
         .padding(10)
         .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
+        // A selected member going offline silently falls back to everyone,
+        // so the highlight always points at a real, sendable target.
+        .onChange(of: members) {
+            if let r = recipient, !members.contains(where: { $0.id == r }) {
+                recipient = nil
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private func header(connected: Bool) -> some View {
+        HStack {
+            Circle()
+                .fill(connected ? Color.green : Color.orange)
+                .frame(width: 8, height: 8)
+                .help(connected ? "Connected" : "Connecting…")
+            Text(code)
+                .font(.system(.subheadline, design: .monospaced).weight(.semibold))
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(code, forType: .string)
+            } label: {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("Copy code")
+            Spacer()
+            Button {
+                model.leave(code: code)
+            } label: {
+                Image(systemName: "rectangle.portrait.and.arrow.right")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help("Leave circle")
+        }
+    }
+
+    // MARK: - Recipient picker (globe = everyone, then one avatar per member)
+
+    private func recipientRow(members: [GroupSession.Member]) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                targetButton(
+                    selected: recipient == nil,
+                    help: "Everyone"
+                ) {
+                    recipient = nil
+                } label: {
+                    Image(systemName: "globe")
+                        .font(.system(size: 13))
+                        .frame(width: targetSize, height: targetSize)
+                        .background(.quaternary, in: Circle())
+                }
+
+                ForEach(members) { member in
+                    targetButton(
+                        selected: recipient == member.id,
+                        help: member.label
+                    ) {
+                        recipient = member.id
+                        fieldFocused = true
+                    } label: {
+                        AvatarView(name: member.label, imageData: member.avatar, size: targetSize)
+                    }
+                }
+
+                if members.isEmpty {
+                    Text("No one else online")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.leading, 4)
+                }
+            }
+            .padding(2)
+        }
+    }
+
+    /// A selectable round target with an accent ring when chosen.
+    private func targetButton(
+        selected: Bool,
+        help: String,
+        action: @escaping () -> Void,
+        @ViewBuilder label: () -> some View
+    ) -> some View {
+        Button(action: action) {
+            label()
+                .overlay(
+                    Circle()
+                        .strokeBorder(Color.accentColor, lineWidth: 2)
+                        .opacity(selected ? 1 : 0)
+                )
+                .overlay(
+                    Circle()
+                        .strokeBorder(Color.accentColor, lineWidth: 2)
+                        .padding(-2)
+                        .opacity(selected ? 0.35 : 0)
+                )
+        }
+        .buttonStyle(.plain)
+        .help(help)
+        .animation(.spring(duration: 0.25), value: selected)
+    }
+
+    // MARK: - Message field + send
+
+    private func messageRow(members: [GroupSession.Member]) -> some View {
+        HStack(spacing: 6) {
+            TextField(placeholder(members: members), text: $draft)
+                .frostedField()
+                .focused($fieldFocused)
+                .onSubmit(sendTapped)
+
+            Button(action: sendTapped) {
+                Image(systemName: "paperplane.fill")
+            }
+            .disabled(draft.trimmingCharacters(in: .whitespaces).isEmpty)
+            .help(sendHelp(members: members))
+        }
+        .overlay(alignment: .leading) {
+            if let sentNotice {
+                Label(sentNotice, systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8)
+                    .background(.quaternary.opacity(0.9), in: Capsule())
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    private func placeholder(members: [GroupSession.Member]) -> String {
+        if let id = recipient, let m = members.first(where: { $0.id == id }) {
+            return "Message \(m.label)…"
+        }
+        return "Message everyone…"
+    }
+
+    private func sendHelp(members: [GroupSession.Member]) -> String {
+        if let id = recipient, let m = members.first(where: { $0.id == id }) {
+            return "Send to \(m.label) (↩)"
+        }
+        return "Send to everyone (↩)"
     }
 
     private func sendTapped() {
         let text = draft.trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else { return }
+        let members = model.session(for: code)?.members ?? []
+        let targetName = recipient.flatMap { id in members.first { $0.id == id }?.label }
         model.send(text: text, group: code, to: recipient)
         draft = ""
+        flashSent(to: targetName)
+    }
+
+    private func flashSent(to name: String?) {
+        sentNoticeToken += 1
+        let token = sentNoticeToken
+        withAnimation(.spring(duration: 0.25)) {
+            sentNotice = name.map { "Sent to \($0)" } ?? "Sent to everyone"
+        }
+        Task {
+            try? await Task.sleep(for: .seconds(1.6))
+            guard token == sentNoticeToken else { return }
+            withAnimation(.spring(duration: 0.25)) { sentNotice = nil }
+        }
     }
 }

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -364,8 +364,8 @@ struct GroupSectionView: View {
     @State private var draft = ""
     /// Selected send target; nil = everyone (the globe). Default everyone.
     @State private var recipient: String?
-    /// Transient "Sent to …" confirmation, cleared after a short delay.
-    @State private var sentNotice: String?
+    /// Briefly turns the send button into a checkmark after a send.
+    @State private var justSent = false
     @State private var sentNoticeToken = 0
     @FocusState private var fieldFocused: Bool
 
@@ -499,20 +499,17 @@ struct GroupSectionView: View {
                 .onSubmit(sendTapped)
 
             Button(action: sendTapped) {
-                Image(systemName: "paperplane.fill")
+                // Confirmation lives in the button itself — a brief checkmark
+                // instead of a chip that overlapped the field's placeholder.
+                // Neutral color, and a fixed-size frame so swapping the glyph
+                // never changes the button's width.
+                Image(systemName: justSent ? "checkmark" : "paperplane.fill")
+                    .foregroundStyle(.primary)
+                    .frame(width: 16, height: 16)
+                    .animation(.spring(duration: 0.25), value: justSent)
             }
-            .disabled(draft.trimmingCharacters(in: .whitespaces).isEmpty)
+            .disabled(draft.trimmingCharacters(in: .whitespaces).isEmpty && !justSent)
             .help(sendHelp(members: members))
-        }
-        .overlay(alignment: .leading) {
-            if let sentNotice {
-                Label(sentNotice, systemImage: "checkmark.circle.fill")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 8)
-                    .background(.quaternary.opacity(0.9), in: Capsule())
-                    .transition(.opacity)
-            }
         }
     }
 
@@ -533,23 +530,19 @@ struct GroupSectionView: View {
     private func sendTapped() {
         let text = draft.trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else { return }
-        let members = model.session(for: code)?.members ?? []
-        let targetName = recipient.flatMap { id in members.first { $0.id == id }?.label }
         model.send(text: text, group: code, to: recipient)
         draft = ""
-        flashSent(to: targetName)
+        flashSent()
     }
 
-    private func flashSent(to name: String?) {
+    private func flashSent() {
         sentNoticeToken += 1
         let token = sentNoticeToken
-        withAnimation(.spring(duration: 0.25)) {
-            sentNotice = name.map { "Sent to \($0)" } ?? "Sent to everyone"
-        }
+        withAnimation(.spring(duration: 0.25)) { justSent = true }
         Task {
-            try? await Task.sleep(for: .seconds(1.6))
+            try? await Task.sleep(for: .seconds(1.4))
             guard token == sentNoticeToken else { return }
-            withAnimation(.spring(duration: 0.25)) { sentNotice = nil }
+            withAnimation(.spring(duration: 0.25)) { justSent = false }
         }
     }
 }

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -122,6 +122,11 @@ struct MessageNotchContainer: View {
         .animation(.spring(response: 0.35, dampingFraction: 0.75), value: model.fullyExpanded)
         .animation(.spring(response: 0.35, dampingFraction: 0.75), value: model.replying)
         .animation(.spring(response: 0.35, dampingFraction: 0.75), value: model.replySent)
+        // Animate the container's own height when history expands/changes, so
+        // it grows downward in step with the rows instead of the fixedSize
+        // height jumping while the rows animate.
+        .animation(.spring(response: 0.35, dampingFraction: 0.75), value: model.historyExpanded)
+        .animation(.spring(response: 0.35, dampingFraction: 0.75), value: model.history)
         // The notch is always black — pin the content to dark so the
         // system light mode can't restyle field, caret and chip.
         .colorScheme(.dark)

--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchScreenMetrics.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchScreenMetrics.swift
@@ -34,15 +34,19 @@ enum NotchScreenMetrics {
         return (cutout, true, menubarHeight)
     }
 
-    /// Top-centre panel frame: a generous half-screen canvas pinned to the top
-    /// edge (size `screen.frame / 2`, origin at top centre) so the content's
-    /// top-anchored layout hangs from the notch and the open/close morph animates
-    /// inside a fixed window without resizing it. Notched and notchless screens
+    /// Top-centre panel frame: a half-width canvas spanning the *full* screen
+    /// height, pinned so its top edge is the screen top. Full height (not the
+    /// old half-screen) gives the top-anchored content unlimited room to grow
+    /// downward — expanded history could otherwise outgrow a half-screen
+    /// window and get clipped at the window's bottom edge, cutting off the
+    /// notch's bottom corners and breaking the layout. The visible shape is
+    /// unaffected: the NotchShape mask sizes to the content, not the window,
+    /// and the empty canvas stays click-through. Notched and notchless screens
     /// share this frame; only the content chrome inside differs.
     @MainActor
     static func panelFrame(for screen: NSScreen) -> NSRect {
-        let size = NSSize(width: screen.frame.width / 2, height: screen.frame.height / 2)
-        let origin = NSPoint(x: screen.frame.midX - size.width / 2, y: screen.frame.maxY - size.height)
-        return NSRect(origin: origin, size: size)
+        let width = screen.frame.width / 2
+        let origin = NSPoint(x: screen.frame.midX - width / 2, y: screen.frame.minY)
+        return NSRect(x: origin.x, y: origin.y, width: width, height: screen.frame.height)
     }
 }


### PR DESCRIPTION
## Why

Picking who you send to wasn't obvious. The circle card hid recipients behind a dropdown, and the quick-send palette was a big flat list where it was unclear who got which message. This makes both feel like the rest of the app: pick a target, type, send.

## What

- **Circle card** — dropdown is gone. The globe (everyone) and online members are tappable targets; pick one, type, Enter sends. A short checkmark in the send button confirms it (no more chip overlapping the placeholder).
- **Quick-send palette** — compact and grouped by circle, with globe/avatar chips instead of a flat list. Full D-pad arrows (left/right within a circle, up/down between circles), draggable like Spotlight, Tab stays in the field.
- **Notch fix** — expanded history could outgrow the panel and clip at the bottom (cutting the notch corners, breaking the layout). The canvas now spans full screen height, so content stays pinned under the notch and only grows down.
- Circle list cap raised a touch so a fourth card peeks in and hints it scrolls.

## Test plan

- [x] `swift build` + `swift test` (39 green)
- [x] Manually verified each change live (send to member/everyone, palette navigation + drag, history expand, scroll hint)