### PR TITLE
feat(macos): UI polish + message cap (issues #31,33,34,35,37,38)

### DIFF
--- a/apps/cli/src/munkel.ts
+++ b/apps/cli/src/munkel.ts
@@ -71,11 +71,17 @@ if (args[0] === "circles" || args[0] === "groups") {
   if (args.length < 3) {
     fail("usage: munkel <circle> <recipient|all> <message…>", 64)
   }
+  const text = args.slice(2).join(" ")
+  // Mirrors MessageLimits.maxCharacters in the macOS app.
+  const MAX_MESSAGE_CHARS = 2048
+  if (text.length > MAX_MESSAGE_CHARS) {
+    fail(`message too long (${text.length} > ${MAX_MESSAGE_CHARS} characters)`, 64)
+  }
   request = {
     action: "send",
     group: args[0],
     to: args[1],
-    text: args.slice(2).join(" "),
+    text,
   }
 }
 

--- a/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
@@ -158,6 +158,11 @@ struct CommandPaletteView: View {
                 .focused($focused)
                 .onSubmit(send)
                 .onExitCommand(perform: onClose)
+                .onChange(of: state.message) { _, new in
+                    if new.count > MessageLimits.maxCharacters {
+                        state.message = String(new.prefix(MessageLimits.maxCharacters))
+                    }
+                }
 
             Button(action: send) {
                 Image(systemName: "paperplane.fill")

--- a/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
@@ -162,7 +162,7 @@ struct CommandPaletteView: View {
                     .font(.system(size: 15))
             }
             .buttonStyle(.plain)
-            .foregroundStyle(.tint)
+            .foregroundStyle(.primary)
             .focusable(false)
             .disabled(isEmpty || state.selectedRecipient == nil)
         }

--- a/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
@@ -21,7 +21,9 @@ struct CommandPaletteView: View {
             composer
         }
         .frame(width: width)
-        .background(.regularMaterial)
+        // Behind-window vibrancy like Spotlight (and the menu-bar popover),
+        // instead of SwiftUI's flatter, grayer within-window .regularMaterial.
+        .background(VisualEffectView(material: .popover, blendingMode: .behindWindow))
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)

--- a/apps/macos/Sources/MunkelApp/GroupSession.swift
+++ b/apps/macos/Sources/MunkelApp/GroupSession.swift
@@ -57,7 +57,7 @@ final class GroupSession {
 
     @discardableResult
     func sendChat(_ text: String, to memberId: String? = nil) async -> Bool {
-        let payload = AppPayload.chat(text: text, sentAt: Date())
+        let payload = AppPayload.chat(text: MessageLimits.clamp(text), sentAt: Date())
         return await send(payload, to: memberId)
     }
 
@@ -163,7 +163,7 @@ final class GroupSession {
         case let .chat(text, _):
             let sender = members.first { $0.id == memberId }
                 ?? Member(id: memberId)
-            onChat?(sender, text, to != nil)
+            onChat?(sender, MessageLimits.clamp(text), to != nil)
         }
     }
 }

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -557,6 +557,11 @@ struct GroupSectionView: View {
                 .frostedField()
                 .focused($fieldFocused)
                 .onSubmit(sendTapped)
+                .onChange(of: draft) { _, new in
+                    if new.count > MessageLimits.maxCharacters {
+                        draft = String(new.prefix(MessageLimits.maxCharacters))
+                    }
+                }
 
             Button(action: sendTapped) {
                 // Confirmation lives in the button itself — a brief checkmark

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -309,6 +309,59 @@ struct MenuView: View {
     }
 }
 
+/// A selectable round recipient target with an accent ring when chosen and a
+/// fast custom tooltip on hover (the system `.help()` delay felt laggy). On
+/// hover it reports its name + frame up to the card, which floats the bubble
+/// outside the recipient row's clipping ScrollView.
+private struct TargetChip<Label: View>: View {
+    let selected: Bool
+    let tooltip: String
+    let cardSpace: String
+    @Binding var hoverTip: GroupSectionView.HoverTip?
+    let action: () -> Void
+    @ViewBuilder let label: Label
+
+    @State private var hoverTask: Task<Void, Never>?
+
+    var body: some View {
+        Button(action: action) {
+            label
+                .overlay(
+                    Circle()
+                        .strokeBorder(Color.accentColor, lineWidth: 2)
+                        .opacity(selected ? 1 : 0)
+                )
+                .overlay(
+                    Circle()
+                        .strokeBorder(Color.accentColor, lineWidth: 2)
+                        .padding(-2)
+                        .opacity(selected ? 0.35 : 0)
+                )
+        }
+        .buttonStyle(.plain)
+        .animation(.spring(duration: 0.25), value: selected)
+        .background(
+            GeometryReader { geo in
+                Color.clear.onHover { hovering in
+                    hoverTask?.cancel()
+                    if hovering {
+                        let frame = geo.frame(in: .named(cardSpace))
+                        hoverTask = Task {
+                            try? await Task.sleep(for: .milliseconds(120))
+                            guard !Task.isCancelled else { return }
+                            withAnimation(.easeOut(duration: 0.1)) {
+                                hoverTip = .init(text: tooltip, midX: frame.midX, topY: frame.minY)
+                            }
+                        }
+                    } else if hoverTip?.text == tooltip {
+                        withAnimation(.easeOut(duration: 0.1)) { hoverTip = nil }
+                    }
+                }
+            }
+        )
+    }
+}
+
 private struct GroupListHeightKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
@@ -368,9 +421,19 @@ struct GroupSectionView: View {
     /// Briefly turns the send button into a checkmark after a send.
     @State private var justSent = false
     @State private var sentNoticeToken = 0
+    /// Active member tooltip (custom, fast) — replaces the slow `.help()`.
+    @State private var hoverTip: HoverTip?
     @FocusState private var fieldFocused: Bool
 
     private let targetSize: CGFloat = 26
+    private let cardSpace = "circleCard"
+
+    /// A target chip's tooltip text plus where to float it (card coordinates).
+    struct HoverTip: Equatable {
+        let text: String
+        let midX: CGFloat
+        let topY: CGFloat
+    }
 
     var body: some View {
         // Re-renders on presenceVersion bumps via the EnvironmentObject.
@@ -384,6 +447,24 @@ struct GroupSectionView: View {
         }
         .padding(10)
         .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
+        .coordinateSpace(name: cardSpace)
+        // Floating member tooltip, drawn at card level so the recipient row's
+        // horizontal ScrollView can't clip it.
+        .overlay(alignment: .topLeading) {
+            if let tip = hoverTip {
+                Text(tip.text)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 5))
+                    .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(.quaternary, lineWidth: 1))
+                    .fixedSize()
+                    .position(x: tip.midX, y: max(tip.topY - 14, 6))
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
+            }
+        }
         // A selected member going offline silently falls back to everyone,
         // so the highlight always points at a real, sendable target.
         .onChange(of: members) {
@@ -429,9 +510,11 @@ struct GroupSectionView: View {
     private func recipientRow(members: [GroupSession.Member]) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 6) {
-                targetButton(
+                TargetChip(
                     selected: recipient == nil,
-                    help: "Everyone"
+                    tooltip: "Everyone",
+                    cardSpace: cardSpace,
+                    hoverTip: $hoverTip
                 ) {
                     recipient = nil
                 } label: {
@@ -442,9 +525,11 @@ struct GroupSectionView: View {
                 }
 
                 ForEach(members) { member in
-                    targetButton(
+                    TargetChip(
                         selected: recipient == member.id,
-                        help: member.label
+                        tooltip: member.label,
+                        cardSpace: cardSpace,
+                        hoverTip: $hoverTip
                     ) {
                         recipient = member.id
                         fieldFocused = true
@@ -462,32 +547,6 @@ struct GroupSectionView: View {
             }
             .padding(2)
         }
-    }
-
-    /// A selectable round target with an accent ring when chosen.
-    private func targetButton(
-        selected: Bool,
-        help: String,
-        action: @escaping () -> Void,
-        @ViewBuilder label: () -> some View
-    ) -> some View {
-        Button(action: action) {
-            label()
-                .overlay(
-                    Circle()
-                        .strokeBorder(Color.accentColor, lineWidth: 2)
-                        .opacity(selected ? 1 : 0)
-                )
-                .overlay(
-                    Circle()
-                        .strokeBorder(Color.accentColor, lineWidth: 2)
-                        .padding(-2)
-                        .opacity(selected ? 0.35 : 0)
-                )
-        }
-        .buttonStyle(.plain)
-        .help(help)
-        .animation(.spring(duration: 0.25), value: selected)
     }
 
     // MARK: - Message field + send

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -92,7 +92,7 @@ struct MenuView: View {
     private var header: some View {
         HStack {
             Image(systemName: "bubble.left.and.bubble.right.fill")
-                .foregroundStyle(.tint)
+                .foregroundStyle(.primary)
             Text("Munkel")
                 .font(.headline)
             Spacer()

--- a/apps/macos/Sources/MunkelApp/MessageLimits.swift
+++ b/apps/macos/Sources/MunkelApp/MessageLimits.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Shared message-size limits. The 2048-character cap applies symmetrically:
+/// outgoing text is clamped before sending and incoming text is clamped before
+/// display, so neither a local typo nor a peer can produce an oversized message.
+/// (Well under the protocol's 48 KiB payload ceiling — see `protocol.ts`.)
+/// The `munkel` CLI mirrors this value in `apps/cli/src/munkel.ts`.
+enum MessageLimits {
+    static let maxCharacters = 2048
+
+    /// Trims `text` to the character cap.
+    static func clamp(_ text: String) -> String {
+        text.count > maxCharacters ? String(text.prefix(maxCharacters)) : text
+    }
+}

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -260,6 +260,11 @@ struct MessageNotchContainer: View {
                 .padding(.vertical, 5)
                 .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 7))
                 .focused($replyFocused)
+                .onChange(of: draft) { _, new in
+                    if new.count > MessageLimits.maxCharacters {
+                        draft = String(new.prefix(MessageLimits.maxCharacters))
+                    }
+                }
                 .onSubmit {
                     let text = draft.trimmingCharacters(in: .whitespaces)
                     guard !text.isEmpty else { return }

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -60,6 +60,8 @@ struct MessageNotchContainer: View {
     var onTeaserFinished: () -> Void
 
     @State private var draft = ""
+    /// Measured height of the expanded history, to bound its scroll region.
+    @State private var historyHeight: CGFloat = 0
     @FocusState private var replyFocused: Bool
 
     private let avatarSize: CGFloat = 20
@@ -149,18 +151,10 @@ struct MessageNotchContainer: View {
                 .fill(.white.opacity(0.15))
                 .frame(height: 1)
                 .padding(.bottom, 3)
-            ForEach(model.history.reversed()) { entry in
-                if model.historyExpanded {
-                    // Expanded: full text on its own line below the name.
-                    VStack(alignment: .leading, spacing: 1) {
-                        historyHeader(for: entry)
-                        Text(entry.text)
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.55))
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    .padding(.bottom, 2)
-                } else {
+            if model.historyExpanded {
+                expandedHistory
+            } else {
+                ForEach(model.history.reversed()) { entry in
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
                         historyHeader(for: entry)
                         Text(entry.text)
@@ -180,6 +174,36 @@ struct MessageNotchContainer: View {
         .background(AreaMarker { [weak model] in model?.historyMarker = $0 })
         .animation(.spring(duration: 0.3), value: model.history)
         .animation(.spring(duration: 0.3), value: model.historyExpanded)
+    }
+
+    /// Expanded history: full text per row, bounded to ~⅓ of the screen and
+    /// scrollable beyond that so a long backlog can't run down the display.
+    /// Explicit (measured) height — a bare ScrollView collapses inside the
+    /// notch's fixedSize layout.
+    private var expandedHistory: some View {
+        let cap = (NSScreen.main?.frame.height ?? 900) / 3
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 3) {
+                ForEach(model.history.reversed()) { entry in
+                    VStack(alignment: .leading, spacing: 1) {
+                        historyHeader(for: entry)
+                        Text(entry.text)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.white.opacity(0.55))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(.bottom, 2)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                GeometryReader { geo in
+                    Color.clear.preference(key: HistoryHeightKey.self, value: geo.size.height)
+                }
+            )
+        }
+        .frame(height: historyHeight == 0 ? nil : min(historyHeight, cap))
+        .onPreferenceChange(HistoryHeightKey.self) { historyHeight = $0 }
     }
 
     /// Dot, sender and channel icon of one history row.
@@ -322,4 +346,11 @@ private struct AreaMarker: NSViewRepresentable {
     // view, and re-registering during transition animations would let a
     // disappearing branch clobber the registration of the live one.
     func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+private struct HistoryHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
 }


### PR DESCRIPTION
Knocks out the assigned macOS UI issues. One commit per issue.

## What

- **#35** — quick-send palette send icon is neutral, not accent.
- **#31** — popover header icon loses its blue tint (real glyph still tracked in #32, so this only partially closes it).
- **#34** — member chips get a fast custom tooltip (120 ms) instead of the laggy system `.help()`; it floats at card level so the recipient row's scroll view can't clip it.
- **#33** — quick-send palette uses a behind-window `NSVisualEffect` (`.popover`) instead of `.regularMaterial`, so its blur/gray matches the popover and Spotlight in light + dark.
- **#38** — expanded notch history is capped at ~⅓ screen and scrolls; the current message stays pinned above.
- **#37** — messages are capped at 2048 characters, clamped on send and on display (every input field + incoming), with the CLI rejecting over-long messages.

## Test plan

- [x] `swift build` + `swift test` (39 green)
- [x] CLI `bun run typecheck` + `bun test` (11 green)
- [x] Verified live: neutral icons, tooltip speed, palette glass vs Spotlight, history scroll cap, 2048 limit in fields + CLI

## Notes

- #31 is only partially addressed (blue tint removed); the new icon waits on the logo in #32, which stays open.
- #32 (app icon / logo) and #36 (auto-updates) are out of scope here.

Closes #33
Closes #34
Closes #35
Closes #37
Closes #38