### PR TITLE
docs: add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/limehq/munkel/actions/workflows/ci.yml/badge.svg)](https://github.com/limehq/munkel/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/limehq/munkel/actions/workflows/codeql.yml/badge.svg)](https://github.com/limehq/munkel/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/limehq/munkel/badge)](https://scorecard.dev/viewer/?uri=github.com/limehq/munkel)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13278/badge)](https://www.bestpractices.dev/projects/13278)
 [![Latest release](https://img.shields.io/github/v/release/limehq/munkel?display_name=tag&sort=semver)](https://github.com/limehq/munkel/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Website](https://img.shields.io/badge/website-munkel.app-black)](https://munkel.app)


### PR DESCRIPTION
Registered Munkel on bestpractices.dev — **project 13278**, badge level **passing**.

Adds the badge to the README next to the existing OpenSSF Scorecard badge. The Scorecard **CII-Best-Practices** check reads the bestpractices.dev API by repo URL, so the Scorecard score rises from 0 to the passing tier on the next Scorecard run on `main` (the README badge itself is for human readers).