### PR TITLE
fix(macos): unblock release build — work around swift#88173 inliner crash

### DIFF
--- a/apps/macos/make-bundle.sh
+++ b/apps/macos/make-bundle.sh
@@ -46,11 +46,24 @@ for arch in ${=MUNKEL_ARCHS:-}; do
   arch_flags+=(--arch "$arch")
 done
 
+# Workaround for swiftlang/swift#88173: the SIL performance inliner segfaults
+# under -O when compiling a module that opts into approachable concurrency via
+# `-default-isolation MainActor`. KeyboardShortcuts 3.0 declares that in its own
+# manifest, so an optimized (release) build of the dependency crashes
+# swift-frontend on ObjectAssociation.deinit. Force -Onone for release until the
+# toolchain ships a fix — debug is already -Onone and so is unaffected.
+# swift-bundler forwards each --Xswiftpm value straight through to `swift build`.
+opt_workaround=()
+if [[ "$CONFIG" == "release" ]]; then
+  opt_workaround=(--Xswiftpm -Xswiftc --Xswiftpm -Onone)
+fi
+
 "$SWIFT_BUNDLER" bundle \
   --config-file "$CONFIG_DIR/Bundler.toml" \
   --configuration "$CONFIG" \
   --scratch-path .build \
-  "${arch_flags[@]}"
+  "${arch_flags[@]}" \
+  "${opt_workaround[@]}"
 
 # Swift Bundler writes to .build/bundler/apps/Munkel/Munkel.app; move it to the
 # path the rest of the pipeline (build-release.sh, README) expects.


### PR DESCRIPTION
## Problem

The **v0.7.0 Release** workflow fails in **Build & sign app** ([run](https://github.com/limehq/munkel/actions/runs/27584919603/job/81553072486)). It is a **`swift-frontend` compiler crash**, not our code:

- The SIL performance inliner (`EarlyPerfInliner`) segfaults under `-O` when compiling a module that opts into approachable concurrency via `-default-isolation MainActor` — upstream [swiftlang/swift#88173](https://github.com/swiftlang/swift/issues/88173).
- **KeyboardShortcuts 3.0** declares `.defaultIsolation(MainActor.self)` in its own manifest, so the optimized release build of the dependency dies on `ObjectAssociation.deinit`.
- Only the **release** pipeline breaks: debug builds (CI `swift test`, CodeQL, `make-bundle.sh debug`, local `swift build`) are already `-Onone` and never run the optimizer.

**This was introduced by the #28 bump to KeyboardShortcuts 3.0** — v0.6.0 (on 2.x) released fine; v0.7.0 (first release on 3.0) crashed. Reproduces locally on Xcode 26.4 / Swift 6.3.0 and on the runner's 26.4.1 / 6.3.1.

## Fix

Force `-Onone` for **release only**, forwarded through swift-bundler's `--Xswiftpm` passthrough. `-Onone` is immaterial for a menu-bar app, and debug is unchanged. Tagged with the upstream issue so it can be reverted once the toolchain ships a fix.

## Test plan

- [x] Reproduced the exact crash locally (`swift build -c release --arch arm64 --arch x86_64`).
- [x] Confirmed `-disable-cmo` and `-no-whole-module-optimization` do **not** work; `-Onone` does.
- [x] End-to-end: `make-bundle.sh release` → signed universal `Munkel.app` (`x86_64 arm64`), no crash.
- [x] `make-bundle.sh debug` still builds.
- [ ] Re-run the Release workflow on the tag to confirm green through notarization.