### PR TITLE
ci(codeql): run Swift on push + schedule only (clears code-scanning warning)

### DIFF
--- a/.github/workflows/codeql-swift.yml
+++ b/.github/workflows/codeql-swift.yml
@@ -1,28 +1,21 @@
 name: CodeQL (Swift)
 
-# Swift is split out of codeql.yml because its extractor is CPU-bound (~6 min, with
-# no cross-run cache and no buildless mode) on the single self-hosted runner. The
-# actual `swift build` is ~20s; the rest is irreducible extraction tracing, so the
-# only lever is how often it runs.
-#
-# - pull_request: only when macOS sources (or this workflow) change, so the ~90% of
-#   PRs that touch apps/server, apps/landing, apps/cli never pay the Swift cost.
-# - push to main + weekly schedule: always, so main and the scheduled scan keep full
-#   Swift coverage regardless of which files a given merge touched.
+# Swift is split out of codeql.yml and runs on push to main + the weekly schedule
+# only — deliberately NOT on pull_request. Its extractor is CPU-bound (~6 min, no
+# cross-run cache, no buildless mode) on the single self-hosted runner, so running
+# it per-PR is slow. It also can't run *conditionally* on PRs without tripping code
+# scanning's "configuration not found" diff warning (every PR that doesn't re-run
+# Swift fails to reproduce main's Swift config). Push + schedule keep main and the
+# weekly scan fully covered, and Swift alerts still surface on PRs as they merge.
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - "apps/macos/**"
-      - ".github/workflows/codeql-swift.yml"
   push:
     branches: [main]
   schedule:
     - cron: "12 5 * * 2"
   workflow_dispatch:
 
-# One in-flight Swift analysis per ref: a newer commit cancels the previous run so
-# PRs don't queue behind stale analyses on the single self-hosted runner.
+# One in-flight Swift analysis per ref: a newer push cancels the previous run so
+# they don't queue on the single self-hosted runner.
 concurrency:
   group: codeql-swift-${{ github.ref }}
   cancel-in-progress: true
@@ -33,9 +26,6 @@ permissions:
 jobs:
   analyze:
     name: Analyze swift
-    # Fork PRs must never execute on the self-hosted runner; push, schedule, and
-    # manual dispatch always run.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 30
     # Least privilege: writes live on the job, not the workflow top level.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,8 @@ name: CodeQL
 # JavaScript/TypeScript analysis. The JS/TS extractor needs no build and finishes
 # in well under a minute, so it scans every pull request, every push to main, and
 # the weekly schedule. Swift lives in codeql-swift.yml instead: its extractor is
-# CPU-bound (~6 min, no cross-run cache) on the single self-hosted runner, so it is
-# path-filtered on PRs rather than run on every one.
+# CPU-bound (~6 min, no cross-run cache) on the single self-hosted runner, so it
+# runs on push + schedule only, off the PR path entirely.
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
## Why

After #47, PRs show **"Code scanning cannot determine the alerts introduced by this pull request, because 1 configuration present on refs/heads/main was not found: Actions workflow (codeql.yml) /language:swift"**.

Root cause: conditionally running Swift on PRs is incompatible with code scanning's PR alert-diff. GitHub expects every PR to reproduce each Swift configuration present on `main`; a PR where the path-filtered Swift workflow doesn't run can't, so it warns. (The first occurrence was compounded by an orphaned `codeql.yml:analyze /language:swift` analysis left when #46 merged 9s before #47 on the old matrix `codeql.yml` — that stale config is being deleted separately.)

## What

Drop the `pull_request` trigger (and path filter) from `codeql-swift.yml` so Swift runs on **push to main + weekly schedule only** — the standard "push-only language" setup that GitHub diffs cleanly. `main` and the scheduled scan stay fully covered, Swift alerts still surface on PRs as they merge, and JS/TS still scans every PR via `codeql.yml`.

**Trade-off:** the macOS app is no longer CodeQL-scanned *pre-merge* on PRs (it is on merge + weekly). This matches the repo's original pre-#44 design; the higher-risk untrusted-input surface (the relay in `apps/server`) is JS/TS and still scanned on every PR.

## Test plan

- [x] Both workflows validated as YAML; `codeql-swift.yml` has no `pull_request` trigger.
- [ ] After merge + deleting the orphaned `codeql.yml/swift` analysis: open a PR and confirm no "configuration not found" warning.