### PR TITLE
feat(macos): enable Sparkle auto-updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 # Tag push (v0.2.0) → universal build (app with the munkel CLI embedded) →
 # Developer ID signing → notarization → staple app → drag-to-Applications DMG →
-# notarize + staple DMG → GitHub release → cask bump in limehq/homebrew-tap.
+# notarize + staple DMG → EdDSA-signed Sparkle appcast → GitHub release →
+# cask bump in limehq/homebrew-tap.
 #
 # Required repository secrets (see RELEASING.md for how to create each):
 #   MACOS_CERTIFICATE_P12       base64 of the Developer ID Application .p12
@@ -10,6 +11,7 @@ name: Release
 #   APPLE_API_KEY_P8            base64 of the App Store Connect API key (.p8)
 #   APPLE_API_KEY_ID            10-char key ID
 #   APPLE_API_ISSUER_ID         issuer UUID
+#   SPARKLE_ED_PRIVATE_KEY      base64 EdDSA private key that signs the appcast
 #   TAP_GITHUB_TOKEN            PAT with push access to limehq/homebrew-tap
 
 on:
@@ -98,6 +100,18 @@ jobs:
           xcrun stapler staple "dist/Munkel-$VERSION.dmg"
           rm AuthKey.p8
 
+      - name: Generate Sparkle appcast
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          if [ -z "$SPARKLE_ED_PRIVATE_KEY" ]; then
+            echo "::warning::SPARKLE_ED_PRIVATE_KEY not set — skipping appcast (auto-update feed not generated)"
+            exit 0
+          fi
+          # EdDSA-sign the notarized + stapled DMG and render appcast.xml. Uploaded
+          # below and served via munkel.app/appcast.xml (the app's SUFeedURL).
+          scripts/build-appcast.sh "$VERSION" "dist/Munkel-$VERSION.dmg" "dist/appcast.xml"
+
       - name: Checksum release artifact
         run: shasum -a 256 "dist/Munkel-$VERSION.dmg" | tee "dist/Munkel-$VERSION.dmg.sha256"
 
@@ -123,6 +137,7 @@ jobs:
             dist/Munkel-${{ env.VERSION }}.dmg
             dist/Munkel-${{ env.VERSION }}.dmg.sha256
             dist/Munkel-${{ env.VERSION }}.dmg.sigstore.json
+            dist/appcast.xml
 
       - name: Bump cask in homebrew-tap
         env:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ and adds it to `~/.zshrc` when Homebrew is absent (reopen your terminal
 afterward). Either way the CLI needs the running app, which it talks to over a
 socket.
 
+Munkel keeps itself up to date via [Sparkle](https://sparkle-project.org): it
+checks in the background and installs notarized updates in place. Trigger a
+check or turn automatic checks on/off anytime from the menu-bar gear menu
+(**Check for Updates…**); the Homebrew cask is `auto_updates true`, so `brew
+upgrade` defers to Sparkle.
+
 Or build locally from source:
 
 ```sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,9 +73,13 @@ Pushing a tag `v<version>` runs `.github/workflows/release.yml`:
    drag-to-Applications `Munkel-<version>.dmg` (plain `hdiutil`: app +
    `/Applications` symlink, so it runs headless on CI). The DMG is then
    notarized and stapled too, so it opens without a warning.
-4. GitHub release with `Munkel-<version>.dmg` (+ `.sha256` + Sigstore bundle).
-5. `scripts/build-brew-cask.sh` renders `Casks/munkel.rb` with the new
-   version + DMG sha256 and pushes it to `limehq/homebrew-tap`.
+4. `scripts/build-appcast.sh` EdDSA-signs the notarized DMG and renders the
+   Sparkle auto-update feed `appcast.xml` (see **Auto-updates** below).
+5. GitHub release with `Munkel-<version>.dmg` (+ `.sha256` + Sigstore bundle
+   + `appcast.xml`).
+6. `scripts/build-brew-cask.sh` renders `Casks/munkel.rb` (with `auto_updates
+   true`) with the new version + DMG sha256 and pushes it to
+   `limehq/homebrew-tap`.
 
 ## One-time setup checklist
 
@@ -97,7 +101,8 @@ shape of the setup, not publish operational details.
 - Public tap repository `limehq/homebrew-tap`; the `homebrew-` prefix is
   required for `brew tap limehq/tap` to resolve.
 - Repository secrets for the macOS certificate, certificate password,
-  notarization API key, API key ID, issuer ID, and tap push token.
+  notarization API key, API key ID, issuer ID, the Sparkle appcast signing key
+  (`SPARKLE_ED_PRIVATE_KEY`, see **Auto-updates**), and tap push token.
 - The tap token should be a fine-grained PAT scoped only to
   `limehq/homebrew-tap` with **Contents: Read and write**. If it is absent,
   `release.yml` skips the cask bump with a warning.
@@ -118,6 +123,37 @@ Validate a rendered cask:
 scripts/build-brew-cask.sh 1.0.0 <sha256> /tmp/munkel.rb
 brew style --cask /tmp/munkel.rb
 ```
+
+## Auto-updates (Sparkle)
+
+Munkel updates itself via [Sparkle](https://sparkle-project.org): the app reads
+a signed appcast and installs notarized updates in place, so direct-download
+users get updates without re-downloading the DMG. The Homebrew cask is marked
+`auto_updates true`, so `brew upgrade` defers to Sparkle instead of fighting the
+in-place update.
+
+- **Feed URL**: the app ships `SUFeedURL = https://munkel.app/appcast.xml`
+  (`apps/macos/Bundler.toml`). That route
+  (`apps/landing/src/routes/appcast[.]xml.ts`) 302-redirects to the latest
+  release's `appcast.xml` asset; Sparkle follows the redirect. Owning the URL
+  lets the backing store change later (e.g. an R2-backed accumulating feed)
+  without reshipping the URL baked into already-installed builds.
+- **Signing key**: every update is verified with an EdDSA key independent of the
+  Developer ID signature. The public half is committed as `SUPublicEDKey` in
+  `Bundler.toml`; the private half signs the appcast in CI and lives only in the
+  `SPARKLE_ED_PRIVATE_KEY` repository secret. Generate the pair once with
+  Sparkle's `generate_keys` (private key → your login Keychain; `generate_keys
+  -p` prints the public key; `generate_keys -x <file>` exports the private key
+  for the secret). Back the private key up outside the repo: it is
+  unrecoverable, and losing it breaks updates for everyone not yet updated.
+- **Appcast**: `scripts/build-appcast.sh` downloads the pinned Sparkle tools,
+  EdDSA-signs the notarized DMG, and renders a single-entry `appcast.xml` that
+  the release workflow uploads as a release asset. Keep its `SPARKLE_VERSION` in
+  sync with the Sparkle SPM version in `apps/macos/Package.swift`.
+
+First-release note: the release that introduces Sparkle produces the first
+appcast, but existing users run a build without an updater: they update once
+manually, and auto-updates take over from the next release onward.
 
 ## Why notarization is non-negotiable
 

--- a/apps/landing/src/routeTree.gen.ts
+++ b/apps/landing/src/routeTree.gen.ts
@@ -9,8 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as AppcastDotxmlRouteImport } from './routes/appcast[.]xml'
 import { Route as IndexRouteImport } from './routes/index'
 
+const AppcastDotxmlRoute = AppcastDotxmlRouteImport.update({
+  id: '/appcast.xml',
+  path: '/appcast.xml',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +25,39 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/appcast.xml': typeof AppcastDotxmlRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/appcast.xml': typeof AppcastDotxmlRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/appcast.xml': typeof AppcastDotxmlRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/appcast.xml'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/appcast.xml'
+  id: '__root__' | '/' | '/appcast.xml'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AppcastDotxmlRoute: typeof AppcastDotxmlRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/appcast.xml': {
+      id: '/appcast.xml'
+      path: '/appcast.xml'
+      fullPath: '/appcast.xml'
+      preLoaderRoute: typeof AppcastDotxmlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +70,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AppcastDotxmlRoute: AppcastDotxmlRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/landing/src/routes/appcast[.]xml.ts
+++ b/apps/landing/src/routes/appcast[.]xml.ts
@@ -1,0 +1,17 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+// Sparkle reads Munkel's appcast from a stable URL on our own domain
+// (SUFeedURL = https://munkel.app/appcast.xml). Sparkle (and curl) GET it
+// directly; SSR runs beforeLoad and the thrown redirect becomes a real HTTP 302
+// to the latest GitHub release's EdDSA-signed appcast asset (built in
+// release.yml). Sparkle follows the redirect. Owning the URL means the backing
+// store can later change (e.g. an R2-backed accumulating feed) without
+// reshipping the SUFeedURL baked into already-installed builds.
+const APPCAST_TARGET =
+  'https://github.com/limehq/munkel/releases/latest/download/appcast.xml'
+
+export const Route = createFileRoute('/appcast.xml')({
+  beforeLoad: () => {
+    throw redirect({ href: APPCAST_TARGET, statusCode: 302 })
+  },
+})

--- a/apps/macos/Bundler.toml
+++ b/apps/macos/Bundler.toml
@@ -14,3 +14,13 @@ identifier = "dev.uq.munkel"
 LSUIElement = true
 LSMinimumSystemVersion = "14.0"
 NSHighResolutionCapable = true
+# Sparkle auto-updates. The feed lives at a stable URL on our own domain
+# (munkel.app/appcast.xml → 302 to the latest GitHub release asset), so the
+# backing store can change without reshipping the app. The EdDSA public key
+# verifies every update; its private half signs the appcast in CI
+# (SPARKLE_ED_PRIVATE_KEY — see RELEASING.md). Automatic checks default on and
+# are user-toggleable in the menu (Sparkle persists the choice in UserDefaults).
+SUFeedURL = "https://munkel.app/appcast.xml"
+SUPublicEDKey = "hNXNZe99QfQWaJTBeYJyQZNTx+86sbHFjfj193jpfzA="
+SUEnableAutomaticChecks = true
+SUScheduledCheckInterval = 86400

--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "de3410094aa20f863ab25db68f4e471265eaf69a884c16632726485f9a92669e",
+  "originHash" : "ae29f4400005886ee37676efcaa5e404bee98fee0475fe50cddeb6780d681b50",
   "pins" : [
     {
       "identity" : "keyboardshortcuts",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "f7d08ba4109d5ca025e1a64165be169cdf089206",
         "version" : "3.0.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     }
   ],

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "3.0.0"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
     ],
     targets: [
         .target(name: "MunkelKit"),
@@ -14,8 +15,15 @@ let package = Package(
             dependencies: [
                 "MunkelKit",
                 .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
+                .product(name: "Sparkle", package: "Sparkle"),
             ],
             path: "Sources/MunkelApp"
+            // No linkerSettings rpath: Sparkle ships as a binary framework that
+            // Swift Bundler embeds in Contents/Frameworks/ and makes loadable by
+            // adding an @executable_path rpath, which resolves Sparkle's
+            // @rpath/../Frameworks/Sparkle.framework/… install name to
+            // Contents/Frameworks/. Adding our own @executable_path here would just
+            // duplicate that rpath (see make-bundle.sh / scripts/build-release.sh).
         ),
         .testTarget(
             name: "MunkelKitTests",

--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -36,6 +36,10 @@ final class AppModel: ObservableObject {
     /// Bumped whenever any session's presence changes, so views refresh.
     @Published private(set) var presenceVersion = 0
 
+    /// Sparkle bridge, injected by `AppDelegate` at launch (release build only;
+    /// nil in the dev build, which doesn't auto-update).
+    var updater: UpdaterController?
+
     private static let groupsKey = "groupCodes"
     private static let relayURLKey = "relayURL"
     private static let defaultRelayURL = "wss://relay.munkel.app"

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -116,10 +116,8 @@ struct MenuView: View {
             } label: {
                 Label("About Munkel", systemImage: "info.circle")
             }
-            Button {
-                checkForUpdates()
-            } label: {
-                Label("Check for Updates…", systemImage: "arrow.triangle.2.circlepath")
+            if let updater = model.updater {
+                UpdaterMenuItems(updater: updater)
             }
             Button {
                 model.openCommandPalette()
@@ -163,19 +161,6 @@ struct MenuView: View {
     private func showAbout() {
         NSApp.activate(ignoringOtherApps: true)
         NSApp.orderFrontStandardAboutPanel(nil)
-    }
-
-    /// Placeholder until a real update channel exists (e.g. Sparkle or a
-    /// GitHub-Releases check) — shows the running version so the item is
-    /// already useful.
-    private func checkForUpdates() {
-        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
-        NSApp.activate(ignoringOtherApps: true)
-        let alert = NSAlert()
-        alert.messageText = "Check for Updates"
-        alert.informativeText = "You're running Munkel \(version). Automatic update checks aren't available yet."
-        alert.addButton(withTitle: "OK")
-        alert.runModal()
     }
 
     /// One field for both flows: join and create are the same operation in
@@ -318,6 +303,31 @@ struct MenuView: View {
     private func joinTapped() {
         model.join(code: joinCode)
         joinCode = ""
+    }
+}
+
+/// The update section of the settings menu: a prominent "Update to <version>…"
+/// item once Sparkle has found a newer release (its menu-bar "gentle reminder"),
+/// the manual check, and a toggle for background checks. Its own
+/// `@ObservedObject` view so the menu re-renders as the updater's state changes.
+private struct UpdaterMenuItems: View {
+    @ObservedObject var updater: UpdaterController
+
+    var body: some View {
+        if let version = updater.availableUpdateVersion {
+            Button {
+                updater.checkForUpdates()
+            } label: {
+                Label("Update to \(version)…", systemImage: "arrow.down.circle.fill")
+            }
+        }
+        Button {
+            updater.checkForUpdates()
+        } label: {
+            Label("Check for Updates…", systemImage: "arrow.triangle.2.circlepath")
+        }
+        .disabled(!updater.canCheckForUpdates)
+        Toggle("Check Automatically", isOn: $updater.automaticallyChecksForUpdates)
     }
 }
 

--- a/apps/macos/Sources/MunkelApp/MunkelApp.swift
+++ b/apps/macos/Sources/MunkelApp/MunkelApp.swift
@@ -9,6 +9,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem?
     private let popover = NSPopover()
     private var model: AppModel?
+    /// Sparkle auto-updater, retained for the process lifetime. Release-only —
+    /// nil in the dev build, which must not update the installed release.
+    private var updater: UpdaterController?
     /// Guards against the transient-popover flicker: clicking the status
     /// button while open first closes the popover (outside click on
     /// mouseDown), then fires the action (mouseUp) — which would reopen it.
@@ -20,6 +23,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         let model = AppModel()
         self.model = model
+
+        // Sparkle auto-updates. Release-only: the dev build runs as "Munkel Dev"
+        // with its own bundle id and must not update the installed release.
+        #if !DEBUG
+        let updater = UpdaterController()
+        self.updater = updater
+        model.updater = updater
+        #endif
 
         let hosting = NSHostingController(rootView: MenuView().environmentObject(model))
         hosting.sizingOptions = .preferredContentSize

--- a/apps/macos/Sources/MunkelApp/UpdaterController.swift
+++ b/apps/macos/Sources/MunkelApp/UpdaterController.swift
@@ -1,0 +1,84 @@
+import Combine
+import Sparkle
+import SwiftUI
+
+/// Bridges Sparkle's `SPUStandardUpdaterController` into SwiftUI: it triggers
+/// update checks, mirrors whether a check is currently allowed, exposes the
+/// automatic-check setting as a two-way toggle, and surfaces a found update in
+/// our own menu (Sparkle "gentle reminders") instead of an unprompted popup.
+///
+/// `AppDelegate` owns it for the process lifetime and hands it to `MenuView`
+/// through `AppModel`. Release-only — the dev build never creates it.
+///
+/// `@objc` delegate callbacks are `nonisolated` (Sparkle invokes them on the
+/// main thread, but the protocols aren't actor-annotated) and hop back to the
+/// main actor to touch `@Published` state — the same shape `RelayClient` uses
+/// to cross the @objc/Swift-concurrency boundary.
+@MainActor
+final class UpdaterController: NSObject, ObservableObject {
+    /// Mirrors `SPUUpdater.canCheckForUpdates` (KVO) — greys out the menu's
+    /// check item while a check or install is already in flight.
+    @Published private(set) var canCheckForUpdates = false
+
+    /// Two-way mirror of `SPUUpdater.automaticallyChecksForUpdates`, bound to the
+    /// menu toggle. Sparkle persists the chosen value in UserDefaults.
+    @Published var automaticallyChecksForUpdates = true {
+        didSet { controller.updater.automaticallyChecksForUpdates = automaticallyChecksForUpdates }
+    }
+
+    /// Non-nil once a check finds a newer version — drives the prominent
+    /// "Update to <version>…" menu item; cleared when a check finds nothing.
+    @Published private(set) var availableUpdateVersion: String?
+
+    private var controller: SPUStandardUpdaterController!
+
+    override init() {
+        super.init()
+        // startingUpdater: true → begins scheduled checks immediately using the
+        // SUFeedURL / SUPublicEDKey from Info.plist. We act as both delegates:
+        // the user-driver delegate lets a scheduled update surface in our menu
+        // instead of Sparkle forcing its own window to the front.
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true, updaterDelegate: self, userDriverDelegate: self
+        )
+        let updater = controller.updater
+        automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
+        updater.publisher(for: \.canCheckForUpdates).assign(to: &$canCheckForUpdates)
+    }
+
+    /// User-initiated check (menu). Sparkle shows its standard update UI.
+    func checkForUpdates() {
+        controller.updater.checkForUpdates()
+    }
+}
+
+extension UpdaterController: SPUUpdaterDelegate {
+    @objc nonisolated func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        let version = item.displayVersionString
+        Task { @MainActor in self.availableUpdateVersion = version }
+    }
+
+    @objc nonisolated func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+        Task { @MainActor in self.availableUpdateVersion = nil }
+    }
+}
+
+extension UpdaterController: SPUStandardUserDriverDelegate {
+    /// Opt into gentle reminders: we surface scheduled updates in the menu.
+    @objc nonisolated var supportsGentleScheduledUpdateReminders: Bool { true }
+
+    /// Don't let Sparkle force its window forward for a *scheduled* update — the
+    /// menu indicator is the reminder; the user pulls the update up deliberately.
+    @objc nonisolated func standardUserDriverShouldHandleShowingScheduledUpdate(
+        _ update: SUAppcastItem, andInImmediateFocus immediateFocus: Bool
+    ) -> Bool {
+        false
+    }
+
+    @objc nonisolated func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool, forUpdate update: SUAppcastItem, state: SPUUserUpdateState
+    ) {
+        let version = update.displayVersionString
+        Task { @MainActor in self.availableUpdateVersion = version }
+    }
+}

--- a/scripts/build-appcast.sh
+++ b/scripts/build-appcast.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Renders a single-entry Sparkle appcast for a published release. The file is
+# uploaded as the `appcast.xml` GitHub release asset; the app's SUFeedURL points
+# at munkel.app/appcast.xml, which 302-redirects to the latest release's asset
+# (apps/landing/src/routes/appcast[.]xml.ts). Sparkle follows the redirect.
+#
+# EdDSA-signs the DMG with $SPARKLE_ED_PRIVATE_KEY — the private half of the
+# SUPublicEDKey baked into the app (apps/macos/Bundler.toml). sign_update is the
+# prebuilt tool from a pinned Sparkle release tarball, so there is no `swift run`
+# and no Keychain dependency in CI.
+#
+# Usage: scripts/build-appcast.sh <version> <dmg-path> [outfile]
+# Env:
+#   SPARKLE_ED_PRIVATE_KEY  base64 EdDSA private key (required)
+#   SPARKLE_VERSION         Sparkle tools version (default below) — keep in sync
+#                           with the Sparkle SPM version in apps/macos/Package.swift
+set -euo pipefail
+
+VERSION="${1:?usage: build-appcast.sh <version> <dmg-path> [outfile]}"
+DMG="${2:?usage: build-appcast.sh <version> <dmg-path> [outfile]}"
+OUT="${3:-/dev/stdout}"
+: "${SPARKLE_ED_PRIVATE_KEY:?SPARKLE_ED_PRIVATE_KEY not set}"
+[[ -f "$DMG" ]] || { echo "dmg not found: $DMG" >&2; exit 1; }
+
+SPARKLE_VERSION="${SPARKLE_VERSION:-2.9.3}"
+MIN_OS="14.0"
+DMG_URL="https://github.com/limehq/munkel/releases/download/v${VERSION}/Munkel-${VERSION}.dmg"
+NOTES_URL="https://github.com/limehq/munkel/releases/tag/v${VERSION}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Prebuilt sign_update from the pinned Sparkle release (not the SPM artifact,
+# which carries only the framework). Pin matches the linked Sparkle version.
+curl -fsSL -o "$WORK/sparkle.tar.xz" \
+  "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+tar -xf "$WORK/sparkle.tar.xz" -C "$WORK"
+
+# Private key to a 0600 file (read via --ed-key-file; never placed on argv where
+# `ps` could read it). Removed right after signing.
+KEYFILE="$WORK/ed_private_key"
+( umask 077; printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$KEYFILE" )
+
+# Default output is the enclosure attributes verbatim: sparkle:edSignature="…"
+# length="…" (length is the DMG's byte size). -p would print only the signature.
+SIG_ATTRS="$("$WORK/bin/sign_update" --ed-key-file "$KEYFILE" "$DMG")"
+rm -f "$KEYFILE"
+
+PUBDATE="$(LC_ALL=C date -u '+%a, %d %b %Y %H:%M:%S +0000')"
+
+# sparkle:version and sparkle:shortVersionString are both the SemVer: the build
+# stamps CFBundleVersion == CFBundleShortVersionString == <version>, so Sparkle's
+# default comparator compares clean SemVers. Keep them aligned if that ever
+# changes (e.g. a separate monotonic build number).
+cat > "$OUT" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Munkel</title>
+    <link>https://munkel.app/appcast.xml</link>
+    <description>Munkel updates</description>
+    <language>en</language>
+    <item>
+      <title>${VERSION}</title>
+      <pubDate>${PUBDATE}</pubDate>
+      <sparkle:version>${VERSION}</sparkle:version>
+      <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>${MIN_OS}</sparkle:minimumSystemVersion>
+      <sparkle:releaseNotesLink>${NOTES_URL}</sparkle:releaseNotesLink>
+      <enclosure url="${DMG_URL}" type="application/octet-stream" ${SIG_ATTRS} />
+    </item>
+  </channel>
+</rss>
+XML
+
+echo "build-appcast: wrote appcast for $VERSION" >&2

--- a/scripts/build-brew-cask.sh
+++ b/scripts/build-brew-cask.sh
@@ -26,6 +26,10 @@ cask "munkel" do
     strategy :github_latest
   end
 
+  # Munkel self-updates via Sparkle; tell Homebrew so `brew upgrade` doesn't
+  # fight the in-place update (or flag the app as outdated after Sparkle ran).
+  auto_updates true
+
   depends_on macos: :sonoma
 
   app "Munkel.app"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -55,10 +55,43 @@ mkdir -p "$APP/Contents/Resources"
 cp "$ROOT/apps/cli/dist/release/munkel" "$APP/Contents/Resources/munkel"
 chmod +x "$APP/Contents/Resources/munkel"
 
+# Sparkle.framework: Swift Bundler embeds it in Contents/Frameworks/ when the
+# executable links it. Self-heal if a future bundler change ever drops it (copy
+# from the SwiftPM artifacts and add the bundle rpath), then fail loudly rather
+# than ship an app that dyld-crashes the moment it launches.
+FW_DIR="$APP/Contents/Frameworks"
+SPARKLE_FW="$FW_DIR/Sparkle.framework"
+if [[ ! -d "$SPARKLE_FW" ]]; then
+  echo "Sparkle.framework not embedded by Swift Bundler — copying from .build" >&2
+  mkdir -p "$FW_DIR"
+  SRC="$(/usr/bin/find "$ROOT/apps/macos/.build" -type d -name 'Sparkle.framework' 2>/dev/null | head -n1)"
+  [[ -n "$SRC" ]] || { echo "could not locate Sparkle.framework under apps/macos/.build" >&2; exit 1; }
+  /usr/bin/ditto "$SRC" "$SPARKLE_FW"
+  # Sparkle's install name is @rpath/../Frameworks/Sparkle.framework/…, so the
+  # resolving rpath is @executable_path (Swift Bundler normally adds it).
+  /usr/bin/otool -l "$APP/Contents/MacOS/Munkel" | grep -q 'path @executable_path ' \
+    || /usr/bin/install_name_tool -add_rpath "@executable_path" "$APP/Contents/MacOS/Munkel"
+fi
+[[ -d "$SPARKLE_FW" ]] || { echo "Sparkle.framework missing after embed step" >&2; exit 1; }
+
 if [[ -n "$IDENTITY" ]]; then
-  # Inside-out signing: the nested CLI first (with its own JIT entitlements),
-  # then the outer bundle WITHOUT --deep — so the app seal records the CLI's
-  # signature instead of clobbering its entitlements with the app's.
+  # Not sandboxed → Sparkle's XPC services are unused; drop them so there is
+  # nothing extra to sign and notarize (Sparkle supports this for non-sandboxed
+  # apps). Done only on the signed path so a plain ad-hoc build keeps Swift
+  # Bundler's framework seal intact.
+  rm -rf "$SPARKLE_FW/Versions/B/XPCServices"
+
+  # Inside-out signing: every nested code item is signed first, then the outer
+  # bundle WITHOUT --deep — so the app seal records those signatures instead of
+  # clobbering them. Sparkle's helpers and the CLI's JIT entitlements both rely
+  # on this; --deep would re-sign (and break) the framework's nested helpers.
+  codesign --force --options runtime --timestamp \
+    --sign "$IDENTITY" "$SPARKLE_FW/Versions/B/Autoupdate"
+  codesign --force --options runtime --timestamp \
+    --sign "$IDENTITY" "$SPARKLE_FW/Versions/B/Updater.app"
+  codesign --force --options runtime --timestamp \
+    --sign "$IDENTITY" "$SPARKLE_FW"
+  # The embedded munkel CLI (its own JIT entitlements), then the outer bundle.
   codesign --force --options runtime --timestamp \
     --entitlements "$ROOT/apps/cli/entitlements.plist" \
     --sign "$IDENTITY" "$APP/Contents/Resources/munkel"
@@ -66,6 +99,7 @@ if [[ -n "$IDENTITY" ]]; then
     --sign "$IDENTITY" "$APP"
   codesign --verify --deep --strict "$APP"
   codesign --verify --strict "$APP/Contents/Resources/munkel"
+  codesign --verify --strict "$SPARKLE_FW"
 fi
 
 # Smoke test: broken lipo/codesign/--define combinations fail right here.


### PR DESCRIPTION
Closes #36.

Replaces the `Check for Updates…` placeholder alert with a real **Sparkle** updater: in-app check → download → install → relaunch, background checks (user-toggleable), and a prominent **Update to X…** menu item when an update is found (Sparkle "gentle reminders").

## Changes

**App** (`apps/macos/`)
- `UpdaterController.swift` (new) bridges `SPUStandardUpdaterController` into SwiftUI: `canCheckForUpdates`, two-way `automaticallyChecksForUpdates`, `availableUpdateVersion`. Swift-6 strict-concurrency clean (`@MainActor` + `@objc nonisolated` delegates hopping to the main actor). Release-only (`#if !DEBUG`) — the dev build never updates.
- `MenuView.swift`: stub removed → `UpdaterMenuItems` (update item + check item with `.disabled` + `Check Automatically` toggle).
- `Package.swift`: Sparkle 2.x (resolved 2.9.3). No linker rpath — Swift Bundler embeds `Sparkle.framework` and adds the `@executable_path` rpath that resolves Sparkle's `@rpath/../Frameworks/…` install name.
- `Bundler.toml`: `SUFeedURL`, `SUPublicEDKey`, `SUEnableAutomaticChecks`, `SUScheduledCheckInterval`.

**Build & signing**
- `build-release.sh`: ensure `Sparkle.framework` is embedded (self-healing fallback + hard fail), trim its XPC services (not sandboxed), and inside-out sign Autoupdate → Updater.app → framework → CLI → app — never `--deep`, mirroring the existing CLI signing.

**Appcast & hosting**
- `build-appcast.sh` (new): EdDSA-signs the notarized DMG (pinned `sign_update`) and renders a single-entry `appcast.xml`.
- `release.yml`: appcast step (signs with `SPARKLE_ED_PRIVATE_KEY`, skips with a warning if unset) + uploads `appcast.xml`.
- Feed at `munkel.app/appcast.xml` — `apps/landing/src/routes/appcast[.]xml.ts` 302-redirects to the latest release asset, so the backing store can change later (e.g. R2 accumulating feed) without reshipping.

**Cask & docs**: cask `auto_updates true`; `RELEASING.md` (Auto-updates section + new secret) and `README.md`.

## Verification (local, all green)
- `swift build` ✓ · `swift test` (39 tests) ✓ · JS `turbo test typecheck` (server 22, cli 11, landing typecheck) ✓
- `Sparkle.framework` embedded ✓ · dyld resolves via single `@executable_path` rpath ✓
- inside-out signing dry-run: `codesign --verify --deep --strict` ✓
- landing route curled: `GET /appcast.xml` → **302** + correct `Location` ✓

## Required before the first release ships updates
Add the **`SPARKLE_ED_PRIVATE_KEY`** GitHub Actions secret (private half of the committed `SUPublicEDKey`; export with Sparkle's `generate_keys -x`, back it up). Until it is set, `release.yml` skips appcast generation with a warning. First-release caveat: existing installs have no updater, so they update once manually; auto-updates take over from the next release on.

> Note: this branch also carries the in-flight `release.yml` `runs-on: macos-26` change (GitHub-hosted runner), incidental to the Sparkle work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)