### PR TITLE
docs(releasing): document Release-As; cut v0.8.2 to test auto-update

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,6 +45,11 @@ in the product changelog, which is intentional (one product, one version).
 Escape hatch: a manually pushed `v*` tag still triggers `release.yml`
 directly, bypassing release-please.
 
+Forcing a specific version: add a `Release-As: <x.y.z>` footer to any commit on
+`main` (e.g. a quick patch to exercise the in-app Sparkle updater). release-please
+then opens a release PR for exactly that version, updating the manifest and
+changelog, regardless of the commit's conventional type.
+
 The `version` fields in the workspace `package.json`s are irrelevant
 (`private: true`, never published to npm) and stay untouched.
 


### PR DESCRIPTION
Small **test release** to exercise the in-app Sparkle updater end to end now that v0.8.1 is live: an installed v0.8.1 should detect and install v0.8.2.

- Adds a real RELEASING.md note on forcing a version via a `Release-As:` footer.
- The commit carries `Release-As: 0.8.2`, so release-please cuts **v0.8.2** (manifest + changelog updated) regardless of the `docs:` type.
- No app/pipeline behavior change — v0.8.2 is identical to v0.8.1 except the version stamp, so the auto-update test is clean (verify post-update via **About Munkel → 0.8.2**).