### PR TITLE
fix(release): stop build-brew-cask.sh executing backticks in the cask template

### DIFF
--- a/scripts/build-brew-cask.sh
+++ b/scripts/build-brew-cask.sh
@@ -3,6 +3,12 @@
 # The output file is committed to the tap repo (limehq/homebrew-tap) as
 # Casks/munkel.rb by the release workflow.
 #
+# The template is a QUOTED heredoc (`<<'CASK'`), so NO shell expansion happens
+# inside it — backticks or $(…) in comments can never execute. (An earlier
+# unquoted heredoc let a `brew upgrade` backtick in a comment run on the CI
+# runner and inject its output into the cask, breaking `brew install`.) Only the
+# explicit __VERSION__ / __SHA256__ placeholders are substituted afterwards.
+#
 # Usage: scripts/build-brew-cask.sh <version> <sha256> [outfile]
 set -euo pipefail
 
@@ -10,10 +16,10 @@ VERSION="${1:?usage: build-brew-cask.sh <version> <sha256> [outfile]}"
 SHA256="${2:?usage: build-brew-cask.sh <version> <sha256> [outfile]}"
 OUT="${3:-/dev/stdout}"
 
-cat > "$OUT" <<CASK
+cat <<'CASK' | sed -e "s|__VERSION__|${VERSION}|g" -e "s|__SHA256__|${SHA256}|g" > "$OUT"
 cask "munkel" do
-  version "$VERSION"
-  sha256 "$SHA256"
+  version "__VERSION__"
+  sha256 "__SHA256__"
 
   url "https://github.com/limehq/munkel/releases/download/v#{version}/Munkel-#{version}.dmg",
       verified: "github.com/limehq/munkel/"
@@ -26,8 +32,8 @@ cask "munkel" do
     strategy :github_latest
   end
 
-  # Munkel self-updates via Sparkle; tell Homebrew so `brew upgrade` doesn't
-  # fight the in-place update (or flag the app as outdated after Sparkle ran).
+  # Munkel self-updates via Sparkle; tell Homebrew not to fight the in-place
+  # update (or flag the app as outdated after Sparkle has already updated it).
   auto_updates true
 
   depends_on macos: :sonoma


### PR DESCRIPTION
**Broke `brew install limehq/tap/munkel`.** The cask template was an *unquoted* heredoc (needed for `$VERSION`/`$SHA256`), so the backticks around `` `brew upgrade` `` in the `auto_updates` comment were executed on the release runner — and the `brew upgrade` log output (ANSI codes, "==> Upgrading rustup…") got injected into `Casks/munkel.rb`, producing Ruby syntax errors.

Fix: quoted heredoc (`<<'CASK'`) with `__VERSION__`/`__SHA256__` placeholders substituted via `sed`, so no shell expansion can ever run inside the template; also dropped the backticks from the comment.

- Verified locally: generated cask passes `ruby -c` (Syntax OK).
- The already-published cask was repaired directly in `limehq/homebrew-tap` (commit 6b21fbd), so `brew info --cask limehq/tap/munkel` reads cleanly again — this PR prevents the next release from re-corrupting it.