### PR TITLE
feat: one-call `munkel dm` for agents, app residency, reply timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,16 +243,24 @@ app: create one, tick **Enable Device Flow**, then either edit
 ## munkel CLI
 
 ```sh
+munkel dm sebil "deploy is green"   # notify one person — resolves the name across circles
 munkel circles                      # ● blue-table-42  —  Alex, Sam
-munkel blue-table-42 Alex hey       # direct delivery by display name
+munkel blue-table-42 Alex hey       # circle-scoped direct delivery (disambiguates a name)
 munkel blue-table-42 all "coffee?"  # circle broadcast
 ```
+
+`munkel dm <name> …` is the one-call path: the app resolves `<name>` (display
+name or key-id prefix) across every circle, so no `munkel circles` lookup is
+needed first. If the name is unknown or matches more than one circle the send
+fails with a message naming the candidates, so a single call self-corrects.
 
 The CLI is a thin client: it talks to the running app over
 `~/Library/Application Support/Munkel/control.sock` (newline-delimited
 JSON; see `ControlProtocol.swift`, mirrored in `apps/cli/src/munkel.ts`). If
 the app isn't running, the CLI launches it in the background (`open -g -b
-dev.uq.munkel`) and waits for the socket before sending. The
+dev.uq.munkel`) and waits for the socket before sending. The release app also
+registers itself as a login item on first launch (toggle under the menu's
+gear) so it stays resident and the first send skips cold-start. The
 socket path can be overridden via `MUNKEL_SOCKET` (used by the tests). The
 app resolves circle-code prefixes and recipient display names, and owns all
 crypto and relay connections, an ideal substrate for scripting and agent

--- a/apps/cli/src/munkel.ts
+++ b/apps/cli/src/munkel.ts
@@ -44,6 +44,25 @@ function fail(message: string, code = 1): never {
   process.exit(code)
 }
 
+// Mirrors MessageLimits.maxCharacters in the macOS app.
+const MAX_MESSAGE_CHARS = 2048
+
+// Everything after the recipient is one message joined with spaces; quoting is
+// only needed for shell metacharacters.
+function joinMessage(parts: string[]): string {
+  const text = parts.join(" ")
+  if (text.length > MAX_MESSAGE_CHARS) {
+    fail(`message too long (${text.length} > ${MAX_MESSAGE_CHARS} characters)`, 64)
+  }
+  return text
+}
+
+function formatGroup(group: ControlGroupInfo): string {
+  const status = group.connected ? "●" : "○"
+  const members = group.members.length === 0 ? "no one else online" : group.members.join(", ")
+  return `${status} ${group.code}  —  ${members}`
+}
+
 // Stamped at compile time by build-release.sh via `bun build --define`;
 // dev runs (bun src/munkel.ts) fall back to the placeholder.
 declare const MUNKEL_BUILD_VERSION: string
@@ -51,12 +70,17 @@ const version = typeof MUNKEL_BUILD_VERSION === "string" ? MUNKEL_BUILD_VERSION 
 
 const usage = `munkel — munkel into your friends' notches
 
-  munkel <circle> <recipient|all> <message…>      Send a message
-  munkel circles                                 Show your circles & members
+  munkel dm <recipient> <message…>                Notify one person (resolved across circles)
+  munkel <circle> <recipient|all> <message…>      Send within a circle, or broadcast with 'all'
+  munkel circles [--json]                         Show your circles & members
 
 Examples:
+  munkel dm sebil "deploy is green"
   munkel blue-table-42 Alex hey
-  munkel blue-table-42 all "coffee?"`
+  munkel blue-table-42 all "coffee?"
+
+Exit codes: 0 ok · 64 usage · 75 app didn't reply · 1 other failure
+MUNKEL_SOCKET overrides the control socket; MUNKEL_DEV=1 targets the dev app.`
 
 const args = process.argv.slice(2)
 
@@ -71,25 +95,31 @@ if (["-v", "--version", "version"].includes(args[0])) {
 }
 
 let request: ControlRequest
+let jsonOutput = false
 // `circles` is the documented command; `groups` stays as a back-compat
 // alias. The wire action remains "groups" (see ControlProtocol.swift).
 if (args[0] === "circles" || args[0] === "groups") {
   request = { action: "groups" }
+  jsonOutput = args.includes("--json")
+} else if (args[0] === "dm") {
+  // `munkel dm <recipient> <message…>` — recipient-only send. The app
+  // resolves the name across every circle, so an agent can notify someone in
+  // a single call without first listing circles.
+  if (args.length < 3) {
+    fail("usage: munkel dm <recipient> <message…>", 64)
+  }
+  request = { action: "send", to: args[1], text: joinMessage(args.slice(2)) }
 } else {
+  // `munkel <circle> <recipient|all> <message…>` — circle-scoped send;
+  // required for broadcasts and to disambiguate a name across circles.
   if (args.length < 3) {
     fail("usage: munkel <circle> <recipient|all> <message…>", 64)
-  }
-  const text = args.slice(2).join(" ")
-  // Mirrors MessageLimits.maxCharacters in the macOS app.
-  const MAX_MESSAGE_CHARS = 2048
-  if (text.length > MAX_MESSAGE_CHARS) {
-    fail(`message too long (${text.length} > ${MAX_MESSAGE_CHARS} characters)`, 64)
   }
   request = {
     action: "send",
     group: args[0],
     to: args[1],
-    text,
+    text: joinMessage(args.slice(2)),
   }
 }
 
@@ -173,16 +203,44 @@ if (!socket) {
 
 socket.write(JSON.stringify(request) + "\n")
 
+// Bound the wait for a reply. `firstLine` only settles on a newline, EOF or
+// socket error, so an app that accepts the connection but never answers would
+// otherwise hang the caller — and any agent turn driving it — indefinitely.
+// MUNKEL_RESPONSE_TIMEOUT_MS lets the tests shrink the bound.
+const parsedTimeout = Number(process.env.MUNKEL_RESPONSE_TIMEOUT_MS)
+const responseTimeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : 4000
+let responseTimer: ReturnType<typeof setTimeout> | undefined
+const responseTimeout = new Promise<never>((_, reject) => {
+  responseTimer = setTimeout(() => reject(new Error("timeout")), responseTimeoutMs)
+})
+
 let response: ControlResponse
 try {
-  response = JSON.parse(await firstLine)
-} catch {
+  response = JSON.parse(await Promise.race([firstLine, responseTimeout]))
+} catch (error) {
+  socket.end()
+  if (error instanceof Error && error.message === "timeout") {
+    // EX_TEMPFAIL (75): app is up but didn't answer in time; a retry may work.
+    fail("the Munkel app accepted the connection but never replied — it may be busy; try again", 75)
+  }
   fail("No valid response from the app")
+} finally {
+  clearTimeout(responseTimer)
 }
 socket.end()
 
 if (!response.ok) {
+  // An error can carry the candidate circles (e.g. an ambiguous `dm`
+  // recipient) so a single failed call is self-correcting — surface them.
+  for (const group of response.groups ?? []) {
+    console.error(`  ${formatGroup(group)}`)
+  }
   fail(response.error ?? "Unknown error")
+}
+
+if (jsonOutput) {
+  console.log(JSON.stringify(response.groups ?? []))
+  process.exit(0)
 }
 
 if (response.groups) {
@@ -190,10 +248,7 @@ if (response.groups) {
     console.log("No circles yet — create one in the Munkel app")
   }
   for (const group of response.groups) {
-    const status = group.connected ? "●" : "○"
-    const members =
-      group.members.length === 0 ? "no one else online" : group.members.join(", ")
-    console.log(`${status} ${group.code}  —  ${members}`)
+    console.log(formatGroup(group))
   }
 } else {
   console.log("munkeled ✓")

--- a/apps/cli/test/munkel.test.ts
+++ b/apps/cli/test/munkel.test.ts
@@ -180,3 +180,80 @@ test("too few send arguments prints usage error", async () => {
   expect(result.exitCode).toBe(64)
   expect(result.stderr).toContain("usage: munkel")
 })
+
+test("dm sends a recipient-only request with no circle", async () => {
+  const app = fakeApp(() => ({ ok: true }))
+  const result = await runMunkel(["dm", "sebil", "deploy", "is", "green"], app.socketPath)
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stdout).toContain("munkeled ✓")
+  expect(app.requests).toEqual([{ action: "send", to: "sebil", text: "deploy is green" }])
+})
+
+test("dm with no message is a usage error", async () => {
+  const result = await runMunkel(["dm", "sebil"])
+
+  expect(result.exitCode).toBe(64)
+  expect(result.stderr).toContain("usage: munkel dm")
+})
+
+test("an error's candidate circles are printed to stderr", async () => {
+  // An ambiguous `dm` recipient comes back with the candidate circles so the
+  // single failed call is self-correcting — no follow-up `circles` needed.
+  const app = fakeApp(() => ({
+    ok: false,
+    error: '"sebil" is in blue-table-42, green-room-17 — say `munkel <circle> sebil …`',
+    groups: [
+      { code: "blue-table-42", connected: true, members: ["Sebastian", "Sam"] },
+      { code: "green-room-17", connected: true, members: ["Sebil"] },
+    ],
+  }))
+  const result = await runMunkel(["dm", "sebil", "hi"], app.socketPath)
+
+  expect(result.exitCode).toBe(1)
+  expect(result.stderr).toContain("is in blue-table-42")
+  expect(result.stderr).toContain("● blue-table-42")
+  expect(result.stderr).toContain("● green-room-17")
+})
+
+test("circles --json emits machine-readable output", async () => {
+  const groups = [
+    { code: "blue-table-42", connected: true, members: ["Alex", "Sam"] },
+    { code: "green-room-17", connected: false, members: [] },
+  ]
+  const app = fakeApp(() => ({ ok: true, groups }))
+  const result = await runMunkel(["circles", "--json"], app.socketPath)
+
+  expect(result.exitCode).toBe(0)
+  expect(JSON.parse(result.stdout)).toEqual(groups)
+  expect(app.requests).toEqual([{ action: "groups" }])
+})
+
+test("a silent app triggers a bounded response timeout", async () => {
+  // The app accepts the connection but never replies; the CLI must not hang
+  // the caller (and any agent turn driving it) indefinitely.
+  const socketPath = join(
+    tmpdir(),
+    `munkel-silent-${process.pid}-${Math.random().toString(36).slice(2)}.sock`,
+  )
+  const server = Bun.listen({
+    unix: socketPath,
+    socket: { data() { /* swallow the request, never respond */ } },
+  })
+  try {
+    const proc = Bun.spawn(["bun", cliPath, "circles"], {
+      env: { ...process.env, MUNKEL_SOCKET: socketPath, MUNKEL_RESPONSE_TIMEOUT_MS: "200" },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [stderr, exitCode] = await Promise.all([
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).toBe(75)
+    expect(stderr).toContain("never replied")
+  } finally {
+    server.stop(true)
+  }
+})

--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -296,26 +296,65 @@ final class AppModel: ObservableObject {
             guard let text = request.text, !text.isEmpty else {
                 return ControlResponse(ok: false, error: "Empty message")
             }
-            guard let groupQuery = request.group else {
-                return ControlResponse(ok: false, error: "Missing circle")
-            }
-            guard let session = resolveGroup(groupQuery) else {
-                return ControlResponse(ok: false, error: "Unknown or ambiguous circle \"\(groupQuery)\" — munkel circles shows them all")
+            let isBroadcast = (request.to.map { ["all", "*"].contains($0.lowercased()) }) ?? false
+
+            // Circle-scoped send: explicit circle code. Required for a
+            // broadcast and used to disambiguate a name across circles.
+            if let groupQuery = request.group {
+                guard let session = resolveGroup(groupQuery) else {
+                    return ControlResponse(ok: false, error: "Unknown or ambiguous circle \"\(groupQuery)\" — munkel circles shows them all")
+                }
+                var recipientId: String?
+                if let to = request.to, !isBroadcast {
+                    let matches = session.members.filter { Self.recipientMatches($0, to) }
+                    guard matches.count == 1 else {
+                        let problem = matches.isEmpty ? "isn't online" : "is ambiguous"
+                        return ControlResponse(ok: false, error: "\"\(to)\" \(problem) in \(session.code)")
+                    }
+                    recipientId = matches[0].id
+                }
+                let sent = await session.sendChat(text, to: recipientId)
+                return sent
+                    ? ControlResponse(ok: true)
+                    : ControlResponse(ok: false, error: "Send failed — no connection to the relay?")
             }
 
-            var recipientId: String?
-            if let to = request.to, !["all", "*"].contains(to.lowercased()) {
-                let matches = session.members.filter {
-                    $0.label.caseInsensitiveCompare(to) == .orderedSame || $0.id.hasPrefix(to.lowercased())
-                }
-                guard matches.count == 1 else {
-                    let problem = matches.isEmpty ? "isn't online" : "is ambiguous"
-                    return ControlResponse(ok: false, error: "\"\(to)\" \(problem) in \(session.code)")
-                }
-                recipientId = matches[0].id
+            // Recipient-only send (`munkel dm <name> …`): no circle given, so
+            // resolve the name across every circle. This lets an agent notify
+            // someone in a single call instead of listing circles first.
+            guard let to = request.to, !isBroadcast else {
+                return ControlResponse(ok: false, error: "Broadcast needs a circle — say `munkel <circle> all …`")
             }
-
-            let sent = await session.sendChat(text, to: recipientId)
+            var hits: [(session: GroupSession, member: GroupSession.Member)] = []
+            for code in groupCodes {
+                guard let session = sessions[code] else { continue }
+                for member in session.members where Self.recipientMatches(member, to) {
+                    hits.append((session, member))
+                }
+            }
+            guard hits.count == 1 else {
+                if hits.isEmpty {
+                    return ControlResponse(ok: false, error: "No online member matches \"\(to)\" — munkel circles shows who's online")
+                }
+                // Ambiguous: name only the candidate circles (and attach them
+                // as a discovery payload) so the caller can retry with
+                // `munkel <circle> <name> …` — never the whole social graph.
+                var candidateCodes: [String] = []
+                for code in hits.map(\.session.code) where !candidateCodes.contains(code) {
+                    candidateCodes.append(code)
+                }
+                let payload = candidateCodes.compactMap { code in
+                    sessions[code].map {
+                        ControlGroupInfo(code: code, connected: $0.isConnected, members: $0.members.map(\.label))
+                    }
+                }
+                return ControlResponse(
+                    ok: false,
+                    error: "\"\(to)\" is in \(candidateCodes.joined(separator: ", ")) — say `munkel <circle> \(to) …`",
+                    groups: payload
+                )
+            }
+            let sent = await hits[0].session.sendChat(text, to: hits[0].member.id)
             return sent
                 ? ControlResponse(ok: true)
                 : ControlResponse(ok: false, error: "Send failed — no connection to the relay?")
@@ -323,6 +362,13 @@ final class AppModel: ObservableObject {
         default:
             return ControlResponse(ok: false, error: "Unknown action \"\(request.action)\"")
         }
+    }
+
+    /// Recipient match shared by the circle-scoped and cross-circle send
+    /// paths: case-insensitive display-name match, or a public-key id prefix.
+    private static func recipientMatches(_ member: GroupSession.Member, _ query: String) -> Bool {
+        member.label.caseInsensitiveCompare(query) == .orderedSame
+            || member.id.hasPrefix(query.lowercased())
     }
 
     /// Exact code match first, then unique prefix (so `munkel kaffee …` works).

--- a/apps/macos/Sources/MunkelApp/LoginItem.swift
+++ b/apps/macos/Sources/MunkelApp/LoginItem.swift
@@ -1,0 +1,54 @@
+import Foundation
+import ServiceManagement
+
+/// Registers the app to relaunch at login via `SMAppService.mainApp`, so the
+/// `munkel` CLI's first send hits an already-running app instead of paying
+/// cold-start inside a coding agent's loop. A flat enum of static members that
+/// owns its own defaults key, mirroring the codebase's small preference types.
+///
+/// Never fatal: `register()`/`unregister()` are synchronous and throwing, and
+/// every call site stays best-effort — a thrown failure (an unsigned or
+/// translocated build, or Login Items disabled system-wide) must not crash
+/// launch or the menu.
+enum LoginItem {
+    /// One-time auto-register guard. Set once (release builds, first launch) and
+    /// never re-read for enabling, so a user who later turns the toggle off — or
+    /// disables Login Items in System Settings — is not silently re-enabled.
+    private static let didAutoRegisterKey = "loginItemAutoRegistered"
+
+    /// True only when the OS will actually launch us at login. `.requiresApproval`
+    /// (the user disabled Login Items for this app) and `.notRegistered` both
+    /// read as false, so the toggle reflects reality — not merely that we called
+    /// `register()`.
+    static var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    /// Register or unregister the app as a login item. Throwing so the menu
+    /// binding's `try?` can snap the toggle back to its true state on failure.
+    static func setEnabled(_ enabled: Bool) throws {
+        if enabled {
+            // Re-registering while already enabled hits the documented
+            // "already registered" edge — skip it.
+            guard SMAppService.mainApp.status != .enabled else { return }
+            try SMAppService.mainApp.register()
+        } else {
+            try SMAppService.mainApp.unregister()
+        }
+    }
+
+    /// Call once from `AppDelegate.applicationDidFinishLaunching`, RELEASE ONLY:
+    /// the dev build is "Munkel Dev" with its own bundle id, and `mainApp` keys
+    /// off the running bundle. The flag is set before the attempt, so a failed
+    /// or denied first launch is not retried on every subsequent launch.
+    static func registerOnFirstLaunchIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: didAutoRegisterKey) else { return }
+        defaults.set(true, forKey: didAutoRegisterKey)
+        do {
+            try setEnabled(true)
+        } catch {
+            NSLog("munkel: login-item auto-register failed: \(error)")
+        }
+    }
+}

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -133,6 +133,15 @@ struct MenuView: View {
                 Label("Install Command Line Tool…", systemImage: "terminal")
             }
             #endif
+            Divider()
+            // Bound to live SMAppService status, not @AppStorage: it reads back
+            // the real system state (incl. changes from System Settings › Login
+            // Items) and never crashes — `try?` snaps the toggle back to its
+            // true state if a register/unregister fails.
+            Toggle("Launch at Login", isOn: Binding(
+                get: { LoginItem.isEnabled },
+                set: { try? LoginItem.setEnabled($0) }
+            ))
             #if DEBUG
             Divider()
             Toggle("Echo my broadcasts to me", isOn: $devEchoBroadcasts)

--- a/apps/macos/Sources/MunkelApp/MunkelApp.swift
+++ b/apps/macos/Sources/MunkelApp/MunkelApp.swift
@@ -32,6 +32,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         model.updater = updater
         #endif
 
+        // Keep the app resident across logins so the `munkel` CLI's first send
+        // never pays app cold-start. Release-only and once: the dev build runs
+        // as "Munkel Dev" (own bundle id) and must not self-install, and a user
+        // who later opts out isn't re-enabled on the next launch.
+        #if !DEBUG
+        LoginItem.registerOnFirstLaunchIfNeeded()
+        #endif
+
         let hosting = NSHostingController(rootView: MenuView().environmentObject(model))
         hosting.sizingOptions = .preferredContentSize
         popover.contentViewController = hosting

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# e2e-local.sh — stand up a local end-to-end Munkel rig on ONE Mac to exercise
+# the CLI ↔ app ↔ relay ↔ notch path (Schicht 2/3 of the test plan).
+#
+# The release app and the dev app have distinct bundle ids, identities, and
+# control sockets, so they run side by side as TWO peers. Point both at a local
+# relay and join them to the same circle and you can watch `munkel dm <name>`
+# light up the other app's notch — no second machine needed.
+#
+# Usage:
+#   scripts/e2e-local.sh check      # verify prerequisites (safe, no side effects)
+#   scripts/e2e-local.sh up         # relay + both apps, pointed at the local relay
+#   scripts/e2e-local.sh down       # tear it all down
+#
+# After `up`: join both apps to the same circle (e.g. blue-table-42) in their
+# menus, then:
+#   munkel circles                         # release app sees the dev app as a member
+#   munkel dm <dev-app-name> "hi"          # dev app's notch lights up
+#   MUNKEL_DEV=1 bun apps/cli/src/munkel.ts dm <release-app-name> "yo"
+#   scripts/simulate-whispers.sh blue-table-42 Sim   # a third, simulated member
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RELAY_URL="${RELAY_URL:-ws://127.0.0.1:8787}"
+RELAY_PORT="${RELAY_PORT:-8787}"
+MACOS="$REPO_ROOT/apps/macos"
+REL_APP="$MACOS/.build/Munkel.app"
+DEV_APP="$MACOS/.build/MunkelDev.app"
+RELAY_PID="/tmp/munkel-e2e-relay.pid"
+
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$1"; }
+info() { printf '\033[1m%s\033[0m\n' "$1"; }
+
+cmd_check() {
+  local fail=0
+  info "Prerequisites"
+  command -v bun >/dev/null 2>&1 && ok "bun on PATH" || { bad "bun missing"; fail=1; }
+  command -v open >/dev/null 2>&1 && ok "open (macOS)" || { bad "not macOS?"; fail=1; }
+  command -v launchctl >/dev/null 2>&1 && ok "launchctl" || { bad "launchctl missing"; fail=1; }
+
+  info "Build artifacts (run: cd apps/macos && ./make-bundle.sh release && ./make-bundle.sh debug)"
+  [ -d "$REL_APP" ] && ok "release app  $REL_APP" || { bad "missing $REL_APP"; fail=1; }
+  [ -d "$DEV_APP" ] && ok "dev app      $DEV_APP" || { bad "missing $DEV_APP"; fail=1; }
+
+  info "Relay (apps/server, wrangler dev on :$RELAY_PORT)"
+  [ -f "$REPO_ROOT/apps/server/package.json" ] && ok "apps/server present" || { bad "no apps/server"; fail=1; }
+  if lsof -i ":$RELAY_PORT" >/dev/null 2>&1; then ok "something already listening on :$RELAY_PORT"; else info "  (relay not running yet — 'up' will start it)"; fi
+
+  info "Helpers"
+  [ -x "$REPO_ROOT/scripts/simulate-whispers.sh" ] && ok "simulate-whispers.sh" || bad "simulate-whispers.sh not executable"
+  [ -f "$REPO_ROOT/apps/cli/src/munkel.ts" ] && ok "CLI source" || { bad "CLI source missing"; fail=1; }
+
+  [ "$fail" -eq 0 ] && info "READY — run: scripts/e2e-local.sh up" || { info "NOT READY — fix the ✗ above"; return 1; }
+}
+
+cmd_up() {
+  info "Pointing GUI apps at the local relay ($RELAY_URL)"
+  launchctl setenv MUNKEL_RELAY_URL "$RELAY_URL"; ok "launchctl setenv MUNKEL_RELAY_URL"
+
+  if ! lsof -i ":$RELAY_PORT" >/dev/null 2>&1; then
+    info "Starting relay (wrangler dev)…"
+    ( cd "$REPO_ROOT/apps/server" && nohup bun run dev >/tmp/munkel-e2e-relay.log 2>&1 & echo $! >"$RELAY_PID" )
+    for _ in $(seq 1 60); do lsof -i ":$RELAY_PORT" >/dev/null 2>&1 && break; sleep 0.5; done
+    lsof -i ":$RELAY_PORT" >/dev/null 2>&1 && ok "relay up on :$RELAY_PORT" || { bad "relay didn't come up — see /tmp/munkel-e2e-relay.log"; return 1; }
+  else
+    ok "relay already on :$RELAY_PORT"
+  fi
+
+  info "Launching both apps (two peers)…"
+  open "$REL_APP"; ok "release app"
+  open "$DEV_APP"; ok "dev app"
+
+  cat <<EOF
+
+Next:
+  1. In BOTH menu-bar apps, join the same circle (e.g. blue-table-42).
+  2. munkel circles                          # should list the other app as a member
+  3. munkel dm <other-display-name> "hi"     # the other app's notch slides out
+  4. scripts/simulate-whispers.sh blue-table-42 Sim   # optional simulated member
+Tear down with: scripts/e2e-local.sh down
+EOF
+}
+
+cmd_down() {
+  info "Tearing down"
+  launchctl unsetenv MUNKEL_RELAY_URL && ok "unset MUNKEL_RELAY_URL" || true
+  osascript -e 'quit app "Munkel"'    2>/dev/null && ok "quit Munkel"    || true
+  osascript -e 'quit app "MunkelDev"' 2>/dev/null && ok "quit MunkelDev" || true
+  if [ -f "$RELAY_PID" ]; then kill "$(cat "$RELAY_PID")" 2>/dev/null && ok "stopped relay" || true; rm -f "$RELAY_PID"; fi
+  pkill -f 'wrangler dev' 2>/dev/null || true
+}
+
+case "${1:-check}" in
+  check) cmd_check ;;
+  up)    cmd_up ;;
+  down)  cmd_down ;;
+  *) echo "usage: $0 {check|up|down}" >&2; exit 64 ;;
+esac

--- a/scripts/skill-fake-app.ts
+++ b/scripts/skill-fake-app.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+// Scriptable stand-in for the Munkel app's control socket. Lets us test the
+// `munkel` CLI and skill steering without the real app, relay, or notch: it
+// logs every request as JSONL and answers per FAKE_SCENARIO. Mirrors the wire
+// contract in MunkelKit/ControlProtocol.swift.
+//
+//   FAKE_SOCKET    unix socket to bind (required)
+//   FAKE_LOG       JSONL request log, appended (required)
+//   FAKE_SCENARIO  happy | ambiguous | unknown | silent   (default happy)
+import { appendFileSync, existsSync, unlinkSync } from "node:fs"
+
+const socketPath = process.env.FAKE_SOCKET
+const logPath = process.env.FAKE_LOG
+const scenario = process.env.FAKE_SCENARIO ?? "happy"
+if (!socketPath || !logPath) {
+  console.error("skill-fake-app: set FAKE_SOCKET and FAKE_LOG")
+  process.exit(2)
+}
+if (existsSync(socketPath)) unlinkSync(socketPath)
+
+const circles = (members: Record<string, string[]>) =>
+  Object.entries(members).map(([code, m]) => ({ code, connected: true, members: m }))
+
+// Returns the response object, or undefined to send nothing (silent scenario).
+function respond(req: { action?: string; group?: string; to?: string }): unknown | undefined {
+  if (scenario === "silent") return undefined
+
+  if (req.action === "groups") {
+    if (scenario === "unknown") return { ok: true, groups: circles({ "blue-table-42": ["Alex"] }) }
+    return {
+      ok: true,
+      groups: circles({ "blue-table-42": ["Sim", "Alex"], "green-room-17": ["Sam"] }),
+    }
+  }
+
+  if (req.action === "send") {
+    const to = (req.to ?? "").toLowerCase()
+    const isBroadcast = to === "all" || to === "*"
+    // Circle-scoped sends (explicit group) and broadcasts always succeed —
+    // this is the disambiguation path the agent should fall back to.
+    if (req.group || isBroadcast) return { ok: true }
+
+    // Recipient-only (`dm`) send — the path under test.
+    if (scenario === "ambiguous") {
+      return {
+        ok: false,
+        error: `"${req.to}" is in blue-table-42, green-room-17 — say \`munkel <circle> ${req.to} …\``,
+        groups: circles({ "blue-table-42": ["Sim", "Alex"], "green-room-17": ["Sim", "Sam"] }),
+      }
+    }
+    if (scenario === "unknown") {
+      return {
+        ok: false,
+        error: `No online member matches "${req.to}" — munkel circles shows who's online`,
+      }
+    }
+    return { ok: true } // happy
+  }
+
+  return { ok: false, error: `unknown action ${req.action}` }
+}
+
+Bun.listen({
+  unix: socketPath,
+  socket: {
+    data(sock, data) {
+      let req: { action?: string; group?: string; to?: string; raw?: string }
+      try {
+        req = JSON.parse(data.toString().split("\n")[0])
+      } catch {
+        req = { raw: data.toString() }
+      }
+      appendFileSync(logPath, JSON.stringify(req) + "\n")
+      const res = respond(req)
+      if (res !== undefined) {
+        sock.write(JSON.stringify(res) + "\n")
+        sock.end()
+      }
+      // silent: keep the connection open and never reply → CLI hits its timeout.
+    },
+  },
+})
+console.error(`skill-fake-app: listening on ${socketPath} (scenario=${scenario})`)

--- a/scripts/skill-testbin/munkel
+++ b/scripts/skill-testbin/munkel
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Test shim named `munkel`: put scripts/skill-testbin on PATH and the skill's
+# `munkel …` calls route to the from-source CLI against a per-run fake app
+# (scripts/skill-fake-app.ts). Used to measure how the skill steers an agent —
+# every call is logged, nothing touches the real app/relay/notch.
+#
+#   MUNKEL_STEER_RUN       isolates socket + log per run   (default "default")
+#   MUNKEL_STEER_SCENARIO  happy | ambiguous | unknown | silent  (default happy)
+set -euo pipefail
+
+bindir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$bindir/../.." && pwd)"
+
+run="${MUNKEL_STEER_RUN:-default}"
+scenario="${MUNKEL_STEER_SCENARIO:-happy}"
+sock="/tmp/munkel-steer-$run.sock"
+log="/tmp/munkel-steer-$run.jsonl"
+
+# Fresh log on the run's first call only; lazy reboots below append to it so a
+# reaped background fake never loses earlier calls.
+[ -f "$log" ] || : > "$log"
+
+# Lazily (re)start the fake app if its socket isn't up.
+if [ ! -S "$sock" ]; then
+  FAKE_SOCKET="$sock" FAKE_LOG="$log" FAKE_SCENARIO="$scenario" \
+    nohup bun "$repo/scripts/skill-fake-app.ts" >"/tmp/munkel-steer-$run.applog" 2>&1 &
+  for _ in $(seq 1 60); do [ -S "$sock" ] && break; sleep 0.05; done
+fi
+
+exec env MUNKEL_SOCKET="$sock" bun "$repo/apps/cli/src/munkel.ts" "$@"

--- a/skills/munkel/SKILL.md
+++ b/skills/munkel/SKILL.md
@@ -34,7 +34,9 @@ munkel <circle> all <message…>       # broadcast to the whole circle
 ```
 
 `<circle>` is a code like `blue-table-42`; any unambiguous prefix works.
-Broadcast (`all`) always needs an explicit circle.
+Broadcast (`all`) always needs an explicit circle. If you can't tell which
+circle is the right one, ask — don't send to every candidate, or you'll notify
+the wrong people too.
 
 ## List circles (only when a send fails)
 

--- a/skills/munkel/SKILL.md
+++ b/skills/munkel/SKILL.md
@@ -8,62 +8,47 @@ description: Send ephemeral end-to-end-encrypted messages that appear in
 
 # munkel — munkel into your friends' notches
 
-Munkel delivers ephemeral E2E-encrypted messages that slide out of the
-recipient's MacBook notch. The CLI is **send-only**: it cannot read,
-receive, or wait for messages. It is a thin client for the running
-Munkel.app, which owns circles, crypto, and the relay connection.
+Ephemeral, E2E-encrypted messages that slide out of the recipient's MacBook
+notch. The CLI is **send-only** — a thin client for the running Munkel.app,
+which owns circles, crypto, and the relay. It auto-launches the app if it
+isn't running, so no `open -a Munkel` first.
 
-## Requirements
-
-- macOS with Munkel.app installed: `brew install limehq/tap/munkel`. If the
-  app isn't running, the CLI launches it automatically (in the background)
-  and waits for it before sending — no need to `open -a Munkel` first.
-- The user must already be in a circle — circles are created/joined in the
-  app's menu-bar UI, not the CLI.
-
-## Commands
+## Notify one person — the common case
 
 ```sh
-munkel circles                       # list circles and online members
-munkel <circle> <recipient> <text…>  # direct message (recipient = display name)
-munkel <circle> all <text…>          # broadcast to the whole circle
+munkel dm <name> <message…>      # e.g. munkel dm sebil deploy is green
 ```
 
-- `<circle>` is a circle code like `blue-table-42`; any unambiguous
-  prefix works (`blue-table` suffices if only one circle starts with it).
-- `<recipient>` is a member's display name exactly as shown by
-  `munkel circles`; `all` broadcasts.
-- Everything after the recipient is joined with spaces, so quoting is
-  only needed for shell metacharacters.
+`dm` resolves `<name>` across every circle, so this is a **single call** — do
+NOT run `munkel circles` first. `<name>` matches a member's display name
+(case-insensitive) or a prefix of their key id (both shown by `munkel
+circles`). Success prints `munkeled ✓` and exits 0.
 
-`munkel circles` output (● = relay-connected, ○ = offline; members shown
-are the ones currently online):
+If the send fails, the error says which case it is: an unknown name prints
+`No online member matches …`; a name in more than one circle prints the
+candidate circles. Either way, retry with the circle-scoped form:
 
+```sh
+munkel <circle> <name> <message…>    # munkel blue-table-42 sebil hi
+munkel <circle> all <message…>       # broadcast to the whole circle
 ```
-● blue-table-42  —  Alex, Sam
+
+`<circle>` is a code like `blue-table-42`; any unambiguous prefix works.
+Broadcast (`all`) always needs an explicit circle.
+
+## List circles (only when a send fails)
+
+```sh
+munkel circles            # ● online / ○ offline, with online members
+munkel circles --json     # machine-readable [{code,connected,members}]
 ```
-
-Run `munkel circles` first to discover valid circle codes and recipient
-names.
-
-## Behavior and errors
-
-Success prints `munkeled ✓` and exits 0.
-
-- The CLI auto-starts Munkel.app if it isn't running and waits for it. A
-  `couldn't start the Munkel app` error means the launch itself failed —
-  the app likely isn't installed (`brew install limehq/tap/munkel`).
-- `Munkel app isn't running` only appears when a custom `MUNKEL_SOCKET` is
-  set (auto-launch is skipped for custom sockets).
-- Unknown circle / recipient errors come from the app; re-check with
-  `munkel circles`.
-- Exit 64 means a usage error (wrong arguments).
-- `MUNKEL_SOCKET` overrides the control socket path
-  (default `~/Library/Application Support/Munkel/control.sock`) — only
-  relevant for testing.
 
 ## Limits
 
-- Send-only: there is no way to read replies or message history.
-- Messages are ephemeral by design — nothing is stored anywhere. Do not
+- Send-only: no way to read replies or history.
+- Messages are ephemeral — nothing is stored anywhere. A success means the
+  message was handed to the relay, not that it appeared in their notch. Don't
   use Munkel for notifications the user must not miss.
+
+Run `munkel --help` for socket overrides (`MUNKEL_SOCKET`), dev mode, and exit
+codes (64 usage · 75 app didn't reply).


### PR DESCRIPTION
Makes the `munkel` CLI + skill cheap, fast, and stable for coding-agent use. Bumps **0.8.3 → 0.9.0** (feat → minor).

## What changed
**`feat(cli)` — one-call notify + stability**
- `munkel dm <name> <text>`: recipient-only send. The app resolves the name across **every** circle (shared `recipientMatches`: display name or key-id prefix), sends on a unique match, on ambiguity returns only the candidate circles. Collapses the old two-call flow (`munkel circles` → send) into one.
- Bounded reply wait (`Promise.race`, 4s, `MUNKEL_RESPONSE_TIMEOUT_MS`) → a silent app can no longer hang the caller; exit 75 on timeout.
- Errors carry candidate circles in the existing `groups` field; `munkel circles --json`.
- SKILL.md/README rewritten to lead with the one-call path (drops the mandatory `munkel circles` first step).

**`feat(app)` — residency**
- `LoginItem` (SMAppService): one-time, release-only auto-register so the CLI's first send never pays app cold-start. "Launch at Login" toggle in the gear menu.

**`test(munkel)` — verification tooling**
- `scripts/skill-fake-app.ts` + `scripts/skill-testbin/munkel`: scriptable fake app to measure skill steering with no app/relay.
- `scripts/e2e-local.sh {check,up,down}`: one-Mac rig (relay + release app + dev app as two peers) to watch a real `dm` light the notch.

## Test evidence
- `bun test`: 16/16 green · `tsc --noEmit`: clean.
- `make-bundle.sh release`: full signed bundle builds clean.
- Skill steering (9 agents reading the real SKILL.md): **6/6** "notify one person" prompts → a single `dm` call, **0** `circles`-first.

## Not yet verified live
- The **real app resolving `dm` across live circles** is unexecuted (steering used a fake app). The Swift path mirrors the already-shipped within-circle resolver and the unchanged circle-scoped path; low risk, but worth a `scripts/e2e-local.sh up` smoke test before merging the release.
- `AppModel.handleControl` cross-circle resolution has no unit test.

## Note
A naked `swift build -c release` crashes in the KeyboardShortcuts dependency (swiftlang/swift#88173) — already worked around by `make-bundle.sh` (`-Onone`). Not introduced here.