### PR TITLE
feat: show lock/globe icon in collapsed message teaser

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -306,16 +306,22 @@ struct MessageNotchContainer: View {
     /// Text below the notch; avatar lifted into the strip left of the cutout,
     /// flush with the text's leading edge so the line starts right under it.
     private var notchedTeaser: some View {
-        TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
-            .padding(.top, 2)
-            .padding(.bottom, -6)
-            .overlay(alignment: .topLeading) {
-                CompactAvatarView(name: message.sender, avatarData: message.avatarData)
-                    .offset(y: avatarOffsetY)
-            }
-            // In the teaser the message IS the whole content — clicking
-            // it starts the reply (and expands).
-            .background(AreaMarker { [weak model] in model?.teaserMarker = $0 })
+        HStack(alignment: .top, spacing: 6) {
+            TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
+            Image(systemName: message.isDirect ? "lock.fill" : "globe")
+                .font(.system(size: 9))
+                .foregroundStyle(.white.opacity(0.55))
+                .padding(.top, 2)
+        }
+        .padding(.top, 2)
+        .padding(.bottom, -6)
+        .overlay(alignment: .topLeading) {
+            CompactAvatarView(name: message.sender, avatarData: message.avatarData)
+                .offset(y: avatarOffsetY)
+        }
+        // In the teaser the message IS the whole content — clicking
+        // it starts the reply (and expands).
+        .background(AreaMarker { [weak model] in model?.teaserMarker = $0 })
     }
 
     /// Macs without a notch: keep the avatar in-row, nothing to tuck beside.
@@ -323,6 +329,9 @@ struct MessageNotchContainer: View {
         HStack(spacing: 10) {
             CompactAvatarView(name: message.sender, avatarData: message.avatarData)
             TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
+            Image(systemName: message.isDirect ? "lock.fill" : "globe")
+                .font(.system(size: 9))
+                .foregroundStyle(.white.opacity(0.55))
         }
         .padding(.vertical, 4)
         .background(AreaMarker { [weak model] in model?.teaserMarker = $0 })


### PR DESCRIPTION
## Summary
Show the private/public message indicator (🔒 lock for DMs, 🌍 globe for broadcasts) in the notch teaser state so users see at a glance whether a message is private or public without needing to hover or expand.

## Changes
- Added lock/globe icon to notched teaser view (for Macs with notch)
- Added lock/globe icon to fallback teaser view (for Macs without notch)
- Icons use the same styling as the expanded message view for consistency
- Icons are visible immediately when a message arrives—no hover required

## Testing
- Build: `bunx turbo build --filter=@munkel/macos`
- Run: `open apps/macos/.build/MunkelDev.app`
- Verify: Send private and public messages—icons appear in teaser state