### PR TITLE
feat(macos): copy history messages via hover button and "C" shortcut

### DIFF
--- a/apps/macos/Sources/MunkelApp/CopyMessageButton.swift
+++ b/apps/macos/Sources/MunkelApp/CopyMessageButton.swift
@@ -1,5 +1,23 @@
 import SwiftUI
 
+/// The bare copy affordance: a clipboard glyph that morphs into a green
+/// checkmark while `copied` is true. Presentational only — used directly
+/// (no button) for history rows, whose click is caught by NotchPresenter's
+/// event monitor, and wrapped by `CopyMessageButton` for the current message.
+struct CopyGlyph: View {
+    let copied: Bool
+    var diameter: CGFloat = 28
+
+    var body: some View {
+        Image(systemName: copied ? "checkmark" : "doc.on.doc")
+            .font(.system(size: diameter * 0.43, weight: .semibold))
+            .foregroundStyle(copied ? Color.green : .white.opacity(0.65))
+            .contentTransition(.symbolEffect(.replace))
+            .frame(width: diameter, height: diameter)
+            .background(.white.opacity(0.1), in: Circle())
+    }
+}
+
 /// Presentational copy affordance: morphs into a green checkmark while
 /// `copied` is true. The copy state lives in MessageDisplayModel so that
 /// click-anywhere-to-copy flashes the same feedback.
@@ -10,12 +28,7 @@ struct CopyMessageButton: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                .font(.system(size: diameter * 0.43, weight: .semibold))
-                .foregroundStyle(copied ? Color.green : .white.opacity(0.65))
-                .contentTransition(.symbolEffect(.replace))
-                .frame(width: diameter, height: diameter)
-                .background(.white.opacity(0.1), in: Circle())
+            CopyGlyph(copied: copied, diameter: diameter)
         }
         .buttonStyle(.plain)
         // No .help: this button only lives in the notch, and tooltip

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -20,6 +20,20 @@ final class MessageDisplayModel: ObservableObject {
     @Published var history: [HistoryEntry] = []
     /// Click on the history area lifts the one-line truncation.
     @Published var historyExpanded = false
+    /// Which history row just had its text copied — drives the per-row
+    /// checkmark, independent of `copied` (the current message's button).
+    @Published var copiedHistoryID: UUID?
+    /// Which history row the pointer is over (nil = none). Lets NotchPresenter
+    /// enable the bare-"C" copy hotkey only while a row is hovered, and tells it
+    /// which row to copy when "C" is pressed.
+    @Published var hoveredHistoryID: UUID?
+    /// Hover-revealed per-row copy hit targets. The glyph itself is a plain
+    /// visual (CopyGlyph); the AppKit click monitor in NotchPresenter matches
+    /// clicks against these frames — just like historyMarker/replyMarker —
+    /// so the right row copies without a SwiftUI Button stealing the click.
+    /// A row registers its target only while hovered, so a non-hovered row's
+    /// trailing area still falls through to the expand toggle.
+    var historyCopyTargets: [HistoryCopyTarget] = []
     /// Marker views registered by the container so NotchPresenter's click
     /// monitor can match clicks against their frames. NSHostingView's
     /// hitTest doesn't surface embedded NSViews, so frames it is.
@@ -31,15 +45,65 @@ final class MessageDisplayModel: ObservableObject {
     weak var teaserMarker: NSView?
 
     func copy(_ text: String) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-
+        writePasteboard(text)
         withAnimation(.spring(duration: 0.3)) { copied = true }
         Task {
             try? await Task.sleep(for: .seconds(1.5))
             withAnimation(.spring(duration: 0.3)) { copied = false }
         }
+    }
+
+    /// Copy one history row, flashing the checkmark on that row alone.
+    func copyHistory(id: UUID, text: String) {
+        writePasteboard(text)
+        withAnimation(.spring(duration: 0.3)) { copiedHistoryID = id }
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            // Only clear if this row is still the one showing the checkmark,
+            // so a fresh copy on another row isn't cut short.
+            if copiedHistoryID == id {
+                withAnimation(.spring(duration: 0.3)) { copiedHistoryID = nil }
+            }
+        }
+    }
+
+    /// Register a row's copy hit target (called from the hover-revealed glyph).
+    /// Replaces any prior target for the same row and drops dead ones, so the
+    /// list never grows past the handful of rows hovered in one panel's life.
+    func registerHistoryCopy(id: UUID, text: String, view: NSView) {
+        historyCopyTargets.removeAll { $0.view == nil || $0.id == id }
+        historyCopyTargets.append(HistoryCopyTarget(id: id, text: text, view: view))
+    }
+
+    /// Copy whichever history row the pointer is over — the target of the
+    /// hover-only "C" shortcut. No-op if nothing is hovered.
+    func copyHoveredHistory() {
+        guard let id = hoveredHistoryID,
+              let entry = history.first(where: { $0.id == id }) else { return }
+        copyHistory(id: id, text: entry.text)
+    }
+
+    private func writePasteboard(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+}
+
+/// A hover-revealed copy affordance on a history row. Holds the row's id and
+/// text plus a weak reference to the marker NSView laid out under the glyph;
+/// NotchPresenter's click monitor copies the row whose view contains the
+/// click. Weak view: once the row un-hovers the marker leaves the hierarchy
+/// and this target goes stale (matched against nothing, pruned on next use).
+final class HistoryCopyTarget {
+    let id: UUID
+    let text: String
+    weak var view: NSView?
+
+    init(id: UUID, text: String, view: NSView) {
+        self.id = id
+        self.text = text
+        self.view = view
     }
 }
 
@@ -146,7 +210,10 @@ struct MessageNotchContainer: View {
     /// right under the main view. Rows vanish live once they expire
     /// (pruned by NotchPresenter).
     private var historyRows: some View {
-        VStack(alignment: .leading, spacing: 3) {
+        // Zero spacing so the rows' hover zones (each glyph-tall, taller than
+        // the text — see HistoryRow) meet edge to edge: no dead gap between rows
+        // where the copy glyph would flicker off, and the list stays compact.
+        VStack(alignment: .leading, spacing: 0) {
             Rectangle()
                 .fill(.white.opacity(0.15))
                 .frame(height: 1)
@@ -155,13 +222,7 @@ struct MessageNotchContainer: View {
                 expandedHistory
             } else {
                 ForEach(model.history.reversed()) { entry in
-                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        historyHeader(for: entry)
-                        Text(entry.text)
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.55))
-                            .lineLimit(1)
-                    }
+                    HistoryRow(model: model, entry: entry, expanded: false)
                 }
             }
         }
@@ -170,7 +231,9 @@ struct MessageNotchContainer: View {
         .contentShape(Rectangle())
         // The click itself is handled by NotchPresenter's AppKit monitor,
         // which matches click coordinates against this marker's frame to
-        // tell "expand history" apart from "start a reply".
+        // tell "expand history" apart from "start a reply" — and, when a row
+        // is hovered, against that row's copy target (checked first) to copy
+        // it instead of toggling.
         .background(AreaMarker { [weak model] in model?.historyMarker = $0 })
         .animation(.spring(duration: 0.3), value: model.history)
         .animation(.spring(duration: 0.3), value: model.historyExpanded)
@@ -183,16 +246,12 @@ struct MessageNotchContainer: View {
     private var expandedHistory: some View {
         let cap = (NSScreen.main?.frame.height ?? 900) / 3
         return ScrollView {
-            VStack(alignment: .leading, spacing: 3) {
+            // Zero spacing for the same reason as the collapsed list: contiguous,
+            // glyph-tall hover zones with no dead gap (each expanded row adds its
+            // own in-zone bottom inset for readability — see HistoryRow).
+            VStack(alignment: .leading, spacing: 0) {
                 ForEach(model.history.reversed()) { entry in
-                    VStack(alignment: .leading, spacing: 1) {
-                        historyHeader(for: entry)
-                        Text(entry.text)
-                            .font(.system(size: 11))
-                            .foregroundStyle(.white.opacity(0.55))
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    .padding(.bottom, 2)
+                    HistoryRow(model: model, entry: entry, expanded: true)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -204,21 +263,6 @@ struct MessageNotchContainer: View {
         }
         .frame(height: historyHeight == 0 ? nil : min(historyHeight, cap))
         .onPreferenceChange(HistoryHeightKey.self) { historyHeight = $0 }
-    }
-
-    /// Dot, sender and channel icon of one history row.
-    private func historyHeader(for entry: HistoryEntry) -> some View {
-        HStack(spacing: 4) {
-            Circle()
-                .fill(entry.groupColor)
-                .frame(width: 5, height: 5)
-            Text(entry.sender)
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.4))
-            Image(systemName: entry.isDirect ? "lock.fill" : "globe")
-                .font(.system(size: 8))
-                .foregroundStyle(.white.opacity(0.3))
-        }
     }
 
     /// Inline reply. Return sends, Escape dismisses; focus lands here as
@@ -332,6 +376,128 @@ struct MessageNotchContainer: View {
     private var avatarOffsetY: CGFloat {
         -(notchSize.height + avatarSize) / 2
     }
+}
+
+/// One history row: sender header plus the message text (one line collapsed,
+/// full when expanded), with a copy glyph that fades in on hover. The glyph is
+/// purely visual — clicking it is caught by NotchPresenter's event monitor,
+/// which matches the hover-registered hit target laid out beneath the glyph.
+private struct HistoryRow: View {
+    @ObservedObject var model: MessageDisplayModel
+    let entry: HistoryEntry
+    /// Expanded shows the full (wrapping) text; collapsed clamps to one line.
+    let expanded: Bool
+
+    @State private var hovering = false
+
+    /// Matches the current message's own copy button. The slot is always
+    /// reserved (opacity, not layout, hides it), so this also sets the
+    /// collapsed one-line row height — a deliberate trade for a comfortably
+    /// sized, easy-to-hit target over maximum density.
+    private let glyphDiameter: CGFloat = 20
+
+    var body: some View {
+        Group {
+            if expanded {
+                HStack(alignment: .top, spacing: 4) {
+                    VStack(alignment: .leading, spacing: 1) {
+                        header
+                        text.fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: 4)
+                    glyph
+                }
+                // A little air between full-text rows, kept inside the hover
+                // zone so it adds no dead gap. Collapsed rows skip it to stay tight.
+                .padding(.bottom, 4)
+            } else {
+                HStack(spacing: 4) {
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        header
+                        text.lineLimit(1)
+                    }
+                    Spacer(minLength: 4)
+                    glyph
+                }
+            }
+        }
+        // No outer padding — the row is already glyph-tall (≥20pt), so its hover
+        // zone sits a few points above and below the text. With zero spacing
+        // between rows (see historyRows) the zones meet edge to edge, so the
+        // glyph appears as soon as the pointer is in the history block — no need
+        // to land exactly on the text — while collapsed rows stay compact.
+        .contentShape(Rectangle())
+        // Hover gates the glyph, its click target, AND the bare-"C" copy
+        // shortcut (NotchPresenter watches hoveredHistoryID). An un-hovered
+        // row's trailing area still toggles the history via the monitor.
+        .onHover { inside in
+            hovering = inside
+            if inside {
+                model.hoveredHistoryID = entry.id
+            } else if model.hoveredHistoryID == entry.id {
+                // Only clear if we're still the hovered row: moving to an
+                // adjacent row, its enter can land before this leave.
+                model.hoveredHistoryID = nil
+            }
+        }
+    }
+
+    /// Dot, sender and channel icon of the row.
+    private var header: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(entry.groupColor)
+                .frame(width: 5, height: 5)
+            Text(entry.sender)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.4))
+            Image(systemName: entry.isDirect ? "lock.fill" : "globe")
+                .font(.system(size: 8))
+                .foregroundStyle(.white.opacity(0.3))
+        }
+    }
+
+    private var text: some View {
+        Text(entry.text)
+            .font(.system(size: 11))
+            .foregroundStyle(.white.opacity(0.55))
+    }
+
+    /// Copy affordance: hidden until hover (or while its checkmark lingers),
+    /// always reserving its slot so the text doesn't reflow on reveal. The
+    /// hit target only exists while hovered — NotchPresenter copies the row
+    /// whose target the click lands in.
+    private var glyph: some View {
+        let isCopied = model.copiedHistoryID == entry.id
+        let show = hovering || isCopied
+        return CopyGlyph(copied: isCopied, diameter: glyphDiameter)
+            .opacity(show ? 1 : 0)
+            .background {
+                if hovering {
+                    HistoryCopyHitTarget(id: entry.id, text: entry.text) { [weak model] id, text, view in
+                        model?.registerHistoryCopy(id: id, text: text, view: view)
+                    }
+                }
+            }
+            .animation(.easeInOut(duration: 0.12), value: show)
+    }
+}
+
+/// Invisible NSView laid out under a history row's copy glyph. Like AreaMarker
+/// but carries the row id and text, registered into the model so the click
+/// monitor can copy the matching row (NSHostingView's hitTest can't surface it).
+private struct HistoryCopyHitTarget: NSViewRepresentable {
+    let id: UUID
+    let text: String
+    let register: (UUID, String, NSView) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        register(id, text, view)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
 /// Invisible real NSView laid out behind an area of the notch. It only

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -23,10 +23,13 @@ final class MessageDisplayModel: ObservableObject {
     /// Which history row just had its text copied — drives the per-row
     /// checkmark, independent of `copied` (the current message's button).
     @Published var copiedHistoryID: UUID?
-    /// Which history row the pointer is over (nil = none). Lets NotchPresenter
-    /// enable the bare-"C" copy hotkey only while a row is hovered, and tells it
-    /// which row to copy when "C" is pressed.
+    /// Which history row the pointer is over, or nil when it's over the current
+    /// message (or a gap). Tells the hover-"C" shortcut which row to copy; nil
+    /// means copy the current (newest) message.
     @Published var hoveredHistoryID: UUID?
+    /// Text of the current (newest) message, so the hover-"C" shortcut can copy
+    /// it when the pointer isn't over a history row.
+    var currentText = ""
     /// Hover-revealed per-row copy hit targets. The glyph itself is a plain
     /// visual (CopyGlyph); the AppKit click monitor in NotchPresenter matches
     /// clicks against these frames — just like historyMarker/replyMarker —
@@ -75,12 +78,14 @@ final class MessageDisplayModel: ObservableObject {
         historyCopyTargets.append(HistoryCopyTarget(id: id, text: text, view: view))
     }
 
-    /// Copy whichever history row the pointer is over — the target of the
-    /// hover-only "C" shortcut. No-op if nothing is hovered.
-    func copyHoveredHistory() {
-        guard let id = hoveredHistoryID,
-              let entry = history.first(where: { $0.id == id }) else { return }
-        copyHistory(id: id, text: entry.text)
+    /// The hover-"C" shortcut target: the hovered history row, or — when the
+    /// pointer isn't over a row — the current (newest) message.
+    func copyHovered() {
+        if let id = hoveredHistoryID, let entry = history.first(where: { $0.id == id }) {
+            copyHistory(id: id, text: entry.text)
+        } else if !currentText.isEmpty {
+            copy(currentText)
+        }
     }
 
     private func writePasteboard(_ text: String) {

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import KeyboardShortcuts
 import SwiftUI
 
 /// Presents incoming messages below the notch: a slim one-line teaser
@@ -17,6 +18,8 @@ final class NotchPresenter {
     private var hideTask: Task<Void, Never>?
     private var pruneTask: Task<Void, Never>?
     private var hoverObservation: AnyCancellable?
+    /// Toggles the plain-"C" hover-copy hotkey on/off as rows are hovered.
+    private var hoverCopyObservation: AnyCancellable?
     private var clickMonitor: Any?
     private var outsideClickMonitor: Any?
 
@@ -39,6 +42,20 @@ final class NotchPresenter {
     private let afterTeaserDelay: Duration = .seconds(2)
     /// Grace period after the pointer leaves the expanded message.
     private let afterReadDelay: Duration = .seconds(1)
+
+    init() {
+        // The hover-copy shortcut is a bare "C". Attach the handler once, then
+        // force it OFF: registering the handler is what arms the global Carbon
+        // hotkey, so disabling AFTERWARDS guarantees the end state is dormant no
+        // matter the library's internal ordering. display() turns it on ONLY
+        // while a history row is hovered (and no reply is open), so it never
+        // swallows a "C" typed anywhere else.
+        KeyboardShortcuts.onKeyDown(for: .copyHoveredHistory) { [weak self] in
+            self?.currentModel?.copyHoveredHistory()
+        }
+        KeyboardShortcuts.disable(.copyHoveredHistory)
+    }
+
     /// Upper bound in case the teaser never reports completion — sized to
     /// the text so long messages aren't cut off mid-scroll. Rough estimate:
     /// ~7pt per character at the ticker's font, scrolling at 24pt/s through
@@ -118,6 +135,7 @@ final class NotchPresenter {
         hideTask?.cancel()
         hoverObservation = nil
         removeClickMonitors()
+        turnOffHoverCopy()
         if let previous = currentNotch {
             // hide() collapses immediately; afterwards a newer message may
             // already have taken over.
@@ -134,6 +152,20 @@ final class NotchPresenter {
         model.history = visibleHistory(excluding: entryID)
         currentEntryID = entryID
         currentModel = model
+
+        // Enable the bare-"C" copy hotkey only while a history row is hovered
+        // and no reply field is open — otherwise it would eat "C" globally, and
+        // while replying "C" must type into the field, not copy a row.
+        hoverCopyObservation = Publishers.CombineLatest(model.$hoveredHistoryID, model.$replying)
+            .map { hoveredID, replying in hoveredID != nil && !replying }
+            .removeDuplicates()
+            .sink { active in
+                if active {
+                    KeyboardShortcuts.enable(.copyHoveredHistory)
+                } else {
+                    KeyboardShortcuts.disable(.copyHoveredHistory)
+                }
+            }
 
         // Default to the main screen; a future setting (#7) supplies a different
         // closure. One measurement drives both panel placement and content layout.
@@ -242,11 +274,14 @@ final class NotchPresenter {
                     // hitTest is useless here (NSHostingView returns
                     // itself wherever SwiftUI content covers the marker),
                     // so clicks are matched against the marker frames via
-                    // AppKit coordinate conversion instead. History clicks
-                    // toggle the truncation, clicks on the current message
-                    // open the reply — everything else on the shape is
+                    // AppKit coordinate conversion instead. A hovered history
+                    // row's copy glyph wins first (copy that row), then history
+                    // clicks toggle the truncation, then clicks on the current
+                    // message open the reply — everything else on the shape is
                     // inert (buttons handle themselves).
-                    if Self.click(event, lands: model.historyMarker) {
+                    if let target = model.historyCopyTargets.first(where: { Self.click(event, lands: $0.view) }) {
+                        model.copyHistory(id: target.id, text: target.text)
+                    } else if Self.click(event, lands: model.historyMarker) {
                         withAnimation(.spring(duration: 0.3)) {
                             model.historyExpanded.toggle()
                         }
@@ -270,6 +305,16 @@ final class NotchPresenter {
     private static func click(_ event: NSEvent, lands marker: NSView?) -> Bool {
         guard let marker, marker.window === event.window else { return false }
         return marker.bounds.contains(marker.convert(event.locationInWindow, from: nil))
+    }
+
+    /// Hard off-switch for the bare-"C" hotkey, independent of hover state.
+    /// SwiftUI's `.onHover(false)` doesn't reliably fire when the notch is torn
+    /// down, so the hotkey must be force-disabled on every hide — otherwise a
+    /// stale-enabled "C" would keep swallowing the key after the notch is gone.
+    private func turnOffHoverCopy() {
+        hoverCopyObservation = nil
+        currentModel?.hoveredHistoryID = nil
+        KeyboardShortcuts.disable(.copyHoveredHistory)
     }
 
     private func removeClickMonitors() {
@@ -329,6 +374,7 @@ final class NotchPresenter {
             await notch.hide()
             self?.notchVisible = false
             self?.pruneTask?.cancel()
+            self?.turnOffHoverCopy()
         }
     }
 }

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -51,7 +51,7 @@ final class NotchPresenter {
         // while a history row is hovered (and no reply is open), so it never
         // swallows a "C" typed anywhere else.
         KeyboardShortcuts.onKeyDown(for: .copyHoveredHistory) { [weak self] in
-            self?.currentModel?.copyHoveredHistory()
+            self?.currentModel?.copyHovered()
         }
         KeyboardShortcuts.disable(.copyHoveredHistory)
     }
@@ -152,20 +152,9 @@ final class NotchPresenter {
         model.history = visibleHistory(excluding: entryID)
         currentEntryID = entryID
         currentModel = model
-
-        // Enable the bare-"C" copy hotkey only while a history row is hovered
-        // and no reply field is open — otherwise it would eat "C" globally, and
-        // while replying "C" must type into the field, not copy a row.
-        hoverCopyObservation = Publishers.CombineLatest(model.$hoveredHistoryID, model.$replying)
-            .map { hoveredID, replying in hoveredID != nil && !replying }
-            .removeDuplicates()
-            .sink { active in
-                if active {
-                    KeyboardShortcuts.enable(.copyHoveredHistory)
-                } else {
-                    KeyboardShortcuts.disable(.copyHoveredHistory)
-                }
-            }
+        // The hover-"C" shortcut copies this when the pointer isn't over a
+        // history row (see MessageDisplayModel.copyHovered).
+        model.currentText = message.text
 
         // Default to the main screen; a future setting (#7) supplies a different
         // closure. One measurement drives both panel placement and content layout.
@@ -213,6 +202,22 @@ final class NotchPresenter {
                         // must not tear it down mid-typing.
                         self.scheduleHide(of: notch, after: self.afterReadDelay)
                     }
+                }
+            }
+
+        // Arm the bare-"C" copy hotkey whenever the notch is hovered and no
+        // reply field is open. "C" then copies the hovered history row, or the
+        // current (newest) message when the pointer isn't over a row (see
+        // MessageDisplayModel.copyHovered). Gated this way it never eats a "C"
+        // typed away from the notch, and while replying "C" types into the field.
+        hoverCopyObservation = Publishers.CombineLatest(notch.$isHovering, model.$replying)
+            .map { hovering, replying in hovering && !replying }
+            .removeDuplicates()
+            .sink { active in
+                if active {
+                    KeyboardShortcuts.enable(.copyHoveredHistory)
+                } else {
+                    KeyboardShortcuts.disable(.copyHoveredHistory)
                 }
             }
 

--- a/apps/macos/Sources/MunkelApp/Shortcuts.swift
+++ b/apps/macos/Sources/MunkelApp/Shortcuts.swift
@@ -9,4 +9,13 @@ extension KeyboardShortcuts.Name {
         "togglePalette",
         initial: .init(.m, modifiers: [.control, .command])
     )
+
+    /// Copy the hovered history row. A bare "C", no modifiers — only safe
+    /// because NotchPresenter keeps it disabled and enables it ONLY while a
+    /// history row is hovered and no reply is open, so it never swallows a "C"
+    /// typed elsewhere. Not user-rebindable: it's a contextual hover affordance.
+    static let copyHoveredHistory = Self(
+        "copyHoveredHistory",
+        initial: .init(.c)
+    )
 }

--- a/apps/macos/Sources/MunkelApp/Shortcuts.swift
+++ b/apps/macos/Sources/MunkelApp/Shortcuts.swift
@@ -10,10 +10,11 @@ extension KeyboardShortcuts.Name {
         initial: .init(.m, modifiers: [.control, .command])
     )
 
-    /// Copy the hovered history row. A bare "C", no modifiers — only safe
-    /// because NotchPresenter keeps it disabled and enables it ONLY while a
-    /// history row is hovered and no reply is open, so it never swallows a "C"
-    /// typed elsewhere. Not user-rebindable: it's a contextual hover affordance.
+    /// Copy the message under the pointer (a hovered history row, or the
+    /// current message). A bare "C", no modifiers — only safe because
+    /// NotchPresenter keeps it disabled and enables it ONLY while the notch is
+    /// hovered and no reply is open, so it never swallows a "C" typed elsewhere.
+    /// Not user-rebindable: it's a contextual hover affordance.
     static let copyHoveredHistory = Self(
         "copyHoveredHistory",
         initial: .init(.c)


### PR DESCRIPTION
## Summary

The notch's recent-message **history** was read-only — only the *current* message had a copy button. This adds a copy affordance to every history row.

- **Hover-to-copy button** — a copy glyph fades in on hover over any history row (collapsed *and* expanded). Clicking it copies that row's text and flashes a checkmark on that row alone (`copiedHistoryID`).
- **Click routing** — the glyph's click goes through `NotchPresenter`'s existing AppKit event monitor via a per-row hit target that's registered only while hovered. This copies the right row without a SwiftUI `Button` stealing the click, and without toggling the history expand/collapse. A non-hovered row's trailing area still toggles as before.
- **Bare "C" shortcut** — pressing `C` while hovering a row copies it. Implemented as a global hotkey (`KeyboardShortcuts`) so it works regardless of which app has focus, **without** stealing keyboard focus from the user's current app.

### Safety of the "C" hotkey

A modifier-less global `C` would otherwise swallow every `C` typed anywhere. Mitigations:
- Disabled by default; enabled **only** while a history row is hovered and no reply field is open.
- Hard force-off (`turnOffHoverCopy`) on every hide — SwiftUI's `.onHover(false)` doesn't reliably fire when the panel tears down.
- Handler attached then immediately disabled at init, so the end state is always dormant.

### Layout

Rows stay compact: inter-row spacing is `0`, so the glyph-tall hover zones meet edge to edge — the glyph appears anywhere in the history block, no need to land exactly on a text line.

## Test plan

- [ ] Hover a history row (collapsed + expanded) → copy glyph appears; click copies that row; per-row checkmark.
- [ ] Click a row away from the glyph → still toggles expand/collapse.
- [ ] Hover a row, press `C` → copies that row.
- [ ] Type `C`/`c` with the pointer **not** over the notch → types normally (hotkey dormant).
- [ ] Move pointer away after hovering, type `C` → types normally (no stale capture).
- [ ] `C` inside the reply field types normally (hotkey disabled while replying).
- [ ] No notch content leaks into a screen share (capture-exclusion invariant intact).

## Notes

Reviewed via an adversarial multi-agent pass over capture-exclusion, click-monitor races, per-row state/memory, and layout; the one confirmed finding (oversized glyph inflating collapsed rows) was addressed. `swift build` + `swift test` (39 tests) green. Verified live against the dev build with the whisper simulator.