### PR TITLE
feat: image sharing with inline AVIF preview and lazy R2 full-res

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,13 +157,32 @@ UserDefaults), falling back to a circle broadcast. Override via
 `RELAY_URL` / `CIRCLE` / `SENDER` / `INTERVAL` / `TO`. Under the hood it loops
 `apps/server/scripts/dev-send.ts`, the protocol reference sender.
 
-Deploys (need a `wrangler login` with access to the `limehq` account; CI
-deploys the landing automatically on pushes to `main` that touch it):
+Deploys run automatically: CI ships the relay (`deploy-server.yml`) and the
+landing (`deploy-landing.yml`) on pushes to `main` that touch their
+`apps/<name>/**` paths, authenticating with the `CLOUDFLARE_API_TOKEN` /
+`CLOUDFLARE_ACCOUNT_ID` GitHub secrets (the `limehq` account). The R2 binding,
+the cron trigger, and the `relay.munkel.app` custom domain all apply from
+`wrangler.toml` on deploy — no manual step. To deploy by hand instead (needs a
+`wrangler login` with access to `limehq`):
 
 ```sh
 bunx turbo deploy --filter=@munkel/server    # relay.munkel.app
 bunx turbo deploy --filter=@munkel/landing   # munkel.app
 ```
+
+**One-time R2 setup (relay only).** The relay binds an R2 bucket for image
+blobs (`munkel-blobs`, see `apps/server/wrangler.toml`). `wrangler deploy` does
+*not* create it — create it once before the first deploy that includes the
+binding, or the deploy fails with a missing-bucket error:
+
+```sh
+cd apps/server && bunx wrangler r2 bucket create munkel-blobs
+```
+
+The deploy token (`CLOUDFLARE_API_TOKEN`) must also carry **Workers R2 Storage:
+Edit**, on top of the Workers Scripts / Durable Objects scopes the text relay
+already needed — without it the deploy is rejected. Blobs are opaque ciphertext
+with a ~66 s logical TTL; the per-minute cron sweeps expired ones (`src/blob.ts`).
 
 ## Architecture decisions
 

--- a/apps/cli/src/munkel.ts
+++ b/apps/cli/src/munkel.ts
@@ -4,7 +4,7 @@
 // socket; the app owns the relay connections and the crypto.
 
 import { homedir } from "node:os"
-import { basename, join } from "node:path"
+import { basename, join, resolve as resolvePath } from "node:path"
 
 // Mirrors MunkelKit/ControlProtocol.swift: newline-delimited JSON,
 // one request/response per connection.
@@ -13,6 +13,9 @@ interface ControlRequest {
   group?: string
   to?: string
   text?: string
+  // Absolute paths to image files (an album); the app reads, seals and uploads
+  // them, so the bytes never cross this socket.
+  imagePaths?: string[]
 }
 
 interface ControlGroupInfo {
@@ -71,15 +74,17 @@ const version = typeof MUNKEL_BUILD_VERSION === "string" ? MUNKEL_BUILD_VERSION 
 const usage = `munkel — munkel into your friends' notches
 
   munkel dm <recipient> <message…>                Notify one person (resolved across circles)
+  munkel image <recipient> <path…> [--caption <t>] Send image(s) (optional shared caption)
   munkel <circle> <recipient|all> <message…>      Send within a circle, or broadcast with 'all'
   munkel circles [--json]                         Show your circles & members
 
 Examples:
   munkel dm sebil "deploy is green"
+  munkel image sebil ~/Desktop/a.png ~/Desktop/b.png --caption "two shots"
   munkel blue-table-42 Alex hey
   munkel blue-table-42 all "coffee?"
 
-Exit codes: 0 ok · 64 usage · 75 app didn't reply · 1 other failure
+Exit codes: 0 ok · 64 usage · 66 no such file · 75 app didn't reply · 1 other failure
 MUNKEL_SOCKET overrides the control socket; MUNKEL_DEV=1 targets the dev app.`
 
 const args = process.argv.slice(2)
@@ -109,6 +114,38 @@ if (args[0] === "circles" || args[0] === "groups") {
     fail("usage: munkel dm <recipient> <message…>", 64)
   }
   request = { action: "send", to: args[1], text: joinMessage(args.slice(2)) }
+} else if (args[0] === "image") {
+  // `munkel image <recipient> <path…> [--caption <text>]` — recipient-only
+  // image send (dm-style). One or more paths (quote any with spaces) form an
+  // album; an optional `--caption` adds a shared message. Paths are resolved to
+  // absolute because the app reads them from a different working directory;
+  // only the paths + caption travel the socket, never the bytes.
+  const usageImage = "usage: munkel image <recipient> <path…> [--caption <text>]"
+  if (args.length < 3) {
+    fail(usageImage, 64)
+  }
+  const rest = args.slice(2)
+  let caption: string | undefined
+  const rawPaths: string[] = []
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === "--caption" || rest[i] === "-c") {
+      caption = rest.slice(i + 1).join(" ")
+      break
+    }
+    rawPaths.push(rest[i])
+  }
+  if (rawPaths.length === 0) {
+    fail(usageImage, 64)
+  }
+  const imagePaths: string[] = []
+  for (const raw of rawPaths) {
+    const abs = resolvePath(raw)
+    if (!(await Bun.file(abs).exists())) {
+      fail(`no such image file: ${abs}`, 66) // EX_NOINPUT
+    }
+    imagePaths.push(abs)
+  }
+  request = { action: "send", to: args[1], imagePaths, ...(caption ? { text: caption } : {}) }
 } else {
   // `munkel <circle> <recipient|all> <message…>` — circle-scoped send;
   // required for broadcasts and to disambiguate a name across circles.

--- a/apps/cli/test/munkel.test.ts
+++ b/apps/cli/test/munkel.test.ts
@@ -197,6 +197,54 @@ test("dm with no message is a usage error", async () => {
   expect(result.stderr).toContain("usage: munkel dm")
 })
 
+test("image sends a recipient-only request carrying the resolved file path", async () => {
+  const app = fakeApp(() => ({ ok: true }))
+  const imageFile = join(tmpdir(), `munkel-img-${process.pid}-${Math.random().toString(36).slice(2)}.png`)
+  await Bun.write(imageFile, new Uint8Array([0x89, 0x50, 0x4e, 0x47])) // bytes irrelevant to the CLI
+  const result = await runMunkel(["image", "sebil", imageFile], app.socketPath)
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stdout).toContain("munkeled ✓")
+  expect(app.requests).toEqual([{ action: "send", to: "sebil", imagePaths: [imageFile] }])
+})
+
+test("image sends multiple paths as an album", async () => {
+  const app = fakeApp(() => ({ ok: true }))
+  const a = join(tmpdir(), `munkel-img-${process.pid}-${Math.random().toString(36).slice(2)}.png`)
+  const b = join(tmpdir(), `munkel-img-${process.pid}-${Math.random().toString(36).slice(2)}.png`)
+  await Bun.write(a, new Uint8Array([1]))
+  await Bun.write(b, new Uint8Array([2]))
+  const result = await runMunkel(["image", "sebil", a, b], app.socketPath)
+
+  expect(result.exitCode).toBe(0)
+  expect(app.requests).toEqual([{ action: "send", to: "sebil", imagePaths: [a, b] }])
+})
+
+test("image with --caption attaches it as text", async () => {
+  const app = fakeApp(() => ({ ok: true }))
+  const imageFile = join(tmpdir(), `munkel-img-${process.pid}-${Math.random().toString(36).slice(2)}.png`)
+  await Bun.write(imageFile, new Uint8Array([0x89, 0x50, 0x4e, 0x47]))
+  const result = await runMunkel(["image", "sebil", imageFile, "--caption", "ship", "it"], app.socketPath)
+
+  expect(result.exitCode).toBe(0)
+  expect(app.requests).toEqual([{ action: "send", to: "sebil", imagePaths: [imageFile], text: "ship it" }])
+})
+
+test("image with no path is a usage error", async () => {
+  const result = await runMunkel(["image", "sebil"])
+
+  expect(result.exitCode).toBe(64)
+  expect(result.stderr).toContain("usage: munkel image")
+})
+
+test("image with a missing file exits 66 before touching the socket", async () => {
+  const missing = join(tmpdir(), `munkel-missing-${process.pid}-${Math.random().toString(36).slice(2)}.png`)
+  const result = await runMunkel(["image", "sebil", missing])
+
+  expect(result.exitCode).toBe(66)
+  expect(result.stderr).toContain("no such image file")
+})
+
 test("an error's candidate circles are printed to stderr", async () => {
   // An ambiguous `dm` recipient comes back with the candidate circles so the
   // single failed call is self-correcting — no follow-up `circles` needed.

--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -135,6 +135,57 @@ final class AppModel: ObservableObject {
         #endif
     }
 
+    /// Send one or more images (an album), optionally with a caption. The
+    /// session seals each, uploads to R2 and relays one pointer; see
+    /// GroupSession.sendImages.
+    func send(images datas: [Data], caption: String = "", group code: String, to memberId: String? = nil) {
+        guard let session = sessions[code], !datas.isEmpty else { return }
+        Task { await session.sendImages(datas, caption: caption, to: memberId) }
+        #if DEBUG
+        // Dev echo (same rationale as the text path): a broadcast only reaches
+        // *other* members, so show our own album locally too. Decode off-main;
+        // the per-image loader returns the local full bytes — no R2 round trip.
+        if memberId == nil, Self.devEchoBroadcasts {
+            Task { [weak self] in
+                let built = await Task.detached { () -> (images: [IncomingImage], fulls: [String: Data])? in
+                    let datas = Array(datas.prefix(AppPayload.maxImagesPerMessage))
+                    let perThumb = AppPayload.perThumbBudget(imageCount: datas.count)
+                    var images: [IncomingImage] = []
+                    var fulls: [String: Data] = [:]
+                    for (index, data) in datas.enumerated() {
+                        guard let full = ImageCodec.prepareFull(from: data) else { continue }
+                        // Mirror sendImages: reuse the full AVIF as the preview
+                        // when it fits, else a small AVIF — so the local echo
+                        // matches what peers actually receive.
+                        let thumb = full.data.count <= perThumb
+                            ? full.data
+                            : ImageCodec.makeThumbnail(from: data, maxBytes: perThumb)
+                        guard let thumb else { continue }
+                        let id = "echo-\(index)"
+                        images.append(IncomingImage(id: id, thumb: thumb, width: full.width, height: full.height))
+                        fulls[id] = full.data
+                    }
+                    return images.isEmpty ? nil : (images, fulls)
+                }.value
+                guard let self, let built else { return }
+                self.notch.show(
+                    sender: self.displayName,
+                    avatarData: Identity.avatarData,
+                    text: caption,
+                    isDirect: false,
+                    group: code,
+                    groupColor: .groupColor(index: self.groupCodes.firstIndex(of: code) ?? 0),
+                    inMultipleGroups: self.groupCodes.count > 1,
+                    images: built.images,
+                    loadFull: { id in built.fulls[id] }
+                ) { [weak self] reply, _ in
+                    self?.send(text: reply, group: code, to: nil)
+                }
+            }
+        }
+        #endif
+    }
+
     /// Opens the quick-send command palette (also bound to the global hotkey).
     func openCommandPalette() {
         palette?.show()
@@ -293,10 +344,33 @@ final class AppModel: ObservableObject {
             return ControlResponse(ok: true, groups: infos)
 
         case "send":
-            guard let text = request.text, !text.isEmpty else {
+            // An image send carries file paths; the app reads them here so the
+            // bytes never crossed the control socket. An album needs no text.
+            var imageDatas: [Data] = []
+            for path in request.imagePaths ?? [] {
+                guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)), !data.isEmpty else {
+                    return ControlResponse(ok: false, error: "Couldn't read image file: \(path)")
+                }
+                imageDatas.append(data)
+            }
+            let text = request.text ?? ""
+            guard !imageDatas.isEmpty || !text.isEmpty else {
                 return ControlResponse(ok: false, error: "Empty message")
             }
             let isBroadcast = (request.to.map { ["all", "*"].contains($0.lowercased()) }) ?? false
+
+            // Delivers the resolved payload to one target: an image album (with
+            // the text as its shared caption) or a plain chat message.
+            func deliver(_ session: GroupSession, to recipientId: String?) async -> Bool {
+                if !imageDatas.isEmpty {
+                    return await session.sendImages(imageDatas, caption: text, to: recipientId)
+                }
+                return await session.sendChat(text, to: recipientId)
+            }
+            // Image sends can fail at the codec, not just the relay — say so.
+            let sendFailureError = imageDatas.isEmpty
+                ? "Send failed — no connection to the relay?"
+                : "Couldn't send the image — encoding failed or no connection to the relay"
 
             // Circle-scoped send: explicit circle code. Required for a
             // broadcast and used to disambiguate a name across circles.
@@ -313,15 +387,15 @@ final class AppModel: ObservableObject {
                     }
                     recipientId = matches[0].id
                 }
-                let sent = await session.sendChat(text, to: recipientId)
+                let sent = await deliver(session, to: recipientId)
                 return sent
                     ? ControlResponse(ok: true)
-                    : ControlResponse(ok: false, error: "Send failed — no connection to the relay?")
+                    : ControlResponse(ok: false, error: sendFailureError)
             }
 
-            // Recipient-only send (`munkel dm <name> …`): no circle given, so
-            // resolve the name across every circle. This lets an agent notify
-            // someone in a single call instead of listing circles first.
+            // Recipient-only send (`munkel dm <name> …` / `munkel image <name> …`):
+            // no circle given, so resolve the name across every circle. This
+            // lets an agent notify someone in a single call.
             guard let to = request.to, !isBroadcast else {
                 return ControlResponse(ok: false, error: "Broadcast needs a circle — say `munkel <circle> all …`")
             }
@@ -354,7 +428,7 @@ final class AppModel: ObservableObject {
                     groups: payload
                 )
             }
-            let sent = await hits[0].session.sendChat(text, to: hits[0].member.id)
+            let sent = await deliver(hits[0].session, to: hits[0].member.id)
             return sent
                 ? ControlResponse(ok: true)
                 : ControlResponse(ok: false, error: "Send failed — no connection to the relay?")
@@ -401,6 +475,25 @@ final class AppModel: ObservableObject {
             ) { [weak self] reply, privately in
                 // Default mirrors how the message arrived; the toggle
                 // in the reply field can override per message.
+                self?.send(text: reply, group: code, to: privately ? sender.id : nil)
+            }
+        }
+        session.onImages = { [weak self] sender, items, caption, isDirect, loadFull in
+            guard let self else { return }
+            let images = items.map {
+                IncomingImage(id: $0.r2Key, thumb: $0.thumb, width: $0.width, height: $0.height)
+            }
+            self.notch.show(
+                sender: sender.label,
+                avatarData: sender.avatar,
+                text: caption,
+                isDirect: isDirect,
+                group: code,
+                groupColor: .groupColor(index: self.groupCodes.firstIndex(of: code) ?? 0),
+                inMultipleGroups: self.groupCodes.count > 1,
+                images: images,
+                loadFull: loadFull
+            ) { [weak self] reply, privately in
                 self?.send(text: reply, group: code, to: privately ? sender.id : nil)
             }
         }

--- a/apps/macos/Sources/MunkelApp/ClipboardImage.swift
+++ b/apps/macos/Sources/MunkelApp/ClipboardImage.swift
@@ -1,0 +1,19 @@
+import AppKit
+
+/// Reads an image off the general pasteboard for ⌘V-to-attach. Prefers raw
+/// PNG/TIFF data, falling back to any NSImage on the pasteboard. Shared by the
+/// command palette and the menu-bar composer — both intercept ⌘V with an
+/// NSEvent monitor because an accessory app's text fields don't route `paste:`
+/// to SwiftUI's onPasteCommand.
+enum ClipboardImage {
+    static func read() -> Data? {
+        let pasteboard = NSPasteboard.general
+        if let data = pasteboard.data(forType: .png) ?? pasteboard.data(forType: .tiff) {
+            return data
+        }
+        if let image = NSImage(pasteboard: pasteboard), let tiff = image.tiffRepresentation {
+            return tiff
+        }
+        return nil
+    }
+}

--- a/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
@@ -1,6 +1,7 @@
 import AppKit
 import KeyboardShortcuts
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Owns the command-palette window and its global hotkey. Long-lived,
 /// created by AppModel (mirrors NotchPresenter's ownership). The panel is
@@ -14,6 +15,9 @@ final class CommandPalettePresenter {
     private let state: CommandPaletteState
     private var panel: CommandPalettePanel?
     private var keyMonitor: Any?
+    /// Set while the file-open dialog is up: it steals key focus from the
+    /// palette, whose resignKey would otherwise dismiss it (and reset state).
+    private var suppressResignHide = false
 
     /// Fixed width; height follows the SwiftUI content (preferredContentSize).
     private static let panelWidth: CGFloat = 380
@@ -35,12 +39,16 @@ final class CommandPalettePresenter {
         state.reset()
 
         let panel = CommandPalettePanel(size: NSSize(width: Self.panelWidth, height: 200))
-        panel.onResignKey = { [weak self] in self?.hide() }
+        panel.onResignKey = { [weak self] in
+            guard let self, !self.suppressResignHide else { return }
+            self.hide()
+        }
 
         let root = CommandPaletteView(
             model: model,
             state: state,
-            onClose: { [weak self] in self?.hide() }
+            onClose: { [weak self] in self?.hide() },
+            onPickFile: { [weak self] in self?.pickImageFile() }
         )
         // Hosting controller with preferredContentSize so the panel resizes
         // to the (fixed-width, content-height) SwiftUI layout — compact for
@@ -65,6 +73,32 @@ final class CommandPalettePresenter {
         state.reset()
     }
 
+    /// Opens a file picker to attach an image from disk (the paperclip, à la
+    /// Slack). Runs modally while suppressing the palette's resign-key dismiss,
+    /// then restores key focus so the palette stays put with the attachment.
+    private func pickImageFile() {
+        guard let panel else { return }
+        suppressResignHide = true
+        defer {
+            suppressResignHide = false
+            // The open dialog took key focus; hand it back so the palette
+            // stays live and the caption field keeps typing.
+            panel.makeKeyAndOrderFront(nil)
+        }
+        let open = NSOpenPanel()
+        open.allowedContentTypes = [.image]
+        open.allowsMultipleSelection = true
+        open.canChooseDirectories = false
+        open.message = "Choose image(s) to send"
+        NSApp.activate(ignoringOtherApps: true)
+        guard open.runModal() == .OK else { return }
+        for url in open.urls {
+            if let data = try? Data(contentsOf: url) {
+                state.attach(data)
+            }
+        }
+    }
+
     /// Centered horizontally on the screen under the pointer, upper third —
     /// the Spotlight position.
     private func position(_ panel: CommandPalettePanel) {
@@ -87,6 +121,18 @@ final class CommandPalettePresenter {
             guard let self else { return event }
             var consumed = false
             MainActor.assumeIsolated {
+                // ⌘V with an image on the clipboard attaches it. The app has no
+                // Edit menu wiring `paste:`, so SwiftUI's onPasteCommand never
+                // fires — intercept the key here instead. Plain text paste (no
+                // image on the clipboard) falls through to the field editor.
+                if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                   event.charactersIgnoringModifiers?.lowercased() == "v" {
+                    if self.state.attachClipboardImage() {
+                        consumed = true
+                    }
+                    return
+                }
+
                 let dir: CommandPaletteState.Direction?
                 switch event.keyCode {
                 case 123: dir = .left

--- a/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import MunkelKit
 
 /// A target the palette can send to: one member, or a whole circle.
 struct Recipient: Identifiable, Equatable {
@@ -24,11 +25,32 @@ struct Recipient: Identifiable, Equatable {
 final class CommandPaletteState: ObservableObject {
     @Published var selectedIndex = 0
     @Published var message = ""
+    /// Images staged for sending (an album): pasted with ⌘V or uploaded from
+    /// files via the paperclip. When non-empty, Return sends the pictures (any
+    /// typed text rides along as the shared caption).
+    @Published var attachedImages: [Data] = []
 
     private weak var app: AppModel?
 
     init(app: AppModel) {
         self.app = app
+    }
+
+    var canAttachMore: Bool { attachedImages.count < AppPayload.maxImagesPerMessage }
+
+    /// Append a staged image (from the file picker), up to the per-message cap.
+    func attach(_ data: Data) {
+        if canAttachMore { attachedImages.append(data) }
+    }
+
+    /// Append the clipboard's image, if any. Returns whether one was added.
+    /// Called from the palette's ⌘V key monitor (the app has no Edit menu
+    /// wiring `paste:`, so SwiftUI's onPasteCommand never fires).
+    @discardableResult
+    func attachClipboardImage() -> Bool {
+        guard canAttachMore, let data = ClipboardImage.read() else { return false }
+        attachedImages.append(data)
+        return true
     }
 
     /// Every send target across all joined circles, in circle order: a
@@ -65,6 +87,7 @@ final class CommandPaletteState: ObservableObject {
     func reset() {
         selectedIndex = 0
         message = ""
+        attachedImages = []
     }
 
     // MARK: - D-pad navigation

--- a/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Compact, app-like quick-send palette: circle sections with globe/avatar
@@ -7,6 +8,9 @@ struct CommandPaletteView: View {
     @ObservedObject var model: AppModel
     @ObservedObject var state: CommandPaletteState
     let onClose: () -> Void
+    /// Opens a file picker to attach an image from disk (owned by the
+    /// presenter, which suppresses the palette's resign-key dismiss).
+    let onPickFile: () -> Void
 
     @FocusState private var focused: Bool
     @State private var listHeight: CGFloat = 0
@@ -151,30 +155,84 @@ struct CommandPaletteView: View {
     // MARK: - Composer
 
     private var composer: some View {
-        HStack(spacing: 10) {
-            TextField(placeholder, text: $state.message)
-                .textFieldStyle(.plain)
-                .font(.system(size: 15))
-                .focused($focused)
-                .onSubmit(send)
-                .onExitCommand(perform: onClose)
-                .onChange(of: state.message) { _, new in
-                    if new.count > MessageLimits.maxCharacters {
-                        state.message = String(new.prefix(MessageLimits.maxCharacters))
+        VStack(spacing: 0) {
+            if !state.attachedImages.isEmpty {
+                attachmentStrip
+            }
+            HStack(spacing: 10) {
+                attachButton
+
+                TextField(placeholder, text: $state.message)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 15))
+                    .focused($focused)
+                    .onSubmit(send)
+                    .onExitCommand(perform: onClose)
+                    .onChange(of: state.message) { _, new in
+                        if new.count > MessageLimits.maxCharacters {
+                            state.message = String(new.prefix(MessageLimits.maxCharacters))
+                        }
+                    }
+
+                Button(action: send) {
+                    Image(systemName: "paperplane.fill")
+                        .font(.system(size: 15))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.primary)
+                .focusable(false)
+                .disabled(!canSend)
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 48)
+        }
+    }
+
+    /// Staged images as a row of thumbnails; click one to remove it.
+    private var attachmentStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(Array(state.attachedImages.enumerated()), id: \.offset) { index, data in
+                    if let nsImage = NSImage(data: data) {
+                        Button {
+                            withAnimation(.spring(duration: 0.2)) { _ = state.attachedImages.remove(at: index) }
+                            focused = true
+                        } label: {
+                            Image(nsImage: nsImage)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 38, height: 38)
+                                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                                .overlay(alignment: .topTrailing) {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(.white, .black.opacity(0.5))
+                                        .padding(2)
+                                }
+                        }
+                        .buttonStyle(.plain)
+                        .help("Remove")
                     }
                 }
-
-            Button(action: send) {
-                Image(systemName: "paperplane.fill")
-                    .font(.system(size: 15))
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(.primary)
-            .focusable(false)
-            .disabled(isEmpty || state.selectedRecipient == nil)
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
         }
-        .padding(.horizontal, 12)
-        .frame(height: 48)
+    }
+
+    /// Paperclip: upload image file(s) from disk (Slack-style). Pasting from
+    /// the clipboard is ⌘V (handled by the presenter's key monitor).
+    private var attachButton: some View {
+        Button {
+            onPickFile()
+        } label: {
+            Image(systemName: "paperclip")
+                .font(.system(size: 14))
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .disabled(!state.canAttachMore)
     }
 
     // MARK: - Derived
@@ -183,7 +241,16 @@ struct CommandPaletteView: View {
         state.message.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
+    /// Sendable when a target is picked and there's either a staged image or
+    /// some text.
+    private var canSend: Bool {
+        guard state.selectedRecipient != nil else { return false }
+        return !state.attachedImages.isEmpty || !isEmpty
+    }
+
     private var placeholder: String {
+        // Same prompt whether or not images are attached — typed text becomes
+        // the caption when there are.
         guard let r = state.selectedRecipient else { return "Message…" }
         return r.isEveryone ? "Message everyone in \(r.circle)…" : "Message \(r.label)…"
     }
@@ -212,8 +279,16 @@ struct CommandPaletteView: View {
     }
 
     private func send() {
+        guard let r = state.selectedRecipient else { return }
+        if !state.attachedImages.isEmpty {
+            // Any typed text rides along as the album's shared caption.
+            let caption = state.message.trimmingCharacters(in: .whitespaces)
+            model.send(images: state.attachedImages, caption: caption, group: r.circle, to: r.memberId)
+            onClose()
+            return
+        }
         let text = state.message.trimmingCharacters(in: .whitespaces)
-        guard !text.isEmpty, let r = state.selectedRecipient else { return }
+        guard !text.isEmpty else { return }
         model.send(text: text, group: r.circle, to: r.memberId)
         onClose()
     }

--- a/apps/macos/Sources/MunkelApp/GroupSession.swift
+++ b/apps/macos/Sources/MunkelApp/GroupSession.swift
@@ -19,12 +19,22 @@ final class GroupSession {
     /// (the name is kept). Senders stay below this via AvatarCodec.
     private static let maxIncomingAvatarBytes = 32_768
 
+    /// Upper bound for a peer-sent inline thumbnail; larger drops the image.
+    private static let maxIncomingThumbBytes = 65_536
+    /// Upper bound for a fetched full-image blob (sealed ciphertext) — matches
+    /// the server's per-blob cap (apps/server/src/blob.ts) plus envelope.
+    private static let maxIncomingImageBytes = 3 * 1024 * 1024 + 4_096
+
     let code: String
     private(set) var members: [Member] = []
     private(set) var isConnected = false
 
     private let key: GroupKey
     private let client: RelayClient
+    private let blobClient = BlobClient()
+    /// HTTPS base for image blobs, derived from the relay URL; nil if the
+    /// relay URL has an unexpected scheme (image sending then no-ops).
+    private let blobBaseURL: URL?
     private var eventTask: Task<Void, Never>?
 
     /// Called on any presence/connection change so the UI can refresh.
@@ -32,11 +42,17 @@ final class GroupSession {
     /// Called when a chat message arrives; `isDirect` distinguishes a
     /// private message (relay `to` set) from a group broadcast.
     var onChat: ((_ sender: Member, _ text: String, _ isDirect: Bool) -> Void)?
+    /// Called when an image album arrives (1–10 images). `caption` is the
+    /// optional shared message (empty if none). `loadFull` fetches + decrypts
+    /// one image's full resolution from R2 on demand, keyed by its r2Key
+    /// (nil on failure/expiry).
+    var onImages: ((_ sender: Member, _ items: [ImageItem], _ caption: String, _ isDirect: Bool, _ loadFull: @escaping @Sendable (String) async -> Data?) -> Void)?
 
     init(code: String, relayURL: URL) {
         self.code = code
         self.key = GroupKey(code: code)
         self.client = RelayClient(relayURL: relayURL, groupId: key.groupId, memberId: Identity.memberId)
+        self.blobBaseURL = BlobClient.baseURL(fromRelay: relayURL)
     }
 
     func start() {
@@ -68,6 +84,83 @@ final class GroupSession {
             avatar: Identity.avatarData
         )
         return await send(payload, to: memberId)
+    }
+
+    /// Transcodes each image to AVIF, ALWAYS uploads the sealed ciphertext to R2
+    /// (in parallel), then relays ONE pointer listing all of them with their
+    /// inline AVIF thumbnails. Encoding + crypto run off the main actor. The
+    /// caption is shared by the album; NOT subject to the text length clamp.
+    @discardableResult
+    func sendImages(_ imageDatas: [Data], caption: String = "", to memberId: String? = nil) async -> Bool {
+        guard let blobBaseURL else {
+            NSLog("munkel: no blob endpoint for \(code)")
+            return false
+        }
+        let datas = Array(imageDatas.prefix(AppPayload.maxImagesPerMessage))
+        guard !datas.isEmpty else { return false }
+
+        let messageKey = key.messageKey
+        let perThumbBytes = AppPayload.perThumbBudget(imageCount: datas.count)
+        // prepareFull/makeThumbnail/sealRaw are CPU-bound on up to ~2 MiB each —
+        // keep them off the main actor. Undecodable images are dropped.
+        let prepared = await Task.detached {
+            datas.compactMap { data -> (ciphertext: Data, mime: String, width: Int, height: Int, thumb: Data)? in
+                guard let full = ImageCodec.prepareFull(from: data),
+                      let ciphertext = try? MessageCrypto.sealRaw(full.data, using: messageKey)
+                else {
+                    return nil
+                }
+                // Reuse the full AVIF as the inline preview when it already fits
+                // the per-image budget; otherwise a small AVIF (same format).
+                let thumb = full.data.count <= perThumbBytes
+                    ? full.data
+                    : ImageCodec.makeThumbnail(from: data, maxBytes: perThumbBytes)
+                guard let thumb else { return nil }
+                return (ciphertext, full.mime, full.width, full.height, thumb)
+            }
+        }.value
+
+        guard !prepared.isEmpty else {
+            NSLog("munkel: could not prepare any image in \(code) (AVIF encoding available: \(ImageCodec.isAVIFEncodingAvailable))")
+            return false
+        }
+
+        let base = blobBaseURL
+        let groupId = key.groupId
+        let client = blobClient
+        do {
+            // Upload all blobs concurrently; every PUT must finish before the
+            // pointer goes out, or a recipient would GET a 404. Order preserved.
+            let items = try await withThrowingTaskGroup(of: (Int, ImageItem).self) { group in
+                for (index, p) in prepared.enumerated() {
+                    let r2Key = Self.makeBlobKey()
+                    group.addTask {
+                        try await client.upload(baseURL: base, group: groupId, key: r2Key, ciphertext: p.ciphertext)
+                        return (index, ImageItem(
+                            r2Key: r2Key, mime: p.mime, width: p.width, height: p.height,
+                            byteLen: p.ciphertext.count, thumb: p.thumb
+                        ))
+                    }
+                }
+                var collected: [(Int, ImageItem)] = []
+                for try await pair in group { collected.append(pair) }
+                return collected.sorted { $0.0 < $1.0 }.map(\.1)
+            }
+            guard !items.isEmpty else {
+                NSLog("munkel: no image uploaded in \(code)")
+                return false
+            }
+            let payload = AppPayload.image(items: items, caption: MessageLimits.clamp(caption), sentAt: Date())
+            return await send(payload, to: memberId)
+        } catch {
+            NSLog("munkel: image send failed in \(code): \(error)")
+            return false
+        }
+    }
+
+    /// Random, URL-safe object id (matches the server's BLOB_KEY_REGEX).
+    private static func makeBlobKey() -> String {
+        UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
     }
 
     private func send(_ payload: AppPayload, to memberId: String?) async -> Bool {
@@ -164,6 +257,36 @@ final class GroupSession {
             let sender = members.first { $0.id == memberId }
                 ?? Member(id: memberId)
             onChat?(sender, MessageLimits.clamp(text), to != nil)
+
+        case let .image(items, caption, _):
+            // Drop items with an implausibly large inline thumb; the relay
+            // frame cap already bounds the total, this guards each one.
+            let safeItems = items.filter { $0.thumb.count <= Self.maxIncomingThumbBytes }
+            guard !safeItems.isEmpty else {
+                NSLog("munkel: dropping image album with no valid items in \(code)")
+                return
+            }
+            let sender = members.first { $0.id == memberId } ?? Member(id: memberId)
+            // Capture only Sendable values for the off-actor per-image fetch.
+            let base = blobBaseURL
+            let groupId = key.groupId
+            let messageKey = key.messageKey
+            let client = blobClient
+            let maxBytes = Self.maxIncomingImageBytes
+            let loadFull: @Sendable (String) async -> Data? = { r2Key in
+                guard let base else { return nil }
+                return await Task.detached {
+                    do {
+                        let ciphertext = try await client.download(
+                            baseURL: base, group: groupId, key: r2Key, maxBytes: maxBytes
+                        )
+                        return try MessageCrypto.openRaw(ciphertext, using: messageKey)
+                    } catch {
+                        return nil
+                    }
+                }.value
+            }
+            onImages?(sender, safeItems, MessageLimits.clamp(caption), to != nil, loadFull)
         }
     }
 }

--- a/apps/macos/Sources/MunkelApp/IncomingMessage.swift
+++ b/apps/macos/Sources/MunkelApp/IncomingMessage.swift
@@ -13,6 +13,21 @@ struct IncomingMessage: Equatable {
     /// Whether the user is in more than one circle — below that, group
     /// labels are noise and partially hidden.
     let inMultipleGroups: Bool
+    /// Images of an album (empty for a plain text message). Each carries its
+    /// inline preview thumbnail; the full resolution is fetched lazily per
+    /// cell into `MessageDisplayModel.fullImages`.
+    var images: [IncomingImage] = []
+
+    var isImage: Bool { !images.isEmpty }
+}
+
+/// One image in a received album: its inline thumbnail plus the pixel size and
+/// the R2 key (`id`) used to fetch + cache its full resolution.
+struct IncomingImage: Equatable, Identifiable, Sendable {
+    let id: String
+    let thumb: Data
+    let width: Int
+    let height: Int
 }
 
 /// One entry of the short-lived notch history: messages stay visible in

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -1,4 +1,6 @@
+import AppKit
 import KeyboardShortcuts
+import MunkelKit
 import SwiftUI
 
 struct MenuView: View {
@@ -454,6 +456,12 @@ struct GroupSectionView: View {
     @State private var sentNoticeToken = 0
     /// Active member tooltip (custom, fast) — replaces the slow `.help()`.
     @State private var hoverTip: HoverTip?
+    /// Images staged for sending (pasted with ⌘V); Return sends them with the
+    /// typed text as the shared caption.
+    @State private var attachedImages: [Data] = []
+    /// Local ⌘V monitor, live only while this field is focused (the popover
+    /// has no Edit menu route to onPasteCommand for image data).
+    @State private var pasteMonitor: Any?
     @FocusState private var fieldFocused: Bool
 
     private let targetSize: CGFloat = 26
@@ -503,6 +511,45 @@ struct GroupSectionView: View {
                 recipient = nil
             }
         }
+        // ⌘V-to-attach is wired to the field's focus: the monitor lives only
+        // while this composer is the active one, so exactly one is ever armed.
+        .onChange(of: fieldFocused) { _, focused in updatePasteMonitor(focused) }
+        .onDisappear { teardownPasteMonitor() }
+    }
+
+    /// Installs (on focus) / removes (on blur) a local ⌘V monitor that stages
+    /// a clipboard image. Plain text paste falls through to the field editor.
+    private func updatePasteMonitor(_ focused: Bool) {
+        if focused, pasteMonitor == nil {
+            let binding = $attachedImages
+            pasteMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+                // Side effect inside the isolation; the NSEvent (non-Sendable)
+                // is returned outside it — MainActor.assumeIsolated requires a
+                // Sendable result.
+                var consume = false
+                MainActor.assumeIsolated {
+                    guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                          event.charactersIgnoringModifiers?.lowercased() == "v",
+                          binding.wrappedValue.count < AppPayload.maxImagesPerMessage,
+                          let data = ClipboardImage.read()
+                    else {
+                        return
+                    }
+                    binding.wrappedValue.append(data)
+                    consume = true
+                }
+                return consume ? nil : event
+            }
+        } else if !focused {
+            teardownPasteMonitor()
+        }
+    }
+
+    private func teardownPasteMonitor() {
+        if let pasteMonitor {
+            NSEvent.removeMonitor(pasteMonitor)
+        }
+        pasteMonitor = nil
     }
 
     // MARK: - Header
@@ -583,33 +630,69 @@ struct GroupSectionView: View {
     // MARK: - Message field + send
 
     private func messageRow(members: [GroupSession.Member]) -> some View {
-        HStack(spacing: 6) {
-            TextField(placeholder(members: members), text: $draft)
-                .frostedField()
-                .focused($fieldFocused)
-                .onSubmit(sendTapped)
-                .onChange(of: draft) { _, new in
-                    if new.count > MessageLimits.maxCharacters {
-                        draft = String(new.prefix(MessageLimits.maxCharacters))
+        VStack(alignment: .leading, spacing: 6) {
+            // Staged images (⌘V) — click a thumbnail to remove it.
+            if !attachedImages.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(Array(attachedImages.enumerated()), id: \.offset) { index, data in
+                            if let image = NSImage(data: data) {
+                                Button { attachedImages.remove(at: index) } label: {
+                                    Image(nsImage: image)
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(width: 34, height: 34)
+                                        .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+                                        .overlay(alignment: .topTrailing) {
+                                            Image(systemName: "xmark.circle.fill")
+                                                .font(.system(size: 11))
+                                                .foregroundStyle(.white, .black.opacity(0.5))
+                                                .padding(1)
+                                        }
+                                }
+                                .buttonStyle(.plain)
+                                .help("Remove")
+                            }
+                        }
                     }
+                    .padding(.vertical, 1)
                 }
-
-            Button(action: sendTapped) {
-                // Confirmation lives in the button itself — a brief checkmark
-                // instead of a chip that overlapped the field's placeholder.
-                // Neutral color, and a fixed-size frame so swapping the glyph
-                // never changes the button's width.
-                Image(systemName: justSent ? "checkmark" : "paperplane.fill")
-                    .foregroundStyle(.primary)
-                    .frame(width: 16, height: 16)
-                    .animation(.spring(duration: 0.25), value: justSent)
             }
-            .disabled(draft.trimmingCharacters(in: .whitespaces).isEmpty && !justSent)
-            .help(sendHelp(members: members))
+
+            HStack(spacing: 6) {
+                TextField(placeholder(members: members), text: $draft)
+                    .frostedField()
+                    .focused($fieldFocused)
+                    .onSubmit(sendTapped)
+                    .onChange(of: draft) { _, new in
+                        if new.count > MessageLimits.maxCharacters {
+                            draft = String(new.prefix(MessageLimits.maxCharacters))
+                        }
+                    }
+
+                Button(action: sendTapped) {
+                    // Confirmation lives in the button itself — a brief checkmark
+                    // instead of a chip that overlapped the field's placeholder.
+                    // Neutral color, and a fixed-size frame so swapping the glyph
+                    // never changes the button's width.
+                    Image(systemName: justSent ? "checkmark" : "paperplane.fill")
+                        .foregroundStyle(.primary)
+                        .frame(width: 16, height: 16)
+                        .animation(.spring(duration: 0.25), value: justSent)
+                }
+                .disabled(!canSend && !justSent)
+                .help(sendHelp(members: members))
+            }
         }
     }
 
+    private var canSend: Bool {
+        !attachedImages.isEmpty || !draft.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
     private func placeholder(members: [GroupSession.Member]) -> String {
+        // Same prompt whether or not images are attached — typed text becomes
+        // the caption when there are.
         if let id = recipient, let m = members.first(where: { $0.id == id }) {
             return "Message \(m.label)…"
         }
@@ -624,6 +707,14 @@ struct GroupSectionView: View {
     }
 
     private func sendTapped() {
+        if !attachedImages.isEmpty {
+            // Typed text rides along as the album's shared caption.
+            model.send(images: attachedImages, caption: draft.trimmingCharacters(in: .whitespaces), group: code, to: recipient)
+            draft = ""
+            attachedImages = []
+            flashSent()
+            return
+        }
         let text = draft.trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else { return }
         model.send(text: text, group: code, to: recipient)

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -8,6 +8,15 @@ import SwiftUI
 final class MessageDisplayModel: ObservableObject {
     @Published var fullyExpanded = false
     @Published var copied = false
+    /// Decrypted full-resolution bytes per album image (keyed by r2Key),
+    /// fetched from R2 on demand by the grid cells. The inline thumbnail
+    /// stands in until then.
+    @Published var fullImages: [String: Data] = [:]
+    /// Images whose full fetch failed (expired/offline) — show a warning glyph.
+    @Published var failedImages: Set<String> = []
+    /// Per-image full-resolution loaders, set once by NotchPresenter. Not
+    /// @Published: read by cells, it never needs to drive a refresh itself.
+    var imageLoaders: [String: @Sendable () async -> Data?] = [:]
     /// Click on the message opened the reply field (set by NotchPresenter).
     @Published var replying = false
     /// The reply went out — show the confirmation, then auto-hide.
@@ -49,6 +58,20 @@ final class MessageDisplayModel: ObservableObject {
 
     func copy(_ text: String) {
         writePasteboard(text)
+        flashCopied()
+    }
+
+    /// Copy a received image to the clipboard (full resolution if it has
+    /// loaded, otherwise the inline thumbnail).
+    func copyImage(_ data: Data) {
+        guard let image = NSImage(data: data) else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.writeObjects([image])
+        flashCopied()
+    }
+
+    private func flashCopied() {
         withAnimation(.spring(duration: 0.3)) { copied = true }
         Task {
             try? await Task.sleep(for: .seconds(1.5))
@@ -144,15 +167,16 @@ struct MessageNotchContainer: View {
             if model.fullyExpanded {
                 // Same width as the teaser: hovering only grows downward.
                 VStack(alignment: .leading, spacing: 6) {
-                    MessageNotchView(message: message)
+                    MessageNotchView(message: message, model: model)
                         // Reply opens only from a click on the current
                         // message itself, not anywhere on the shape.
                         .background(AreaMarker { [weak model] in model?.replyMarker = $0 })
                         // Expanded, the copy button travels down to sit on
-                        // the message it copies.
+                        // the message it copies. For an image it copies the
+                        // picture (full resolution if loaded, else the thumb).
                         .overlay(alignment: .topTrailing) {
                             CopyMessageButton(copied: model.copied, diameter: avatarSize) {
-                                model.copy(message.text)
+                                copyCurrent()
                             }
                             .padding(.top, 2)
                             .padding(.trailing, 4)
@@ -182,7 +206,7 @@ struct MessageNotchContainer: View {
         .overlay(alignment: .topTrailing) {
             if !model.fullyExpanded {
                 CopyMessageButton(copied: model.copied, diameter: avatarSize) {
-                    model.copy(message.text)
+                    copyCurrent()
                 }
                 .offset(y: notchSize.height > 0 ? avatarOffsetY : 0)
             }
@@ -362,7 +386,7 @@ struct MessageNotchContainer: View {
             Image(systemName: message.isDirect ? "lock.fill" : "globe")
                 .font(.system(size: 9))
                 .foregroundStyle(.white.opacity(0.55))
-            TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
+            teaserContent
         }
         .padding(.top, 2)
         .padding(.bottom, -6)
@@ -384,11 +408,61 @@ struct MessageNotchContainer: View {
                 Image(systemName: message.isDirect ? "lock.fill" : "globe")
                     .font(.system(size: 9))
                     .foregroundStyle(.white.opacity(0.55))
-                TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
+                teaserContent
             }
         }
         .padding(.vertical, 4)
         .background(AreaMarker { [weak model] in model?.teaserMarker = $0 })
+    }
+
+    /// One-line teaser body: the scrolling text, or a thumbnail strip for an
+    /// image message (which has no text to scroll).
+    @ViewBuilder private var teaserContent: some View {
+        if message.isImage {
+            imageTeaserLine
+        } else {
+            TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
+        }
+    }
+
+    private var imageTeaserLine: some View {
+        HStack(spacing: 6) {
+            ForEach(message.images.prefix(3)) { img in
+                NotchThumb(thumb: img.thumb, side: 26)
+                    .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+            }
+            if message.images.count > 3 {
+                Text("+\(message.images.count - 3)")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+            Text(teaserLabel)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+        }
+        // No ticker to report completion — linger briefly, then hand off to
+        // the same auto-hide timing the text teaser uses.
+        .task {
+            try? await Task.sleep(for: .seconds(2.5))
+            onTeaserFinished()
+        }
+    }
+
+    /// Teaser caption: the album's caption if any, else an image count.
+    private var teaserLabel: String {
+        if !message.text.isEmpty { return message.text }
+        return message.images.count == 1 ? "Image" : "\(message.images.count) images"
+    }
+
+    /// Copies the current message: the first picture for an album (full
+    /// resolution if it has loaded, else its thumbnail), otherwise its text.
+    private func copyCurrent() {
+        if let first = message.images.first {
+            model.copyImage(model.fullImages[first.id] ?? first.thumb)
+        } else {
+            model.copy(message.text)
+        }
     }
 
     /// Vertically centers the avatar in the menu-bar-height strip above.

--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -1,35 +1,34 @@
 import AppKit
+import MunkelKit
 import SwiftUI
 
-/// The full (hover-expanded) view: avatar, sender, text. Copying lives in
-/// the persistent strip button; clicking the message opens the inline
-/// reply field (see MessageNotchContainer/NotchPresenter).
+/// The full (hover-expanded) view: avatar, sender, and either the message text
+/// or — for an image message — a picture (single) or thumbnail grid (album),
+/// each cell upgrading from its inline thumbnail to full resolution as it loads
+/// from R2. Copying lives in the persistent strip button; clicking the message
+/// opens the inline reply field (see MessageNotchContainer/NotchPresenter).
 struct MessageNotchView: View {
     let message: IncomingMessage
+    @ObservedObject var model: MessageDisplayModel
+
+    /// Matches the expanded container width.
+    private let contentWidth: CGFloat = 250
+    private let gridSpacing: CGFloat = 6
 
     var body: some View {
+        if message.isImage {
+            imageBody
+        } else {
+            textBody
+        }
+    }
+
+    private var textBody: some View {
         HStack(alignment: .top, spacing: 12) {
             AvatarView(name: message.sender, imageData: message.avatarData)
 
             VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 4) {
-                    Text(message.sender)
-                        .font(.system(size: 11, weight: .semibold))
-                    // Globe: everyone saw this. Lock: only you did. No
-                    // .help — tooltip windows leak into screen shares.
-                    Image(systemName: message.isDirect ? "lock.fill" : "globe")
-                        .font(.system(size: 9))
-                    Text("·")
-                    // Which circle it came from: stable color for
-                    // at-a-glance recognition, name for certainty.
-                    Circle()
-                        .fill(message.groupColor)
-                        .frame(width: 6, height: 6)
-                    Text(message.group)
-                        .font(.system(size: 10, design: .monospaced))
-                        .lineLimit(1)
-                }
-                .foregroundStyle(.white.opacity(0.55))
+                header
                 Text(message.text)
                     .font(.system(size: 14, weight: .medium))
                     .foregroundStyle(.white)
@@ -43,4 +42,166 @@ struct MessageNotchView: View {
         .padding(.vertical, 4)
     }
 
+    /// Header on top, the picture(s) below, an optional caption underneath.
+    private var imageBody: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                AvatarView(name: message.sender, imageData: message.avatarData, size: 18)
+                header
+                Spacer(minLength: 4)
+            }
+
+            imageContent
+
+            if !message.text.isEmpty {
+                Text(message.text)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white)
+                    .lineLimit(4)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+    }
+
+    /// A lone image fills the width at its own aspect; an album is a 2-column
+    /// grid of square cells.
+    @ViewBuilder private var imageContent: some View {
+        if message.images.count == 1, let only = message.images.first {
+            let size = fittedSize(width: only.width, height: only.height)
+            AlbumCell(model: model, image: only, fill: false)
+                .frame(width: size.width, height: size.height)
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        } else {
+            let side = (contentWidth - gridSpacing) / 2
+            let columns = [
+                GridItem(.fixed(side), spacing: gridSpacing),
+                GridItem(.fixed(side), spacing: gridSpacing),
+            ]
+            LazyVGrid(columns: columns, alignment: .leading, spacing: gridSpacing) {
+                ForEach(message.images) { img in
+                    AlbumCell(model: model, image: img, fill: true)
+                        .frame(width: side, height: side)
+                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                }
+            }
+            .frame(width: contentWidth, alignment: .leading)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 4) {
+            Text(message.sender)
+                .font(.system(size: 11, weight: .semibold))
+            // Globe: everyone saw this. Lock: only you did. No .help — tooltip
+            // windows leak into screen shares.
+            Image(systemName: message.isDirect ? "lock.fill" : "globe")
+                .font(.system(size: 9))
+            Text("·")
+            Circle()
+                .fill(message.groupColor)
+                .frame(width: 6, height: 6)
+            Text(message.group)
+                .font(.system(size: 10, design: .monospaced))
+                .lineLimit(1)
+        }
+        .foregroundStyle(.white.opacity(0.55))
+    }
+
+    /// A lone image's display size: its aspect scaled to fit the bounding box
+    /// (never upscaled past it).
+    private func fittedSize(width: Int, height: Int) -> CGSize {
+        let w = CGFloat(width)
+        let h = CGFloat(height)
+        let maxHeight: CGFloat = 260
+        guard w > 0, h > 0 else { return CGSize(width: contentWidth, height: contentWidth * 0.6) }
+        let scale = min(contentWidth / w, maxHeight / h)
+        return CGSize(width: max(1, w * scale), height: max(1, h * scale))
+    }
+}
+
+/// One image cell: paints its inline thumbnail instantly, then fetches its full
+/// resolution from R2 (once, cached on the model) and swaps it in. A spinner
+/// shows while loading, a warning glyph if the fetch failed. Decoding is off
+/// the main actor through ImageCodec's bomb-safe thumbnailer.
+struct AlbumCell: View {
+    @ObservedObject var model: MessageDisplayModel
+    let image: IncomingImage
+    /// Grid cells fill+crop to a square; a lone image fits its aspect.
+    let fill: Bool
+
+    @State private var decoded: CGImage?
+
+    private var isLoaded: Bool { model.fullImages[image.id] != nil }
+    private var didFail: Bool { model.failedImages.contains(image.id) }
+
+    var body: some View {
+        ZStack {
+            if let decoded {
+                Image(decorative: decoded, scale: 1)
+                    .resizable()
+                    .interpolation(.medium)
+                    .aspectRatio(contentMode: fill ? .fill : .fit)
+            } else {
+                Rectangle().fill(.white.opacity(0.08))
+            }
+            if !isLoaded, !didFail {
+                ProgressView().controlSize(.small).tint(.white.opacity(0.8))
+            } else if didFail {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+        }
+        .clipped()
+        .task { await load() }
+    }
+
+    private func load() async {
+        // Instant preview from the inline thumbnail.
+        if decoded == nil {
+            let thumb = image.thumb
+            decoded = await Task.detached { ImageCodec.decode(thumb, maxPixels: 400) }.value
+        }
+        // Full resolution: use the cache, else fetch once via the model's loader.
+        if let full = model.fullImages[image.id] {
+            decoded = await Task.detached { ImageCodec.decode(full, maxPixels: 1400) }.value
+            return
+        }
+        guard !didFail, let loader = model.imageLoaders[image.id] else { return }
+        if let data = await loader() {
+            model.fullImages[image.id] = data
+            decoded = await Task.detached { ImageCodec.decode(data, maxPixels: 1400) }.value
+        } else {
+            model.failedImages.insert(image.id)
+        }
+    }
+}
+
+/// A tiny thumbnail-only image (no R2 fetch) for the collapsed teaser strip.
+struct NotchThumb: View {
+    let thumb: Data
+    let side: CGFloat
+
+    @State private var decoded: CGImage?
+
+    var body: some View {
+        Group {
+            if let decoded {
+                Image(decorative: decoded, scale: 1)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                Rectangle().fill(.white.opacity(0.08))
+            }
+        }
+        .frame(width: side, height: side)
+        .clipped()
+        .task {
+            let thumb = thumb
+            let pixels = Int(side * 2)
+            decoded = await Task.detached { ImageCodec.decode(thumb, maxPixels: pixels) }.value
+        }
+    }
 }

--- a/apps/macos/Sources/MunkelApp/MunkelApp.swift
+++ b/apps/macos/Sources/MunkelApp/MunkelApp.swift
@@ -21,6 +21,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         // Accessory: no Dock icon — menu bar item and notch are the only UI.
         NSApp.setActivationPolicy(.accessory)
 
+        // An accessory app gets no main menu, so the standard editing shortcuts
+        // (⌘X/⌘C/⌘V/⌘A) are never routed to the focused text field's responder.
+        // A minimal, never-displayed Edit menu wires them back up app-wide.
+        installEditMenu()
+
         let model = AppModel()
         self.model = model
 
@@ -66,6 +71,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         item.button?.target = self
         item.button?.action = #selector(togglePopover(_:))
         statusItem = item
+    }
+
+    /// A minimal Edit menu so Cut/Copy/Paste/Select All reach the first
+    /// responder (the focused text field). Never shown — an accessory app has
+    /// no menu bar — but its ⌘-key equivalents are still dispatched.
+    private func installEditMenu() {
+        let mainMenu = NSMenu()
+        let editItem = NSMenuItem()
+        mainMenu.addItem(editItem)
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        editItem.submenu = editMenu
+        NSApp.mainMenu = mainMenu
     }
 
     func popoverDidClose(_ notification: Notification) {

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -68,11 +68,13 @@ final class NotchPresenter {
     func show(
         sender: String,
         avatarData: Data?,
-        text: String,
+        text: String = "",
         isDirect: Bool,
         group: String,
         groupColor: Color,
         inMultipleGroups: Bool,
+        images: [IncomingImage] = [],
+        loadFull: (@Sendable (String) async -> Data?)? = nil,
         onReply: @escaping (_ text: String, _ privately: Bool) -> Void
     ) {
         let message = IncomingMessage(
@@ -82,11 +84,22 @@ final class NotchPresenter {
             isDirect: isDirect,
             group: group,
             groupColor: groupColor,
-            inMultipleGroups: inMultipleGroups
+            inMultipleGroups: inMultipleGroups,
+            images: images
         )
+        // History rows are text-only; an album shows its caption (or an image
+        // count), prefixed with a 📷 so it reads as a picture.
+        let historyText: String
+        if images.isEmpty {
+            historyText = text
+        } else if !text.isEmpty {
+            historyText = "📷 \(text)"
+        } else {
+            historyText = images.count == 1 ? "📷 Image" : "📷 \(images.count) images"
+        }
         let entry = HistoryEntry(
             sender: sender,
-            text: text,
+            text: historyText,
             isDirect: isDirect,
             group: group,
             groupColor: groupColor,
@@ -115,7 +128,7 @@ final class NotchPresenter {
         pendingShow = Task { [weak self] in
             await previous?.value
             guard let self, generation == self.showGeneration else { return }
-            await self.display(message, entryID: entry.id, generation: generation, onReply: onReply)
+            await self.display(message, entryID: entry.id, generation: generation, loadFull: loadFull, onReply: onReply)
         }
     }
 
@@ -123,6 +136,7 @@ final class NotchPresenter {
         _ message: IncomingMessage,
         entryID: UUID,
         generation: Int,
+        loadFull: (@Sendable (String) async -> Data?)?,
         onReply: @escaping (_ text: String, _ privately: Bool) -> Void
     ) async {
         // Never yank an open reply field from under the user — wait until
@@ -146,6 +160,15 @@ final class NotchPresenter {
         let model = MessageDisplayModel()
         // Replies default to the channel the message came in on.
         model.replyPrivately = message.isDirect
+        // Per-image loaders the grid cells call on appear (lazy full fetch).
+        if let loadFull {
+            var loaders: [String: @Sendable () async -> Data?] = [:]
+            for image in message.images {
+                let id = image.id
+                loaders[id] = { await loadFull(id) }
+            }
+            model.imageLoaders = loaders
+        }
         // The expanded state shows what else arrived in the last minute
         // before this message.
         pruneHistory()
@@ -230,7 +253,14 @@ final class NotchPresenter {
         notchVisible = true
         installClickMonitors(for: notch, model: model)
         startHistoryPruning(model: model)
-        scheduleHide(of: notch, after: safetyDuration(for: message.text))
+
+        // Album images load lazily per grid cell (see AlbumCell) once the
+        // notch is expanded — no eager fetch here.
+
+        // The text teaser sizes its safety timeout to the scroll length; an
+        // image teaser has no ticker, so give it a fixed generous window.
+        let safety: Duration = message.isImage ? .seconds(20) : safetyDuration(for: message.text)
+        scheduleHide(of: notch, after: safety)
     }
 
     /// Expires history entries live while the notch is on screen, so rows

--- a/apps/macos/Sources/MunkelKit/AppPayload.swift
+++ b/apps/macos/Sources/MunkelKit/AppPayload.swift
@@ -1,14 +1,56 @@
 import Foundation
 
+/// One image of an album. The full-resolution AVIF is always sealed and
+/// uploaded to R2 under `r2Key`, and only this pointer is relayed; `thumb` is a
+/// tiny inline AVIF (a couple of KiB) so the notch paints instantly while the
+/// full image lazy-loads from R2. `width`/`height` are the full image's pixel
+/// size (for aspect ratio); `byteLen` is the sealed blob's size (informational
+/// only — never used to bound the download).
+public struct ImageItem: Codable, Sendable, Equatable {
+    public let r2Key: String
+    public let mime: String
+    public let width: Int
+    public let height: Int
+    public let byteLen: Int
+    public let thumb: Data
+
+    public init(r2Key: String, mime: String, width: Int, height: Int, byteLen: Int, thumb: Data) {
+        self.r2Key = r2Key
+        self.mime = mime
+        self.width = width
+        self.height = height
+        self.byteLen = byteLen
+        self.thumb = thumb
+    }
+}
+
 /// What lives inside the encrypted blob — the relay never sees these.
 public enum AppPayload: Sendable, Equatable {
     case chat(text: String, sentAt: Date)
     case profile(displayName: String, avatar: Data?)
+    /// One or more images (an album) sent together, with an optional shared
+    /// `caption` ("" if none). Each `ImageItem` is a pointer to an R2 blob plus
+    /// a tiny inline preview thumbnail.
+    case image(items: [ImageItem], caption: String, sentAt: Date)
+
+    /// Hard cap on images per message; senders clamp, receivers drop extras.
+    public static let maxImagesPerMessage = 8
+
+    /// Total raw bytes for inline preview thumbnails across an album, shared so
+    /// the sealed pointer stays under the relay's 48 KiB payload cap even at the
+    /// 8-image max. The single source of truth (dev-image.ts mirrors it).
+    public static let albumThumbBudget = 16_384
+
+    /// Per-image inline thumbnail byte budget for a `count`-image album.
+    public static func perThumbBudget(imageCount: Int) -> Int {
+        max(1_200, albumThumbBudget / max(1, imageCount))
+    }
 }
 
 extension AppPayload: Codable {
     private enum CodingKeys: String, CodingKey {
         case kind, text, sentAt, displayName, avatar
+        case items, caption
     }
 
     public init(from decoder: Decoder) throws {
@@ -30,7 +72,28 @@ extension AppPayload: Codable {
                 displayName: container.decode(String.self, forKey: .displayName),
                 avatar: container.decodeIfPresent(Data.self, forKey: .avatar)
             )
+        case "image":
+            let sentAtRaw = try container.decode(String.self, forKey: .sentAt)
+            guard let sentAt = Self.parseISO8601(sentAtRaw) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .sentAt,
+                    in: container,
+                    debugDescription: "sentAt is not ISO-8601"
+                )
+            }
+            // Drop extras past the cap rather than rejecting (the list comes
+            // from an untrusted peer).
+            let items = try container.decode([ImageItem].self, forKey: .items)
+            self = try .image(
+                items: Array(items.prefix(Self.maxImagesPerMessage)),
+                caption: container.decodeIfPresent(String.self, forKey: .caption) ?? "",
+                sentAt: sentAt
+            )
         default:
+            // Forward-compat: a newer peer may send a kind this build doesn't
+            // know. The caller (GroupSession.handleIncoming) catches this and
+            // drops the frame — better than crashing — so an outdated client
+            // simply ignores message kinds it can't render.
             throw DecodingError.dataCorruptedError(
                 forKey: .kind,
                 in: container,
@@ -58,6 +121,11 @@ extension AppPayload: Codable {
             try container.encode("profile", forKey: .kind)
             try container.encode(displayName, forKey: .displayName)
             try container.encodeIfPresent(avatar, forKey: .avatar)
+        case let .image(items, caption, sentAt):
+            try container.encode("image", forKey: .kind)
+            try container.encode(items, forKey: .items)
+            try container.encode(caption, forKey: .caption)
+            try container.encode(ISO8601DateFormatter().string(from: sentAt), forKey: .sentAt)
         }
     }
 }

--- a/apps/macos/Sources/MunkelKit/AvatarCodec.swift
+++ b/apps/macos/Sources/MunkelKit/AvatarCodec.swift
@@ -18,7 +18,8 @@ public enum AvatarCodec {
 
     /// JPEG ≤ `maxBytes`, longest side ≤ `maxPixels`. Steps down quality,
     /// then size, until it fits. nil when the input is undecodable or
-    /// uncompressible within budget.
+    /// uncompressible within budget. Shares the ImageIO primitives with
+    /// `ImageCodec`.
     public static func makeAvatar(
         from data: Data,
         maxBytes: Int = maxEncodedBytes,
@@ -26,9 +27,9 @@ public enum AvatarCodec {
     ) -> Data? {
         let sizes = [maxPixels, maxPixels * 3 / 4, maxPixels / 2].filter { $0 > 0 }
         for pixels in sizes {
-            guard let image = downsampled(data, maxPixels: pixels) else { return nil }
+            guard let image = ImageCodec.downsample(data, maxPixels: pixels) else { return nil }
             for quality in [0.8, 0.6, 0.4] {
-                if let jpeg = encodeJPEG(image, quality: quality), jpeg.count <= maxBytes {
+                if let jpeg = ImageCodec.encodeJPEG(image, quality: quality), jpeg.count <= maxBytes {
                     return jpeg
                 }
             }
@@ -38,35 +39,6 @@ public enum AvatarCodec {
 
     /// Safe decode for display: never materializes more than `maxPixels`.
     public static func decodeImage(_ data: Data, maxPixels: Int = 256) -> CGImage? {
-        downsampled(data, maxPixels: maxPixels)
-    }
-
-    private static func downsampled(_ data: Data, maxPixels: Int) -> CGImage? {
-        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
-        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
-            return nil
-        }
-        let thumbnailOptions = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceShouldCacheImmediately: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxPixels,
-        ] as [CFString: Any] as CFDictionary
-        return CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions)
-    }
-
-    private static func encodeJPEG(_ image: CGImage, quality: Double) -> Data? {
-        let output = NSMutableData()
-        guard
-            let destination = CGImageDestinationCreateWithData(
-                output, UTType.jpeg.identifier as CFString, 1, nil
-            )
-        else {
-            return nil
-        }
-        let properties = [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary
-        CGImageDestinationAddImage(destination, image, properties)
-        guard CGImageDestinationFinalize(destination) else { return nil }
-        return output as Data
+        ImageCodec.downsample(data, maxPixels: maxPixels)
     }
 }

--- a/apps/macos/Sources/MunkelKit/BlobClient.swift
+++ b/apps/macos/Sources/MunkelKit/BlobClient.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+public enum BlobError: Error, Equatable {
+    case badRelayURL
+    case uploadFailed(status: Int)
+    case downloadFailed(status: Int)
+    case tooLarge
+}
+
+/// HTTP client for image blobs stored in R2 behind the relay Worker. The full
+/// image is sealed by the caller BEFORE upload (see MessageCrypto.sealRaw), so
+/// only opaque ciphertext crosses this client — the server stays blind.
+///
+/// The blob endpoint shares the relay's origin: the relay is reached over
+/// `ws(s)://host/ws`, blobs over `http(s)://host/blob/<group>/<key>`.
+public actor BlobClient {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    /// Same-origin HTTPS base for blobs, derived from the ws(s) relay URL.
+    public static func baseURL(fromRelay relayURL: URL) -> URL? {
+        guard var components = URLComponents(url: relayURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        switch components.scheme?.lowercased() {
+        case "wss", "https": components.scheme = "https"
+        case "ws", "http": components.scheme = "http"
+        default: return nil
+        }
+        components.path = ""
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    /// PUT the sealed ciphertext. Throws on any non-2xx status.
+    public func upload(baseURL: URL, group: String, key: String, ciphertext: Data) async throws {
+        var request = URLRequest(url: blobURL(baseURL: baseURL, group: group, key: key))
+        request.httpMethod = "PUT"
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        let (_, response) = try await session.upload(for: request, from: ciphertext)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(status) else {
+            throw BlobError.uploadFailed(status: status)
+        }
+    }
+
+    /// GET the sealed ciphertext. Throws `.downloadFailed(404)` once the blob
+    /// has expired or was never uploaded.
+    public func download(baseURL: URL, group: String, key: String, maxBytes: Int? = nil) async throws -> Data {
+        let request = URLRequest(url: blobURL(baseURL: baseURL, group: group, key: key))
+        let (data, response) = try await session.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(status) else {
+            throw BlobError.downloadFailed(status: status)
+        }
+        if let maxBytes, data.count > maxBytes {
+            throw BlobError.tooLarge
+        }
+        return data
+    }
+
+    private func blobURL(baseURL: URL, group: String, key: String) -> URL {
+        baseURL
+            .appending(path: "blob")
+            .appending(path: group)
+            .appending(path: key)
+    }
+}

--- a/apps/macos/Sources/MunkelKit/ControlProtocol.swift
+++ b/apps/macos/Sources/MunkelKit/ControlProtocol.swift
@@ -22,12 +22,16 @@ public struct ControlRequest: Codable, Sendable {
     public var group: String?
     public var to: String?
     public var text: String?
+    /// Absolute paths to image files to send as one album. The app reads,
+    /// encodes, seals and uploads them — bytes never cross the socket or argv.
+    public var imagePaths: [String]?
 
-    public init(action: String, group: String? = nil, to: String? = nil, text: String? = nil) {
+    public init(action: String, group: String? = nil, to: String? = nil, text: String? = nil, imagePaths: [String]? = nil) {
         self.action = action
         self.group = group
         self.to = to
         self.text = text
+        self.imagePaths = imagePaths
     }
 }
 

--- a/apps/macos/Sources/MunkelKit/ImageCodec.swift
+++ b/apps/macos/Sources/MunkelKit/ImageCodec.swift
@@ -1,0 +1,176 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Prepares images for sending and decodes incoming ones. Two outputs per send:
+///
+/// - `prepareFull` — the full-resolution image that gets sealed and uploaded to
+///   R2. The source (JPEG, PNG, anything decodable) is ALWAYS transcoded to
+///   AVIF and hard-capped at 2 MiB — AVIF is smaller at equal quality, which is
+///   the whole point: minimize bytes on the wire.
+/// - `makeThumbnail` — a tiny AVIF that rides inside the relay pointer for an
+///   instant notch preview (same format as the full image — no second codec).
+///
+/// Decoding (`decode`) and the shared ImageIO primitives live here too; incoming
+/// bytes are peer-controlled, so every decode is thumbnailed through a hard
+/// pixel cap (a small file can declare huge dimensions — a decompression bomb).
+public enum ImageCodec {
+    /// Byte/pixel budget for the full image uploaded to R2. Matches the server's
+    /// per-blob cap headroom (see apps/server/src/blob.ts, MAX_BLOB_BYTES). The
+    /// pixel ceiling is well above the receiver's 1400px decode cap
+    /// (MessageNotchView) so we don't ship pixels that are decoded away —
+    /// byte cost scales ~quadratically with the longest side.
+    public static let maxFullBytes = 2 * 1024 * 1024
+    public static let maxFullPixels = 2048
+
+    /// Inline-preview thumbnail budget. Kept small so the sealed pointer stays
+    /// well under the relay's 48 KiB payload cap even after base64.
+    public static let maxThumbBytes = 12 * 1024
+    public static let maxThumbPixels = 256
+
+    public struct Prepared: Equatable, Sendable {
+        public let data: Data
+        public let mime: String
+        public let width: Int
+        public let height: Int
+
+        public init(data: Data, mime: String, width: Int, height: Int) {
+            self.data = data
+            self.mime = mime
+            self.width = width
+            self.height = height
+        }
+    }
+
+    /// Full-resolution image ready to seal + upload. The source — JPEG, PNG or
+    /// anything else decodable — is ALWAYS transcoded to AVIF (smaller at equal
+    /// quality, one format on the wire) and hard-capped at `maxBytes` (2 MiB).
+    /// Steps quality down, then pixel size, until it fits. Returns nil when the
+    /// input is undecodable, AVIF encoding is unavailable, or it can't be
+    /// compressed within budget.
+    public static func prepareFull(
+        from data: Data,
+        maxBytes: Int = maxFullBytes,
+        maxPixels: Int = maxFullPixels
+    ) -> Prepared? {
+        let sizes = [maxPixels, maxPixels * 3 / 4, maxPixels / 2].filter { $0 > 0 }
+        for pixels in sizes {
+            guard let image = downsample(data, maxPixels: pixels) else { return nil }
+            for quality in [0.7, 0.5, 0.35] {
+                if let avif = encodeAVIF(image, quality: quality), avif.count <= maxBytes {
+                    return Prepared(data: avif, mime: "image/avif", width: image.width, height: image.height)
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Small AVIF preview for the inline pointer — same format as the full
+    /// image, so there's no separate JPEG version. Steps size down further than
+    /// the full encoder so even an album's tiny per-image budget fits. nil when
+    /// undecodable or uncompressible within budget.
+    public static func makeThumbnail(
+        from data: Data,
+        maxBytes: Int = maxThumbBytes,
+        maxPixels: Int = maxThumbPixels
+    ) -> Data? {
+        let sizes = [maxPixels, maxPixels * 3 / 4, maxPixels / 2, maxPixels / 4].filter { $0 > 0 }
+        for pixels in sizes {
+            guard let image = downsample(data, maxPixels: pixels) else { return nil }
+            for quality in [0.6, 0.45, 0.3] {
+                if let avif = encodeAVIF(image, quality: quality), avif.count <= maxBytes {
+                    return avif
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Safe decode for display: never materializes more than `maxPixels`.
+    public static func decode(_ data: Data, maxPixels: Int = 1024) -> CGImage? {
+        downsample(data, maxPixels: maxPixels)
+    }
+
+    // MARK: - Shared ImageIO primitives (also used by AvatarCodec)
+
+    struct ImageInfo { let width: Int; let height: Int; let mime: String }
+
+    /// Pixel dimensions and MIME of an encoded image, without decoding pixels.
+    static func properties(of data: Data) -> ImageInfo? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = props[kCGImagePropertyPixelWidth] as? Int,
+              let height = props[kCGImagePropertyPixelHeight] as? Int
+        else {
+            return nil
+        }
+        let mime = (CGImageSourceGetType(source).flatMap { UTType($0 as String) })
+            .flatMap { $0.preferredMIMEType } ?? "application/octet-stream"
+        return ImageInfo(width: width, height: height, mime: mime)
+    }
+
+    /// Thumbnail-decode with a hard longest-side cap — the bomb-safe path for
+    /// peer-controlled bytes.
+    static func downsample(_ data: Data, maxPixels: Int) -> CGImage? {
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+            return nil
+        }
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixels,
+        ] as [CFString: Any] as CFDictionary
+        return CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions)
+    }
+
+    static func encodeJPEG(_ image: CGImage, quality: Double) -> Data? {
+        encode(image, type: UTType.jpeg, properties: [kCGImageDestinationLossyCompressionQuality: quality])
+    }
+
+    static func encodePNG(_ image: CGImage) -> Data? {
+        encode(image, type: UTType.png, properties: [:])
+    }
+
+    /// System UTI for AVIF (ImageIO can encode it on macOS 14+). nil if the
+    /// platform doesn't know the type, in which case encoding no-ops.
+    private static let avifType = UTType("public.avif")
+
+    static func encodeAVIF(_ image: CGImage, quality: Double) -> Data? {
+        guard let avifType else { return nil }
+        return encode(image, type: avifType, properties: [kCGImageDestinationLossyCompressionQuality: quality])
+    }
+
+    /// Whether ImageIO can actually encode AVIF here (one-time 1×1 probe). The
+    /// whole feature transcodes to AVIF, so a future OS regression should be
+    /// diagnosable instead of a silent no-op (every image would be dropped).
+    public static let isAVIFEncodingAvailable: Bool = {
+        guard let avifType,
+              let context = CGContext(
+                  data: nil, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 0,
+                  space: CGColorSpaceCreateDeviceRGB(),
+                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ),
+              let probe = context.makeImage()
+        else {
+            return false
+        }
+        return encode(probe, type: avifType, properties: [:]) != nil
+    }()
+
+    private static func encode(_ image: CGImage, type: UTType, properties: [CFString: Any]) -> Data? {
+        let output = NSMutableData()
+        guard
+            let destination = CGImageDestinationCreateWithData(
+                output, type.identifier as CFString, 1, nil
+            )
+        else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, image, properties as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
+    }
+}

--- a/apps/macos/Sources/MunkelKit/MessageCrypto.swift
+++ b/apps/macos/Sources/MunkelKit/MessageCrypto.swift
@@ -11,17 +11,29 @@ public enum CryptoError: Error {
 /// `payload = base64( nonce[12] ‖ ciphertext ‖ tag[16] )`, empty AAD.
 public enum MessageCrypto {
     public static func seal(_ plaintext: Data, using key: SymmetricKey) throws -> String {
-        let sealedBox = try AES.GCM.seal(plaintext, using: key)
-        guard let combined = sealedBox.combined else {
-            throw CryptoError.sealFailed
-        }
-        return combined.base64EncodedString()
+        try sealRaw(plaintext, using: key).base64EncodedString()
     }
 
     public static func open(_ payload: String, using key: SymmetricKey) throws -> Data {
         guard let combined = Data(base64Encoded: payload) else {
             throw CryptoError.invalidPayload
         }
+        return try openRaw(combined, using: key)
+    }
+
+    /// Same sealing as `seal`, but returns the raw `combined` bytes
+    /// (nonce ‖ ciphertext ‖ tag) instead of base64. Used for image blobs
+    /// stored in R2, where base64 would waste ~33% of storage and egress.
+    public static func sealRaw(_ plaintext: Data, using key: SymmetricKey) throws -> Data {
+        let sealedBox = try AES.GCM.seal(plaintext, using: key)
+        guard let combined = sealedBox.combined else {
+            throw CryptoError.sealFailed
+        }
+        return combined
+    }
+
+    /// Inverse of `sealRaw`: opens raw `combined` bytes.
+    public static func openRaw(_ combined: Data, using key: SymmetricKey) throws -> Data {
         let sealedBox = try AES.GCM.SealedBox(combined: combined)
         return try AES.GCM.open(sealedBox, using: key)
     }

--- a/apps/macos/Tests/MunkelKitTests/ImageCodecTests.swift
+++ b/apps/macos/Tests/MunkelKitTests/ImageCodecTests.swift
@@ -48,6 +48,15 @@ private func isAVIF(_ data: Data) -> Bool {
     return major == Array("avif".utf8) || major == Array("avis".utf8)
 }
 
+/// AVIF *encoding* via ImageIO routes through a system media service that needs
+/// a GUI/app context. A plain `swift test` CLI binary on a headless CI runner
+/// has none, so `CGImageDestinationFinalize(public.avif)` blocks forever and the
+/// job only ends at the 20-minute timeout (no output, since stdout is buffered).
+/// GitHub Actions sets `CI`, so skip the encode tests there; they run locally
+/// where a full window-server session is available. Decode/property tests never
+/// reach the encoder and run everywhere.
+private let avifEncodeRunsHere = ProcessInfo.processInfo.environment["CI"] == nil
+
 @Suite("ImageCodec")
 struct ImageCodecTests {
     @Test func readsPropertiesAndMime() {
@@ -58,7 +67,7 @@ struct ImageCodecTests {
         #expect(info?.mime == "image/png")
     }
 
-    @Test func prepareFullTranscodesToAVIF() {
+    @Test(.enabled(if: avifEncodeRunsHere)) func prepareFullTranscodesToAVIF() {
         // A small PNG is still transcoded to AVIF (no passthrough) and is a
         // recognizable, decodable image of the same pixel size.
         let png = noisePNG(width: 64, height: 64)
@@ -71,7 +80,7 @@ struct ImageCodecTests {
         #expect(ImageCodec.decode(prepared.data) != nil)
     }
 
-    @Test func prepareFullHardCapsSizeToBudget() {
+    @Test(.enabled(if: avifEncodeRunsHere)) func prepareFullHardCapsSizeToBudget() {
         let big = noisePNG(width: 1200, height: 1200)
         let prepared = try! #require(ImageCodec.prepareFull(from: big, maxBytes: 80_000, maxPixels: 256))
         #expect(prepared.data.count <= 80_000)
@@ -80,7 +89,7 @@ struct ImageCodecTests {
         #expect(max(prepared.width, prepared.height) <= 256)
     }
 
-    @Test func prepareFullDefaultsToPixelCeiling() {
+    @Test(.enabled(if: avifEncodeRunsHere)) func prepareFullDefaultsToPixelCeiling() {
         // With no explicit maxPixels, a large source is bounded by the default
         // ceiling (2048) — we don't ship pixels the receiver decodes away.
         #expect(ImageCodec.maxFullPixels == 2048)
@@ -89,7 +98,7 @@ struct ImageCodecTests {
         #expect(max(prepared.width, prepared.height) <= ImageCodec.maxFullPixels)
     }
 
-    @Test func makeThumbnailFitsBudget() {
+    @Test(.enabled(if: avifEncodeRunsHere)) func makeThumbnailFitsBudget() {
         let big = noisePNG(width: 800, height: 800)
         let thumb = try! #require(ImageCodec.makeThumbnail(from: big))
         #expect(thumb.count <= ImageCodec.maxThumbBytes)
@@ -98,7 +107,7 @@ struct ImageCodecTests {
         #expect(ImageCodec.decode(thumb) != nil)
     }
 
-    @Test func makeThumbnailFitsTinyAlbumBudget() {
+    @Test(.enabled(if: avifEncodeRunsHere)) func makeThumbnailFitsTinyAlbumBudget() {
         // An 8-image album gives each thumb only ~2 KiB — AVIF must still fit.
         let big = noisePNG(width: 800, height: 800)
         let thumb = try! #require(ImageCodec.makeThumbnail(from: big, maxBytes: 2_048))
@@ -107,9 +116,10 @@ struct ImageCodecTests {
         #expect(ImageCodec.decode(thumb) != nil)
     }
 
-    @Test func avifEncodingIsAvailableHere() {
+    @Test(.enabled(if: avifEncodeRunsHere)) func avifEncodingIsAvailableHere() {
         // If this fails, the host can't encode AVIF and the whole feature
-        // silently no-ops — make that loud.
+        // silently no-ops — make that loud. Skipped on CI (see avifEncodeRunsHere):
+        // touching the probe there would deadlock the same way an encode does.
         #expect(ImageCodec.isAVIFEncodingAvailable)
     }
 

--- a/apps/macos/Tests/MunkelKitTests/ImageCodecTests.swift
+++ b/apps/macos/Tests/MunkelKitTests/ImageCodecTests.swift
@@ -1,0 +1,128 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+@testable import MunkelKit
+
+/// Noisy PNG — noise compresses badly, which exercises the budget stepping.
+private func noisePNG(width: Int, height: Int) -> Data {
+    let context = CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: CGColorSpace(name: CGColorSpace.sRGB)!,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )!
+    var state: UInt64 = 0x9E37_79B9_7F4A_7C15
+    for y in 0..<height where y % 2 == 0 {
+        for x in 0..<width where x % 2 == 0 {
+            state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            let r = CGFloat((state >> 33) & 0xFF) / 255
+            let g = CGFloat((state >> 41) & 0xFF) / 255
+            let b = CGFloat((state >> 49) & 0xFF) / 255
+            context.setFillColor(CGColor(srgbRed: r, green: g, blue: b, alpha: 1))
+            context.fill(CGRect(x: x, y: y, width: 2, height: 2))
+        }
+    }
+    let image = context.makeImage()!
+    let output = NSMutableData()
+    let destination = CGImageDestinationCreateWithData(output, UTType.png.identifier as CFString, 1, nil)!
+    CGImageDestinationAddImage(destination, image, nil)
+    CGImageDestinationFinalize(destination)
+    return output as Data
+}
+
+/// True iff `data` is a real AVIF: an ISOBMFF `ftyp` box whose MAJOR brand is
+/// avif/avis. Deliberately ignores the compatible-brand list — HEIC also lists
+/// mif1/miaf there, so accepting those would let a silent HEIC/JPEG fallback
+/// pass and defeat the "AVIF everywhere" guarantee. Minds Data's slice offset.
+private func isAVIF(_ data: Data) -> Bool {
+    guard data.count >= 12 else { return false }
+    func byte(_ i: Int) -> UInt8 { data[data.startIndex + i] }
+    let box = (4...7).map(byte)
+    guard box == Array("ftyp".utf8) else { return false }
+    let major = (8...11).map(byte)
+    return major == Array("avif".utf8) || major == Array("avis".utf8)
+}
+
+@Suite("ImageCodec")
+struct ImageCodecTests {
+    @Test func readsPropertiesAndMime() {
+        let png = noisePNG(width: 100, height: 60)
+        let info = ImageCodec.properties(of: png)
+        #expect(info?.width == 100)
+        #expect(info?.height == 60)
+        #expect(info?.mime == "image/png")
+    }
+
+    @Test func prepareFullTranscodesToAVIF() {
+        // A small PNG is still transcoded to AVIF (no passthrough) and is a
+        // recognizable, decodable image of the same pixel size.
+        let png = noisePNG(width: 64, height: 64)
+        let prepared = try! #require(ImageCodec.prepareFull(from: png))
+        #expect(prepared.mime == "image/avif")
+        #expect(isAVIF(prepared.data)) // real AVIF bytes, not just the mime label
+        #expect(prepared.data != png)
+        #expect(prepared.width == 64)
+        #expect(prepared.height == 64)
+        #expect(ImageCodec.decode(prepared.data) != nil)
+    }
+
+    @Test func prepareFullHardCapsSizeToBudget() {
+        let big = noisePNG(width: 1200, height: 1200)
+        let prepared = try! #require(ImageCodec.prepareFull(from: big, maxBytes: 80_000, maxPixels: 256))
+        #expect(prepared.data.count <= 80_000)
+        #expect(prepared.mime == "image/avif")
+        #expect(isAVIF(prepared.data))
+        #expect(max(prepared.width, prepared.height) <= 256)
+    }
+
+    @Test func prepareFullDefaultsToPixelCeiling() {
+        // With no explicit maxPixels, a large source is bounded by the default
+        // ceiling (2048) — we don't ship pixels the receiver decodes away.
+        #expect(ImageCodec.maxFullPixels == 2048)
+        let big = noisePNG(width: 2400, height: 1000)
+        let prepared = try! #require(ImageCodec.prepareFull(from: big))
+        #expect(max(prepared.width, prepared.height) <= ImageCodec.maxFullPixels)
+    }
+
+    @Test func makeThumbnailFitsBudget() {
+        let big = noisePNG(width: 800, height: 800)
+        let thumb = try! #require(ImageCodec.makeThumbnail(from: big))
+        #expect(thumb.count <= ImageCodec.maxThumbBytes)
+        #expect(isAVIF(thumb)) // the inline thumb is AVIF too — one format
+        // And it stays decodable for display.
+        #expect(ImageCodec.decode(thumb) != nil)
+    }
+
+    @Test func makeThumbnailFitsTinyAlbumBudget() {
+        // An 8-image album gives each thumb only ~2 KiB — AVIF must still fit.
+        let big = noisePNG(width: 800, height: 800)
+        let thumb = try! #require(ImageCodec.makeThumbnail(from: big, maxBytes: 2_048))
+        #expect(thumb.count <= 2_048)
+        #expect(isAVIF(thumb))
+        #expect(ImageCodec.decode(thumb) != nil)
+    }
+
+    @Test func avifEncodingIsAvailableHere() {
+        // If this fails, the host can't encode AVIF and the whole feature
+        // silently no-ops — make that loud.
+        #expect(ImageCodec.isAVIFEncodingAvailable)
+    }
+
+    @Test func decodeCapsPixels() {
+        let png = noisePNG(width: 256, height: 256)
+        let image = try! #require(ImageCodec.decode(png, maxPixels: 32))
+        #expect(max(image.width, image.height) <= 32)
+    }
+
+    @Test func rejectsUndecodableInput() {
+        let garbage = Data([0x00, 0x01, 0x02, 0x03])
+        #expect(ImageCodec.properties(of: garbage) == nil)
+        #expect(ImageCodec.prepareFull(from: garbage) == nil)
+        #expect(ImageCodec.makeThumbnail(from: garbage) == nil)
+    }
+}

--- a/apps/macos/Tests/MunkelKitTests/ImagePayloadTests.swift
+++ b/apps/macos/Tests/MunkelKitTests/ImagePayloadTests.swift
@@ -1,0 +1,132 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import MunkelKit
+
+@Suite("MessageCrypto raw")
+struct MessageCryptoRawTests {
+    private let key = GroupKey(code: "blue-table-42").messageKey
+
+    @Test func sealRawRoundTrips() throws {
+        let plaintext = Data((0..<5000).map { UInt8($0 & 0xFF) })
+        let sealed = try MessageCrypto.sealRaw(plaintext, using: key)
+        #expect(sealed != plaintext)
+        #expect(try MessageCrypto.openRaw(sealed, using: key) == plaintext)
+    }
+
+    @Test func sealRawIsTheBytesBehindSeal() throws {
+        // seal == base64(sealRaw): both wrap AES.GCM combined output.
+        let plaintext = Data("hello".utf8)
+        let raw = try MessageCrypto.sealRaw(plaintext, using: key)
+        #expect(try MessageCrypto.open(raw.base64EncodedString(), using: key) == plaintext)
+    }
+
+    @Test func openRawRejectsTamperedBytes() throws {
+        var sealed = try MessageCrypto.sealRaw(Data("secret".utf8), using: key)
+        sealed[sealed.count - 1] ^= 0xFF // flip a tag bit
+        #expect(throws: (any Error).self) {
+            _ = try MessageCrypto.openRaw(sealed, using: key)
+        }
+    }
+}
+
+@Suite("AppPayload image")
+struct AppPayloadImageTests {
+    @Test func imageRoundTripsThroughJSON() throws {
+        let thumb = Data((0..<2048).map { UInt8(($0 * 7) & 0xFF) })
+        let item = ImageItem(r2Key: "Zm9vYmFy_key-01", mime: "image/png", width: 1920, height: 1080, byteLen: 524_288, thumb: thumb)
+        let payload = AppPayload.image(items: [item], caption: "deploy is green 🚀", sentAt: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let decoded = try AppPayload.decoded(from: payload.encoded())
+        guard case let .image(items, caption, sentAt) = decoded else {
+            Issue.record("expected .image, got \(decoded)")
+            return
+        }
+        #expect(items == [item])
+        #expect(caption == "deploy is green 🚀")
+        // ISO-8601 encoding is whole-second; allow that rounding.
+        #expect(abs(sentAt.timeIntervalSince1970 - 1_700_000_000) < 1)
+    }
+
+    @Test func imageAlbumClampsToMaxAndKeepsOrder() throws {
+        let items = (0..<15).map {
+            ImageItem(r2Key: "key-\($0)", mime: "image/jpeg", width: 10, height: 10, byteLen: 99, thumb: Data([UInt8($0)]))
+        }
+        let payload = AppPayload.image(items: items, caption: "", sentAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let decoded = try AppPayload.decoded(from: payload.encoded())
+        guard case let .image(decodedItems, _, _) = decoded else {
+            Issue.record("expected .image, got \(decoded)")
+            return
+        }
+        #expect(decodedItems.count == AppPayload.maxImagesPerMessage)
+        #expect(decodedItems.first?.r2Key == "key-0")
+        #expect(decodedItems.last?.r2Key == "key-\(AppPayload.maxImagesPerMessage - 1)")
+    }
+
+    @Test func imageWithoutCaptionDecodesToEmpty() throws {
+        // A pointer omitting `caption` (e.g. the TS dev client) must still
+        // decode, with an empty caption.
+        let json = Data(#"{"kind":"image","items":[{"r2Key":"abc1234567890def","mime":"image/png","width":1,"height":1,"byteLen":10,"thumb":""}],"sentAt":"2023-11-14T22:13:20Z"}"#.utf8)
+        let decoded = try AppPayload.decoded(from: json)
+        guard case let .image(items, caption, _) = decoded else {
+            Issue.record("expected .image, got \(decoded)")
+            return
+        }
+        #expect(items.count == 1)
+        #expect(caption == "")
+    }
+
+    @Test func unknownKindThrowsSoCallersCanDrop() {
+        let json = Data(#"{"kind":"future-thing","payload":"x"}"#.utf8)
+        #expect(throws: (any Error).self) {
+            _ = try AppPayload.decoded(from: json)
+        }
+    }
+}
+
+@Suite("BlobClient base URL")
+struct BlobClientURLTests {
+    @Test func derivesHTTPSFromWSS() {
+        let base = BlobClient.baseURL(fromRelay: URL(string: "wss://relay.munkel.app")!)
+        #expect(base?.absoluteString == "https://relay.munkel.app")
+    }
+
+    @Test func derivesHTTPFromWSAndStripsPathAndQuery() {
+        let base = BlobClient.baseURL(fromRelay: URL(string: "ws://127.0.0.1:8787/ws?group=abc")!)
+        #expect(base?.absoluteString == "http://127.0.0.1:8787")
+    }
+
+    @Test func rejectsNonWebSocketScheme() {
+        #expect(BlobClient.baseURL(fromRelay: URL(string: "ftp://example.com")!) == nil)
+    }
+}
+
+@Suite("AppPayload album budgets & relay cap")
+struct AppPayloadAlbumTests {
+    /// The relay's MAX_PAYLOAD_CHARS (apps/server/src/protocol.ts) — no shared
+    /// Swift constant exists, so it's pinned here.
+    private let maxPayloadChars = 48 * 1024
+    private let messageKey = GroupKey(code: "blue-table-42").messageKey
+
+    @Test func perThumbBudgetScalesAndFloors() {
+        #expect(AppPayload.perThumbBudget(imageCount: 1) == 16_384)
+        #expect(AppPayload.perThumbBudget(imageCount: 8) == 2_048)
+        #expect(AppPayload.perThumbBudget(imageCount: 20) == 1_200) // floor
+    }
+
+    @Test func fullEightImageAlbumStaysUnderRelayCap() throws {
+        // Saturate each per-image thumb budget and stress the metadata so this
+        // is a real ceiling test, not a soft sample.
+        let perThumb = AppPayload.perThumbBudget(imageCount: 8)
+        let items = (0..<8).map { i in
+            ImageItem(
+                r2Key: String(repeating: "k", count: 40), mime: "image/avif",
+                width: 4096, height: 4096, byteLen: 2_000_000,
+                thumb: Data(repeating: UInt8(i), count: perThumb)
+            )
+        }
+        let payload = AppPayload.image(items: items, caption: String(repeating: "x", count: 256), sentAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let sealed = try MessageCrypto.seal(payload.encoded(), using: messageKey)
+        #expect(sealed.count <= maxPayloadChars)
+    }
+}

--- a/apps/server/scripts/dev-image.ts
+++ b/apps/server/scripts/dev-image.ts
@@ -1,0 +1,230 @@
+// Dev helper: the image counterpart to dev-send.ts. Acts as a second member
+// that can SEND an image album (seal each → PUT to the R2 blob API → relay one
+// pointer) or LISTEN for one (receive pointer → GET each blob → decrypt → write
+// to disk). It reimplements the protocol in TypeScript, independently of
+// MunkelKit, so a successful round trip against the Swift app proves crypto +
+// blob + album-schema interop. NOTE: this harness uploads the RAW source bytes;
+// it is NOT an AVIF-fidelity tool. The real AVIF transcode lives in the Swift
+// app (ImageCodec); to test AVIF on the wire, send from the app/CLI and let
+// this client receive (the listener content-sniffs, so the mime is advisory).
+//
+// Usage:
+//   bun scripts/dev-image.ts <group-code> <sender> <path…> [--caption <text>] [--to <memberId>]
+//   bun scripts/dev-image.ts --listen <group-code> <member>
+//
+// Env: RELAY_URL (default ws://127.0.0.1:8787), MEMBER_ID.
+
+import { basename, extname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const MAX_IMAGES = 8; // mirrors AppPayload.maxImagesPerMessage
+// Mirrors AppPayload.albumThumbBudget / perThumbBudget (TS can't import Swift).
+const ALBUM_THUMB_BUDGET = 16_384;
+// 1×1 transparent PNG — a valid placeholder thumb when the real image is too
+// big to ride the relay frame inline (the app fetches the full one from R2).
+const TINY_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMCAQDcdwk0AAAAAElFTkSuQmCC';
+
+const listenMode = process.argv[2] === '--listen';
+const positional = process.argv.slice(listenMode ? 3 : 2);
+const [code, name = 'Alex'] = positional;
+
+// Everything after <sender> is paths, until --caption / --to flags.
+const paths: string[] = [];
+let caption = '';
+let directTo: string | undefined;
+for (let i = 2; i < positional.length; i++) {
+  const arg = positional[i]!;
+  if (arg === '--caption') {
+    caption = positional.slice(i + 1).filter((a) => a !== '--to' && a !== directTo).join(' ');
+    const toAt = positional.indexOf('--to', i);
+    if (toAt !== -1) directTo = positional[toAt + 1];
+    break;
+  }
+  if (arg === '--to') {
+    directTo = positional[i + 1];
+    i++;
+    continue;
+  }
+  paths.push(arg);
+}
+
+if (!code || (!listenMode && paths.length === 0)) {
+  process.stderr.write(
+    'usage: bun scripts/dev-image.ts <group-code> <sender> <path…> [--caption <text>] [--to <memberId>]\n' +
+      '       bun scripts/dev-image.ts --listen <group-code> <member>\n',
+  );
+  process.exit(1);
+}
+
+const encoder = new TextEncoder();
+const normalized = code.normalize('NFC').trim().toLowerCase();
+const salt = encoder.encode('munkel-v1');
+const ikm = await crypto.subtle.importKey('raw', encoder.encode(normalized), 'HKDF', false, ['deriveBits']);
+
+async function derive(info: string, bits: number): Promise<Uint8Array> {
+  const derived = await crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt, info: encoder.encode(info) },
+    ikm,
+    bits,
+  );
+  return new Uint8Array(derived);
+}
+
+const groupId = [...(await derive('group-id', 128))].map((b) => b.toString(16).padStart(2, '0')).join('');
+const key = await crypto.subtle.importKey(
+  'raw',
+  (await derive('message-key', 256)).buffer as ArrayBuffer,
+  'AES-GCM',
+  false,
+  ['encrypt', 'decrypt'],
+);
+
+/** Seal to raw combined bytes (nonce ‖ ciphertext ‖ tag) — MessageCrypto.sealRaw. */
+async function sealRaw(bytes: Uint8Array): Promise<Uint8Array> {
+  const nonce = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: nonce }, key, bytes));
+  const combined = new Uint8Array(nonce.length + ciphertext.length);
+  combined.set(nonce);
+  combined.set(ciphertext, nonce.length);
+  return combined;
+}
+
+/** Inverse of sealRaw — MessageCrypto.openRaw. */
+async function openRaw(combined: Uint8Array): Promise<Uint8Array> {
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: combined.subarray(0, 12) },
+    key,
+    combined.subarray(12),
+  );
+  return new Uint8Array(plaintext);
+}
+
+async function sealJSON(payload: Record<string, unknown>): Promise<string> {
+  return Buffer.from(await sealRaw(encoder.encode(JSON.stringify(payload)))).toString('base64');
+}
+
+async function unsealJSON(payload: string): Promise<Record<string, unknown>> {
+  return JSON.parse(new TextDecoder().decode(await openRaw(new Uint8Array(Buffer.from(payload, 'base64')))));
+}
+
+const relayURL = process.env.RELAY_URL ?? 'ws://127.0.0.1:8787';
+const memberId = process.env.MEMBER_ID ?? (listenMode ? 'dev-image-listener' : 'dev-image-sender');
+const blobBase = relayURL.replace(/^ws/, 'http');
+
+function mimeFor(path: string): string {
+  const ext = extname(path).toLowerCase();
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  if (ext === '.avif') return 'image/avif';
+  if (ext === '.gif') return 'image/gif';
+  return 'image/png';
+}
+
+function relayEndpoint(): string {
+  const endpoint = new URL('/ws', new URL(relayURL));
+  endpoint.searchParams.set('group', groupId);
+  endpoint.searchParams.set('member', memberId);
+  return endpoint.toString();
+}
+
+/** Detect the real format of received bytes — proves AVIF is on the wire. */
+function sniff(bytes: Uint8Array): string {
+  if (bytes.length >= 12) {
+    const ascii = (i: number, j: number) => Buffer.from(bytes.subarray(i, j)).toString('latin1');
+    if (ascii(4, 8) === 'ftyp') {
+      const major = ascii(8, 12);
+      return major === 'avif' || major === 'avis' ? 'AVIF' : `ftyp:${major}`;
+    }
+    if (bytes[0] === 0x89 && bytes[1] === 0x50) return 'PNG';
+    if (bytes[0] === 0xff && bytes[1] === 0xd8) return 'JPEG';
+  }
+  return 'unknown';
+}
+
+process.stdout.write(`groupId: ${groupId}\nblob API: ${blobBase}/blob/${groupId}/<key>\n`);
+
+const ws = new WebSocket(relayEndpoint());
+
+ws.onerror = () => {
+  process.stderr.write('websocket error — is the relay running? (cd apps/server && bun run dev)\n');
+  process.exit(1);
+};
+
+if (listenMode) {
+  ws.onmessage = async (event) => {
+    const frame = JSON.parse(String(event.data));
+    if (frame.type !== 'message') return;
+    let payload: Record<string, unknown>;
+    try {
+      payload = await unsealJSON(frame.payload);
+    } catch {
+      return;
+    }
+    if (payload.kind !== 'image') {
+      process.stdout.write(`<< ${payload.kind} from ${frame.from}\n`);
+      return;
+    }
+    const items = (payload.items as Array<{ r2Key: string; mime: string; byteLen: number; thumb: string }>) ?? [];
+    const cap = payload.caption ? ` caption="${payload.caption}"` : '';
+    process.stdout.write(`image album from ${frame.from}: ${items.length} image(s)${cap}\n`);
+    for (const item of items) {
+      const res = await fetch(`${blobBase}/blob/${groupId}/${item.r2Key}`);
+      if (!res.ok) {
+        process.stderr.write(`  blob GET failed for ${item.r2Key}: ${res.status}\n`);
+        continue;
+      }
+      const full = await openRaw(new Uint8Array(await res.arrayBuffer()));
+      const fmt = sniff(full);
+      const out = join(tmpdir(), `munkel-recv-${item.r2Key}.${fmt === 'AVIF' ? 'avif' : (item.mime.split('/')[1] ?? 'bin').replace('jpeg', 'jpg')}`);
+      await Bun.write(out, full);
+      process.stdout.write(`  ${fmt === 'AVIF' ? '✓ AVIF' : '⚠ ' + fmt}  ${full.byteLength} bytes → ${out}\n`);
+    }
+  };
+  ws.onopen = async () => {
+    ws.send(JSON.stringify({ type: 'send', payload: await sealJSON({ kind: 'profile', displayName: name }) }));
+    process.stdout.write(`listening as "${name}" (${memberId})… send an image to me from the app or another client\n`);
+    setInterval(() => ws.send(JSON.stringify({ type: 'ping' })), 30_000);
+  };
+} else {
+  ws.onopen = async () => {
+    ws.send(JSON.stringify({ type: 'send', payload: await sealJSON({ kind: 'profile', displayName: name }) }));
+
+    const selected = paths.slice(0, MAX_IMAGES);
+    const perThumb = Math.max(1_200, Math.floor(ALBUM_THUMB_BUDGET / selected.length));
+    const items: Array<Record<string, unknown>> = [];
+    for (const path of selected) {
+      const full = new Uint8Array(await Bun.file(path).arrayBuffer());
+      const sealed = await sealRaw(full);
+      const r2Key = crypto.randomUUID().replace(/-/g, '');
+      const put = await fetch(`${blobBase}/blob/${groupId}/${r2Key}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: sealed,
+      });
+      if (!put.ok) {
+        process.stderr.write(`blob PUT failed for ${basename(path)}: ${put.status}\n`);
+        process.exit(1);
+      }
+      // Reuse the file bytes as the inline thumb only when small enough to fit
+      // the shared budget; otherwise a 1×1 placeholder (full loads from R2).
+      const thumb = full.byteLength <= perThumb ? Buffer.from(full).toString('base64') : TINY_PNG_BASE64;
+      items.push({ r2Key, mime: mimeFor(path), width: 0, height: 0, byteLen: sealed.byteLength, thumb });
+      process.stdout.write(`uploaded ${sealed.byteLength} sealed bytes (${basename(path)}) → ${r2Key}\n`);
+    }
+
+    ws.send(
+      JSON.stringify({
+        type: 'send',
+        ...(directTo ? { to: directTo } : {}),
+        payload: await sealJSON({ kind: 'image', items, caption, sentAt: new Date().toISOString() }),
+      }),
+    );
+    process.stdout.write(
+      `sent album of ${items.length} as "${name}"${caption ? ` caption="${caption}"` : ''}${directTo ? ` → ${directTo}` : ''}\n`,
+    );
+    setTimeout(() => {
+      ws.close();
+      process.exit(0);
+    }, 800);
+  };
+}

--- a/apps/server/src/blob.ts
+++ b/apps/server/src/blob.ts
@@ -1,0 +1,153 @@
+import { Hono } from 'hono';
+import { GROUP_ID_REGEX } from './protocol';
+import { createLogger } from './lib/logger';
+
+/**
+ * R2-backed image blobs — the second persistence surface in an otherwise
+ * "stores nothing" system, added so full-resolution images (which never fit
+ * the 48 KiB relay frame) can travel out-of-band while the relay still only
+ * sees a tiny encrypted pointer (see ../../macos/.../AppPayload image kind).
+ *
+ * The Worker is deliberately blind: clients seal the image with the group
+ * `messageKey` (which never leaves a client) BEFORE upload, so R2 only ever
+ * holds opaque ciphertext. The object is namespaced by `groupId` and keyed by
+ * a client-generated random id; knowing both is the only access control —
+ * the same unguessable-id model the WebSocket relay uses.
+ *
+ * Ephemerality is preserved by a short logical TTL tied to how long a message
+ * stays alive in the recipient's notch: a blob older than {@link BLOB_TTL_MS}
+ * is treated as gone (404) and deleted on the next GET. A per-minute cron runs
+ * {@link sweepExpiredBlobs} to physically delete blobs that were never fetched,
+ * so nothing outlives the window (see index.ts / wrangler.toml).
+ */
+
+/** Client-generated per-image object id: URL-safe, 16–128 chars. */
+export const BLOB_KEY_REGEX = /^[A-Za-z0-9_-]{16,128}$/;
+
+/**
+ * Max ciphertext bytes accepted per blob: a ~2 MiB image plus the 28-byte
+ * AES-GCM envelope and headroom. Bounds an unauthenticated write (the group
+ * id is the only credential) to billable storage.
+ */
+export const MAX_BLOB_BYTES = 3 * 1024 * 1024;
+
+/**
+ * How long a message stays alive in the recipient's notch — the basis for the
+ * blob's lifetime (the blob need not outlive the message it points to). Mirrors
+ * NotchPresenter.historyWindow (60 s) on the macOS client.
+ */
+export const NOTCH_SURVIVAL_MS = 60 * 1000; // 60 s
+
+/**
+ * A blob older than this is expired (404 + delete). The notch-survival window
+ * plus a 10% grace, so an in-flight fetch right at the edge still succeeds.
+ */
+export const BLOB_TTL_MS = Math.round(NOTCH_SURVIVAL_MS * 1.1); // 66 s
+
+export interface BlobEnv {
+  BLOBS: R2Bucket;
+}
+
+const log = createLogger('blob');
+
+/** R2 object key: group-namespaced so one prefix holds a circle's blobs. */
+function objectKey(group: string, key: string): string {
+  return `${group}/${key}`;
+}
+
+/**
+ * Mounts `PUT /blob/:group/:key` and `GET /blob/:group/:key` on `app`. The
+ * routes store and serve opaque bytes; all crypto happens on the clients.
+ */
+export function registerBlobRoutes<E extends BlobEnv>(app: Hono<{ Bindings: E }>): void {
+  app.put('/blob/:group/:key', async (c) => {
+    const group = c.req.param('group');
+    const key = c.req.param('key');
+    if (!GROUP_ID_REGEX.test(group)) {
+      return c.text('Invalid group', 400);
+    }
+    if (!BLOB_KEY_REGEX.test(key)) {
+      return c.text('Invalid key', 400);
+    }
+
+    // Reject early on the declared length, then defensively on the real size
+    // (a client can lie about or omit Content-Length).
+    const declared = Number(c.req.header('Content-Length'));
+    if (Number.isFinite(declared) && declared > MAX_BLOB_BYTES) {
+      return c.text('Payload too large', 413);
+    }
+
+    const body = await c.req.arrayBuffer();
+    if (body.byteLength === 0) {
+      return c.text('Empty body', 400);
+    }
+    if (body.byteLength > MAX_BLOB_BYTES) {
+      return c.text('Payload too large', 413);
+    }
+
+    await c.env.BLOBS.put(objectKey(group, key), body, {
+      customMetadata: { uploadedAt: String(Date.now()) },
+    });
+    log.info('blob_put', { group, bytes: body.byteLength });
+    return c.body(null, 204);
+  });
+
+  app.get('/blob/:group/:key', async (c) => {
+    const group = c.req.param('group');
+    const key = c.req.param('key');
+    // Malformed ids can't address a real object — answer 404, not 400, so the
+    // route leaks nothing about what exists.
+    if (!GROUP_ID_REGEX.test(group) || !BLOB_KEY_REGEX.test(key)) {
+      return c.text('Not found', 404);
+    }
+
+    const id = objectKey(group, key);
+    const object = await c.env.BLOBS.get(id);
+    if (!object) {
+      return c.text('Not found', 404);
+    }
+
+    const uploadedAt = Number(object.customMetadata?.uploadedAt ?? '0');
+    if (uploadedAt > 0 && Date.now() - uploadedAt > BLOB_TTL_MS) {
+      await c.env.BLOBS.delete(id);
+      log.info('blob_expired', { group });
+      return c.text('Not found', 404);
+    }
+
+    const bytes = await object.arrayBuffer();
+    return c.body(bytes, 200, { 'Content-Type': 'application/octet-stream' });
+  });
+}
+
+/**
+ * Physically deletes blobs past {@link BLOB_TTL_MS}. The GET path already
+ * 404s + deletes expired blobs on access; this sweep covers blobs that were
+ * never fetched (e.g. all recipients were offline), so nothing outlives the
+ * window. Driven by a per-minute cron (see index.ts / wrangler.toml). Returns
+ * the number deleted.
+ */
+export async function sweepExpiredBlobs(bucket: R2Bucket): Promise<number> {
+  const now = Date.now();
+  let deleted = 0;
+  let cursor: string | undefined;
+  do {
+    // `include` is honored by the runtime; the bundled (non-experimental) R2
+    // types omit it, so assert past the excess-property check.
+    const listing = await bucket.list({ include: ['customMetadata'], cursor } as R2ListOptions);
+    const expiredKeys = listing.objects
+      .filter((object) => {
+        const uploadedAt = Number(object.customMetadata?.uploadedAt ?? '0');
+        return uploadedAt > 0 && now - uploadedAt > BLOB_TTL_MS;
+      })
+      .map((object) => object.key);
+    if (expiredKeys.length > 0) {
+      await bucket.delete(expiredKeys);
+      deleted += expiredKeys.length;
+    }
+    cursor = listing.truncated ? listing.cursor : undefined;
+  } while (cursor);
+  if (deleted > 0) {
+    log.info('blob_sweep', { deleted });
+  }
+  return deleted;
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,11 +1,13 @@
 import { Hono } from 'hono';
 import { GroupRoom } from './group-room';
 import { GROUP_ID_REGEX, MEMBER_ID_REGEX } from './protocol';
+import { registerBlobRoutes, sweepExpiredBlobs } from './blob';
+import type { BlobEnv } from './blob';
 import { createLogger } from './lib/logger';
 
 export { GroupRoom };
 
-interface Env {
+interface Env extends BlobEnv {
   GROUP_ROOM: DurableObjectNamespace<GroupRoom>;
 }
 
@@ -14,6 +16,10 @@ const log = createLogger('router');
 const app = new Hono<{ Bindings: Env }>();
 
 app.get('/health', (c) => c.text('ok'));
+
+// Out-of-band image blobs (R2): clients seal full-resolution images before
+// upload, so the relay frame only carries a small encrypted pointer.
+registerBlobRoutes(app);
 
 app.get('/ws', async (c) => {
   const group = c.req.query('group') ?? '';
@@ -40,4 +46,11 @@ app.get('/ws', async (c) => {
   return stub.fetch(new Request(c.req.raw.url, { headers }));
 });
 
-export default app;
+export default {
+  fetch: app.fetch,
+  // Per-minute cron: physically delete blobs past their TTL (the backstop for
+  // never-fetched objects). Configured in wrangler.toml [triggers].
+  async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(sweepExpiredBlobs(env.BLOBS));
+  },
+} satisfies ExportedHandler<Env>;

--- a/apps/server/src/protocol.ts
+++ b/apps/server/src/protocol.ts
@@ -61,6 +61,12 @@ import { z } from 'zod';
  *   joining and whenever a `peer-joined` arrives, so newcomers learn who
  *   everyone is. Sending `profile` without `avatar` clears it. Byte budgets
  *   live with the codec: AvatarCodec.swift (MunkelKit).
+ * - `image`:   `items` (1–8), shared `caption`, `sentAt`. Each item is
+ *   `{r2Key, mime, width, height, byteLen, thumb (inline AVIF, base64)}`.
+ *   The full-resolution image is AVIF, always sealed and PUT to R2 (blob.ts);
+ *   only the pointer + a tiny inline AVIF thumbnail are relayed, and the full
+ *   image is fetched from R2 on demand. Byte budgets live with the codec:
+ *   ImageCodec.swift (MunkelKit).
  *
  * Reference implementations: AppPayload.swift and ../scripts/dev-send.ts.
  *

--- a/apps/server/test/blob.test.ts
+++ b/apps/server/test/blob.test.ts
@@ -1,0 +1,129 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { BLOB_TTL_MS, MAX_BLOB_BYTES, registerBlobRoutes, sweepExpiredBlobs } from '../src/blob';
+import type { BlobEnv } from '../src/blob';
+
+/**
+ * In-memory stand-in for the bits of R2Bucket the blob routes + sweep use
+ * (put/get/delete/list + customMetadata). Exposes its store so a test can age
+ * an object to exercise the TTL path.
+ */
+class FakeBucket {
+  readonly store = new Map<string, { bytes: Uint8Array; customMetadata?: Record<string, string> }>();
+
+  async put(key: string, value: ArrayBuffer, opts?: { customMetadata?: Record<string, string> }) {
+    this.store.set(key, { bytes: new Uint8Array(value), customMetadata: opts?.customMetadata });
+  }
+
+  async get(key: string) {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    return {
+      customMetadata: entry.customMetadata,
+      arrayBuffer: async () => entry.bytes.buffer.slice(entry.bytes.byteOffset, entry.bytes.byteOffset + entry.bytes.byteLength),
+    };
+  }
+
+  async delete(key: string | string[]) {
+    for (const k of Array.isArray(key) ? key : [key]) this.store.delete(k);
+  }
+
+  async list(_opts?: { include?: string[]; cursor?: string }) {
+    const objects = [...this.store.entries()].map(([key, entry]) => ({ key, customMetadata: entry.customMetadata }));
+    return { objects, truncated: false as const, cursor: undefined };
+  }
+}
+
+const GROUP = 'a'.repeat(32);
+const KEY = 'abcdefghijklmnop'; // 16 chars, passes BLOB_KEY_REGEX
+const PATH = `/blob/${GROUP}/${KEY}`;
+
+function makeApp(bucket: FakeBucket) {
+  const app = new Hono<{ Bindings: BlobEnv }>();
+  registerBlobRoutes(app);
+  return { app, env: { BLOBS: bucket } as unknown as BlobEnv };
+}
+
+describe('blob routes', () => {
+  let bucket: FakeBucket;
+  let app: Hono<{ Bindings: BlobEnv }>;
+  let env: BlobEnv;
+
+  beforeEach(() => {
+    bucket = new FakeBucket();
+    ({ app, env } = makeApp(bucket));
+  });
+
+  it('round-trips an uploaded blob', async () => {
+    const body = new Uint8Array([1, 2, 3, 4, 5]);
+    const put = await app.request(PATH, { method: 'PUT', body }, env);
+    expect(put.status).toBe(204);
+
+    const get = await app.request(PATH, {}, env);
+    expect(get.status).toBe(200);
+    expect(get.headers.get('Content-Type')).toBe('application/octet-stream');
+    expect(new Uint8Array(await get.arrayBuffer())).toEqual(body);
+  });
+
+  it('404s an unknown blob', async () => {
+    const get = await app.request(PATH, {}, env);
+    expect(get.status).toBe(404);
+  });
+
+  it('rejects an invalid group', async () => {
+    const put = await app.request(`/blob/NOTHEX/${KEY}`, { method: 'PUT', body: new Uint8Array([1]) }, env);
+    expect(put.status).toBe(400);
+  });
+
+  it('rejects an invalid key', async () => {
+    const put = await app.request(`/blob/${GROUP}/short`, { method: 'PUT', body: new Uint8Array([1]) }, env);
+    expect(put.status).toBe(400);
+  });
+
+  it('rejects an empty body', async () => {
+    const put = await app.request(PATH, { method: 'PUT', body: new Uint8Array([]) }, env);
+    expect(put.status).toBe(400);
+  });
+
+  it('rejects an oversized declared Content-Length', async () => {
+    const put = await app.request(
+      PATH,
+      { method: 'PUT', body: new Uint8Array([1]), headers: { 'Content-Length': String(MAX_BLOB_BYTES + 1) } },
+      env,
+    );
+    expect(put.status).toBe(413);
+  });
+
+  it('rejects a body over the byte cap', async () => {
+    const big = new Uint8Array(MAX_BLOB_BYTES + 1);
+    const put = await app.request(PATH, { method: 'PUT', body: big }, env);
+    expect(put.status).toBe(413);
+  });
+
+  it('expires and deletes a blob past the TTL on GET', async () => {
+    await app.request(PATH, { method: 'PUT', body: new Uint8Array([9, 9, 9]) }, env);
+
+    // Age the stored object beyond the logical TTL.
+    const entry = bucket.store.get(`${GROUP}/${KEY}`)!;
+    entry.customMetadata = { uploadedAt: String(Date.now() - BLOB_TTL_MS - 1000) };
+
+    const get = await app.request(PATH, {}, env);
+    expect(get.status).toBe(404);
+    expect(bucket.store.has(`${GROUP}/${KEY}`)).toBe(false);
+  });
+
+  it('sweep deletes expired blobs but keeps fresh ones', async () => {
+    await app.request(PATH, { method: 'PUT', body: new Uint8Array([1]) }, env);
+    await app.request(`/blob/${GROUP}/freshkey123456789`, { method: 'PUT', body: new Uint8Array([2]) }, env);
+
+    // Age only the first object past the TTL.
+    bucket.store.get(`${GROUP}/${KEY}`)!.customMetadata = {
+      uploadedAt: String(Date.now() - BLOB_TTL_MS - 1000),
+    };
+
+    const deleted = await sweepExpiredBlobs(bucket as unknown as R2Bucket);
+    expect(deleted).toBe(1);
+    expect(bucket.store.has(`${GROUP}/${KEY}`)).toBe(false);
+    expect(bucket.store.has(`${GROUP}/freshkey123456789`)).toBe(true);
+  });
+});

--- a/apps/server/wrangler.toml
+++ b/apps/server/wrangler.toml
@@ -11,6 +11,20 @@ routes = [
 name = "GROUP_ROOM"
 class_name = "GroupRoom"
 
+# Out-of-band image blobs. Clients seal images with the group key before
+# upload, so this bucket only ever holds opaque ciphertext (see src/blob.ts).
+# `wrangler dev` simulates the bucket locally; production needs it created once:
+#   wrangler r2 bucket create munkel-blobs
+# Ephemerality: a ~66-second logical TTL (notch survival + 10%) is enforced on
+# GET, and the cron below physically sweeps expired blobs (src/blob.ts).
+[[r2_buckets]]
+binding = "BLOBS"
+bucket_name = "munkel-blobs"
+
+# Per-minute sweep of expired blobs (the backstop for never-fetched objects).
+[triggers]
+crons = ["* * * * *"]
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["GroupRoom"]


### PR DESCRIPTION
## Summary

Adds image sharing to Munkel: send **1–8 images as one album** with an optional caption. All sources transcode to **AVIF** client-side and travel over R2 as opaque ciphertext; the relay only carries a small pointer with a tiny inline AVIF preview, and the full image lazy-loads from R2 on expand — keeping the notch snappy while staying ephemeral.

## How it works

- **AVIF everywhere** — every source (PNG/JPEG/…) transcodes to AVIF via ImageIO, hard-capped at **2 MB / 2048 px**. The inline thumbnail is also AVIF (no separate JPEG preview).
- **Always R2** — each image is sealed with the group key and **always** uploaded to R2; the relay never carries full image bytes. The pointer rides one frame with a shared **16 KiB** inline-thumbnail budget (`16384 / count`), so even an 8-image album stays under the 48 KiB payload cap.
- **Ephemeral by design** — blobs get a **~66 s logical TTL** (notch survival 60 s + 10 %) enforced on GET, plus a **per-minute cron** that sweeps never-fetched blobs. Bucket is private; access only through the Worker binding.

## Entry points

- **Command palette** — `⌘V` attaches the clipboard image; the paperclip opens a file picker (Slack-style, multi-select).
- **Menu-bar input** — `⌘V` attaches the clipboard image; placeholder stays "Message Everyone".
- **CLI** — `munkel image <recipient> <path…> [--caption <text>]`.

## Components

- **Server** (`apps/server`): `PUT/GET /blob/:group/:key` with TTL-on-GET + delete, `sweepExpiredBlobs` cron, `[[r2_buckets]]` binding + `[triggers]` in `wrangler.toml`.
- **MunkelKit**: `ImageCodec` (AVIF transcode + thumbnail, decompression-bomb-safe decode), `BlobClient` (URLSession PUT/GET), `MessageCrypto.sealRaw/openRaw` (raw bytes, no base64 tax), `AppPayload.image` album case.
- **App**: album grid + teaser thumbnail strip, lazy per-cell R2 load, clipboard/file attachment UI, programmatic Edit menu so `⌘V` routes in an accessory app.

## Cloudflare / deploy

- R2 bucket **`munkel-blobs`** is already created on the `limehq` account (private, Standard class).
- The CI deploy token (`CLOUDFLARE_API_TOKEN`) already carries **Workers R2 Storage: Edit** — verified.
- Merging to `main` auto-deploys via `deploy-server.yml`; the R2 binding, cron, and `relay.munkel.app` domain all apply from `wrangler.toml`.
- README updated with the one-time R2 setup so a fresh environment isn't missing the bucket/permission.

## Test plan

- [x] `swift build` (whole macOS package) — compiles after rebasing onto current `main`
- [x] Swift unit tests — **60 passed** (ImageCodec AVIF transcode/thumbnail budgets, AppPayload album coding + relay-cap, BlobClient URL derivation, sealRaw/openRaw round-trip)
- [x] Server tests — **31 passed** (blob PUT/GET, size cap, TTL expiry, cron sweep)
- [x] CLI tests — **21 passed** (`image` arg parsing, multi-path, `--caption`)
- [x] Server typecheck (`tsc --noEmit`) clean
- [x] Live end-to-end against a local `wrangler dev` relay + R2: app → R2 → TS dev client receives and identifies AVIF on the wire (`ftypavif`)
- [ ] Post-merge: confirm `deploy-server.yml` ships the relay with the R2 binding + cron

## Notes

- Rebased onto `main` (`623584b`); resolved one conflict in `MessageNotchContainer.swift` to keep both this album rendering and the recently merged notch-history-copy / lock-globe-teaser features.
