### PR TITLE
Make the landing notch demo pixel-perfect to the macOS app

### DIFF
--- a/apps/landing/src/components/sections/hero.tsx
+++ b/apps/landing/src/components/sections/hero.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import { Check, ChevronDown, Copy, Download, Wifi } from 'lucide-react'
+import type { CSSProperties, SVGProps } from 'react'
+import { Check, ChevronDown, Copy, Download, Globe, Wifi } from 'lucide-react'
 import { motion, useMotionValueEvent, useReducedMotion, useScroll, useTransform } from 'motion/react'
 
 import { Button } from '@/components/ui/button'
@@ -8,16 +9,84 @@ import { DOWNLOAD_URL, GITHUB_URL } from '@/lib/constants'
 import { easeInOutQuad } from '@/lib/motion'
 import { sleep } from '@/lib/utils'
 
-const MESSAGES = [
-  { name: 'Alex', avatar: '/avatars/01.png', text: 'coffee?' },
-  { name: 'Sam', avatar: '/avatars/02.png', text: 'on my way' },
-  { name: 'Taylor', avatar: '/avatars/03.png', text: 'deploy is live, go look' },
-  { name: 'Morgan', avatar: '/avatars/05.png', text: 'same table as last time' },
+type Msg = {
+  name: string
+  text: string
+  /** Lock (private to you) vs globe (the whole circle saw it). */
+  direct: boolean
+  /** Circle the message came from — shown in the expanded header. */
+  circle: string
+  /** Stable per-circle dot color, mirroring the app's groupColor. */
+  color: string
+}
+
+// Circle dot colors are the app's groupPalette (system colors, dark variants),
+// assigned by join order: blue, purple, pink, teal, …
+const MESSAGES: Msg[] = [
+  { name: 'Alex', text: 'coffee?', direct: true, circle: 'inner-circle', color: '#0a84ff' },
+  { name: 'Sam', text: 'on my way', direct: false, circle: 'roomies', color: '#bf5af2' },
+  { name: 'Taylor', text: 'deploy is live, go look', direct: false, circle: 'eng', color: '#ff375f' },
+  { name: 'Morgan', text: 'same table as last time', direct: true, circle: 'lunch-crew', color: '#40c8e0' },
 ]
 
 // Stage progress at which the notch whispers — well into the zoom, so the
 // MacBook has visibly zoomed toward the notch before it triggers.
 const DOCK_AT = 0.78
+
+/** Filled padlock, matching the app's SF Symbol `lock.fill` (lucide ships only
+ *  an outline Lock). Globe stays the outline lucide icon, as in the app. */
+function LockFill(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden {...props}>
+      <path d="M8 11V8a4 4 0 0 1 8 0v3" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" />
+      <rect x="5" y="10.5" width="14" height="10" rx="2.6" fill="currentColor" />
+    </svg>
+  )
+}
+
+// macOS-style avatar for users without a photo — a 1:1 port of the app's
+// AvatarView: an initial on a gradient circle, the gradient picked
+// deterministically per name so a sender keeps a stable color.
+const AVATAR_PALETTES: [string, string][] = [
+  ['#f56b6b', '#d93069'],
+  ['#5ca6fa', '#3857eb'],
+  ['#66d99e', '#1a9475'],
+  ['#fab84f', '#eb6b2e'],
+  ['#bf85fa', '#7a40e0'],
+  ['#57d6db', '#2980b8'],
+]
+
+/** FNV-1a over the name (UInt64, matching AvatarView.palette(for:)), so the
+ *  color a sender gets here is the exact one the app would assign. */
+function avatarPalette(name: string): [string, string] {
+  let hash = 0xcbf29ce484222325n
+  const mask = 0xffffffffffffffffn
+  for (const byte of new TextEncoder().encode(name)) {
+    hash ^= BigInt(byte)
+    hash = (hash * 0x100000001b3n) & mask
+  }
+  return AVATAR_PALETTES[Number(hash % BigInt(AVATAR_PALETTES.length))]
+}
+
+/** First letters of up to two words, uppercased — like the app. */
+function avatarInitials(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0] ?? '')
+    .join('')
+    .toUpperCase()
+}
+
+function Avatar({ name, className }: { name: string; className?: string }) {
+  const [c1, c2] = avatarPalette(name)
+  return (
+    <span className={className} style={{ backgroundImage: `linear-gradient(to bottom right, ${c1}, ${c2})` }}>
+      {avatarInitials(name)}
+    </span>
+  )
+}
 
 /** Hero: pinned scroll stage (Motion useScroll/useTransform) + notch whisper demo. */
 export function Hero() {
@@ -35,15 +104,15 @@ export function Hero() {
   const wrapRef = useRef<HTMLDivElement>(null)
   const macRef = useRef<HTMLDivElement>(null)
   const notchRef = useRef<HTMLDivElement>(null)
-  const msgRef = useRef<HTMLDivElement>(null)
-  const avatarRef = useRef<HTMLImageElement>(null)
   const demoHintRef = useRef<HTMLDivElement>(null)
 
   const [clock, setClock] = useState('Thu 9:41')
   const [msgCopied, setMsgCopied] = useState(false)
+  const [copiedRow, setCopiedRow] = useState<number | null>(null)
   const [teaserOpen, setTeaserOpen] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+  const [msgIdx, setMsgIdx] = useState(0)
   const hoveredRef = useRef(false)
-  const msgIdxRef = useRef(0)
   const dockedRef = useRef(false)
 
   // Scroll progress over the 220vh pinned stage: 0 when its top hits the viewport
@@ -124,6 +193,7 @@ export function Hero() {
     } else if (p < DOCK_AT && dockedRef.current) {
       dockedRef.current = false
       setTeaserOpen(false)
+      setExpanded(false)
       demoHintRef.current?.classList.remove('show')
     }
   })
@@ -136,11 +206,15 @@ export function Hero() {
     if (!window.matchMedia('(hover: hover)').matches) return
     const onEnter = () => {
       hoveredRef.current = true
+      // Hover swells the docked teaser into the full message card — like the
+      // real notch. Hovering the closed pill (pre-dock) does nothing.
+      if (dockedRef.current) setExpanded(true)
       const cap = demoHintRef.current
       if (cap?.classList.contains('show')) cap.classList.add('off')
     }
     const onLeave = () => {
       hoveredRef.current = false
+      setExpanded(false)
     }
     root.addEventListener('mouseenter', onEnter)
     root.addEventListener('mouseleave', onLeave)
@@ -150,64 +224,52 @@ export function Hero() {
     }
   }, [])
 
-  // Message rotation — runs only while the notch is open. The effect cleanup
-  // guarantees exactly one live loop (it replaces the old session-token machinery):
-  // a close/reopen tears down the previous loop before the next mounts.
+  // Message rotation — advances the current message only while the notch is
+  // docked, pausing while hovered (the expanded card freezes on whatever you're
+  // reading). The effect cleanup guarantees exactly one live loop: a
+  // close/reopen tears down the previous loop before the next mounts. Each
+  // message cross-fades in via CSS keyed on the index (see `.nt-fade`).
   useEffect(() => {
     if (!teaserOpen || reduce) return
-    const elMsg = msgRef.current
-    const elAvatar = avatarRef.current
-    if (!elMsg || !elAvatar) return
-
     let alive = true
     const dwell = window.matchMedia('(hover: hover)').matches ? 3400 : 5000
-
-    const first = MESSAGES[msgIdxRef.current % MESSAGES.length]
-    elMsg.textContent = first.text
-    elAvatar.src = first.avatar
-    msgIdxRef.current++
-
     void (async () => {
       while (alive) {
         await sleep(dwell)
         while (hoveredRef.current && alive) await sleep(300)
         if (!alive) break
-        const next = MESSAGES[msgIdxRef.current % MESSAGES.length]
-        msgIdxRef.current++
-        elMsg.style.transition = 'opacity 0.18s ease'
-        elAvatar.style.transition = 'opacity 0.18s ease'
-        elMsg.style.opacity = '0'
-        elAvatar.style.opacity = '0'
-        await sleep(200)
-        if (!alive) break
-        elMsg.textContent = next.text
-        elAvatar.src = next.avatar
-        elMsg.style.opacity = '1'
-        elAvatar.style.opacity = '1'
-        await sleep(220)
-        if (!alive) break
-        elMsg.style.transition = ''
-        elAvatar.style.transition = ''
-        elMsg.style.opacity = ''
-        elAvatar.style.opacity = ''
+        setMsgIdx((i) => (i + 1) % MESSAGES.length)
       }
     })()
-
     return () => {
       alive = false
-      elMsg.style.transition = ''
-      elAvatar.style.transition = ''
-      elMsg.style.opacity = ''
-      elAvatar.style.opacity = ''
     }
   }, [teaserOpen, reduce])
 
-  const copyMessage = () => {
-    const text = msgRef.current?.textContent ?? ''
+  const copyText = (text: string) => {
     if (navigator.clipboard) navigator.clipboard.writeText(text).catch(() => {})
+  }
+  const copyMessage = () => {
+    copyText(MESSAGES[msgIdx].text)
     setMsgCopied(true)
     setTimeout(() => setMsgCopied(false), 1400)
   }
+  const copyRow = (idx: number, text: string) => {
+    copyText(text)
+    setCopiedRow(idx)
+    setTimeout(() => setCopiedRow((r) => (r === idx ? null : r)), 1400)
+  }
+
+  const msg = MESSAGES[msgIdx]
+  const ChanIcon = msg.direct ? LockFill : Globe
+  // The pulse-ring color = the avatar's first palette color, like the app.
+  const ring = avatarPalette(msg.name)[0]
+  // The two most recently shown messages, newest first — the "last minute"
+  // backlog the real notch stacks under the current one.
+  const history = [1, 2].map((back) => {
+    const i = (msgIdx - back + MESSAGES.length) % MESSAGES.length
+    return { ...MESSAGES[i], idx: i }
+  })
 
   return (
     <header className="hero">
@@ -277,27 +339,120 @@ export function Hero() {
                     </div>
                   </div>
                   <div
-                    className={`mb-notch${teaserOpen ? ' teaser' : ''}`}
+                    className={`mb-notch${teaserOpen ? ' docked' : ''}${
+                      expanded ? ' expanded' : ''
+                    }`}
                     ref={notchRef}
-                    onClick={() => {
-                      // In the page demo a click copies the message (the real
-                      // notch opens an inline reply on click).
-                      if (teaserOpen) copyMessage()
-                    }}
                   >
                     <span className="notch-cam"></span>
-                    <img className="mbn-avatar" ref={avatarRef} src="/avatars/01.png" alt="" />
-                    <button
-                      className={`mbn-copy${msgCopied ? ' copied' : ''}`}
-                      onClick={copyMessage}
-                      aria-label="Copy message"
-                    >
-                      <Copy className="ic-copy" strokeWidth={2} aria-hidden />
-                      <Check className="ic-check" strokeWidth={2.5} aria-hidden />
-                    </button>
-                    <div className="mbn-body">
-                      <div className="mbn-msg" ref={msgRef}>
-                        coffee?
+
+                    {/* Compact teaser — what the notch shows at rest: avatar and
+                        copy tucked into the menu-bar strip flanking the camera,
+                        with the one-line message running below it. */}
+                    <div className="nt">
+                      {/* Pulse ring behind the avatar (the app's CompactAvatarView
+                          "ping"), in the sender's color. Rendered only while docked
+                          and keyed on the message, so it fires when the notch opens
+                          and replays on each rotation — not silently on page load. */}
+                      {teaserOpen && (
+                        <span
+                          className="nt-ping"
+                          key={`p${msgIdx}`}
+                          style={{ '--ring': ring } as CSSProperties}
+                          aria-hidden
+                        />
+                      )}
+                      <Avatar key={`a${msgIdx}`} name={msg.name} className="nt-avatar nt-fade" />
+                      <button
+                        className={`nt-copy${msgCopied ? ' copied' : ''}`}
+                        onClick={copyMessage}
+                        aria-label="Copy message"
+                      >
+                        <Copy className="ic-copy" strokeWidth={2} aria-hidden />
+                        <Check className="ic-check" strokeWidth={2.5} aria-hidden />
+                      </button>
+                      {/* Channel icon leads the line (and stays put while the text
+                          tickers), vertically centered with the single-line text. */}
+                      <div className="nt-line nt-fade" key={`t${msgIdx}`}>
+                        <ChanIcon
+                          className={`nt-chan${msg.direct ? '' : ' is-globe'}`}
+                          strokeWidth={1.8}
+                          aria-hidden
+                        />
+                        <span className="nt-text">{msg.text}</span>
+                      </div>
+                    </div>
+
+                    {/* Expanded card — the full message view the real notch
+                        swells into on hover: avatar, sender + circle header,
+                        message, reply field, and the last-minute history. */}
+                    <div className="nx" aria-hidden={!expanded}>
+                      <div className="nx-msg">
+                        <Avatar name={msg.name} className="nx-avatar" />
+                        <div className="nx-col">
+                          <div className="nx-head">
+                            <span className="nx-sender">{msg.name}</span>
+                            <ChanIcon
+                              className={`nx-chan${msg.direct ? '' : ' is-globe'}`}
+                              strokeWidth={1.8}
+                              aria-hidden
+                            />
+                            <span className="nx-sep">·</span>
+                            <span className="nx-cdot" style={{ background: msg.color }} />
+                            <span className="nx-circle">{msg.circle}</span>
+                          </div>
+                          <div className="nx-text">{msg.text}</div>
+                        </div>
+                        <button
+                          className={`nx-copy${msgCopied ? ' copied' : ''}`}
+                          onClick={copyMessage}
+                          aria-label="Copy message"
+                        >
+                          <Copy className="ic-copy" strokeWidth={2} aria-hidden />
+                          <Check className="ic-check" strokeWidth={2.5} aria-hidden />
+                        </button>
+                      </div>
+
+                      <div className="nx-reply">
+                        <span className="nx-chip">
+                          <ChanIcon
+                            className={msg.direct ? undefined : 'is-globe'}
+                            strokeWidth={2}
+                            aria-hidden
+                          />
+                        </span>
+                        <div className="nx-input">
+                          {msg.direct ? `Private to ${msg.name}…` : 'Reply to all…'}
+                        </div>
+                      </div>
+
+                      <div className="nx-history">
+                        <div className="nx-rule" />
+                        {history.map((h) => {
+                          const RowIcon = h.direct ? LockFill : Globe
+                          return (
+                            <button
+                              key={h.idx}
+                              className={`nx-row${copiedRow === h.idx ? ' copied' : ''}`}
+                              onClick={() => copyRow(h.idx, h.text)}
+                            >
+                              <span className="nx-rhead">
+                                <span className="nx-rdot" style={{ background: h.color }} />
+                                <span className="nx-rsender">{h.name}</span>
+                                <RowIcon
+                                  className={`nx-rchan${h.direct ? '' : ' is-globe'}`}
+                                  strokeWidth={1.8}
+                                  aria-hidden
+                                />
+                              </span>
+                              <span className="nx-rtext">{h.text}</span>
+                              <span className="nx-rcopy">
+                                <Copy className="ic-copy" strokeWidth={2} aria-hidden />
+                                <Check className="ic-check" strokeWidth={2.5} aria-hidden />
+                              </span>
+                            </button>
+                          )
+                        })}
                       </div>
                     </div>
                   </div>

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -340,60 +340,187 @@ nav.floating .nav-inner {
   position: absolute; top: 0; left: 50%; transform: translateX(-50%);
   width: 128px; height: 25px;
   background: #000;
-  border-radius: 0 0 9px 9px;
   z-index: 5;
-  transition: width 0.45s cubic-bezier(0.32, 1.4, 0.46, 1), height 0.45s cubic-bezier(0.32, 1.4, 0.46, 1), border-radius 0.3s ease, box-shadow 0.3s ease;
+  /* The real NotchShape, not a rounded rectangle: concave top corners that
+     blend into the menu bar, side walls inset by the top radius, convex bottom
+     corners. Built as an animatable clip-path so the demo's silhouette is
+     point-for-point the app's (top radius 15, bottom radius 20 when docked). */
+  clip-path: path('M0 0 Q8 0 8 8 L8 16 Q8 25 17 25 L111 25 Q120 25 120 16 L120 8 Q120 0 128 0 Z');
+  /* Clean ease-out, no overshoot — mirrors the app's well-damped expand
+     spring(response 0.35, dampingFraction 0.75). The old bezier overshot ~40%
+     (the bounce); the real notch barely overshoots (~3%), so it reads linear. */
+  transition: width 0.42s cubic-bezier(0.33, 1, 0.68, 1), height 0.42s cubic-bezier(0.33, 1, 0.68, 1), clip-path 0.42s cubic-bezier(0.33, 1, 0.68, 1), filter 0.3s ease;
 }
-/* Fillet "ears" where the black shape meets the menu bar */
-.mb-notch::before, .mb-notch::after {
-  content: ""; position: absolute; top: 0; width: 10px; height: 10px;
-}
-.mb-notch::before { left: -10px; background: radial-gradient(circle at 0 100%, transparent 9.5px, #000 10px); }
-.mb-notch::after { right: -10px; background: radial-gradient(circle at 100% 100%, transparent 9.5px, #000 10px); }
-.mb-notch.teaser {
-  width: 260px; height: 56px; border-radius: 0 0 18px 18px;
-  box-shadow: 0 14px 40px -12px oklch(0 0 0 / 0.6), 0 4px calc(var(--glow) * 40px) color-mix(in oklab, var(--brand) 25%, transparent);
+
+/* Docked (teaser) and hover-expanded share one width (310pt = real shape):
+   hovering only grows the shape downward, like the real notch. All inner
+   metrics are 1:1 with the SwiftUI source (MessageNotchView / notchedTeaser),
+   so the demo matches the app point-for-point. The 32pt top strip is the
+   hardware-notch safe area the content sits below. The shadow is a drop-shadow
+   (not box-shadow, which clip-path would clip away), matching the app's
+   .shadow(color: .black.opacity(0.5), radius: 10). */
+.mb-notch.docked {
+  width: 310px; height: 58px;
+  clip-path: path('M0 0 Q15 0 15 15 L15 38 Q15 58 35 58 L275 58 Q295 58 295 38 L295 15 Q295 0 310 0 Z');
+  filter: drop-shadow(0 10px 16px oklch(0 0 0 / 0.5));
   cursor: pointer;
 }
-.mb-notch .notch-cam { top: 8px; width: 8px; height: 8px; }
-.mbn-avatar {
-  position: absolute; top: 3px; left: 13px;
-  width: 19px; height: 19px; border-radius: 50%; object-fit: cover; background: #222;
+.mb-notch.docked.expanded {
+  height: 180px;
+  clip-path: path('M0 0 Q15 0 15 15 L15 160 Q15 180 35 180 L275 180 Q295 180 295 160 L295 15 Q295 0 310 0 Z');
+}
+.mb-notch.docked .notch-cam { top: 11px; width: 7px; height: 7px; z-index: 3; }
+
+/* Both content layers fill the shape and clip to it, so the expanded card
+   reveals top-down as the shape grows instead of spilling past the black. */
+.nt, .nx {
+  position: absolute; inset: 0; overflow: hidden;
+  border-radius: 0 0 20px 20px;
   opacity: 0; visibility: hidden;
   transition: opacity 0.2s ease, visibility 0s linear 0.2s;
+  /* Native system font — on macOS these resolve to the SAME faces the app
+     renders (SF Pro / SF Pro Rounded / SF Mono), so the demo text is glyph-for-
+     glyph identical instead of Geist-shaped. */
+  font-family: system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
 }
-.mbn-copy {
-  position: absolute; top: 3px; right: 13px;
-  width: 19px; height: 19px; border-radius: 50%;
+.mb-notch.docked .nt { opacity: 1; visibility: visible; transition: opacity 0.25s ease 0.1s, visibility 0s; }
+.mb-notch.expanded .nt { opacity: 0; visibility: hidden; transition: opacity 0.12s ease, visibility 0s linear 0.12s; }
+.mb-notch.expanded .nx { opacity: 1; visibility: visible; transition: opacity 0.22s ease 0.08s, visibility 0s; }
+
+/* Fresh-message cross-fade, re-triggered by the React key on rotation. */
+.nt-fade { animation: nt-in 0.32s ease both; }
+@keyframes nt-in { from { opacity: 0 } to { opacity: 1 } }
+
+/* ----- Compact teaser (1:1 with notchedTeaser) ----- */
+/* Avatar (20) + copy (20) tuck into the 32pt strip, flush with the content's
+   leading/trailing edges (30pt insets); the one-line message runs below. */
+/* Avatar + ping share one position/size (via vars on .nt), so the pulse ring
+   can never drift off the avatar — including at the mobile scale. */
+.nt { --av-x: 30px; --av-y: 6px; --av-d: 20px; }
+.nt-avatar {
+  position: absolute; top: var(--av-y); left: var(--av-x); width: var(--av-d); height: var(--av-d);
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-family: ui-rounded, system-ui, sans-serif; font-weight: 700;
+  font-size: calc(var(--av-d) * 0.38); line-height: 1; color: #fff;
+}
+.nt-copy {
+  position: absolute; top: 6px; right: 30px; width: 20px; height: 20px; border-radius: 50%;
   display: inline-flex; align-items: center; justify-content: center;
-  border: none; padding: 0;
-  background: oklch(1 0 0 / 0.14); color: oklch(0.88 0 0);
-  opacity: 0; visibility: hidden;
-  transition: opacity 0.2s ease, visibility 0s linear 0.2s, background 0.15s;
+  border: none; padding: 0; cursor: pointer;
+  background: oklch(1 0 0 / 0.1); color: oklch(1 0 0 / 0.65);
+  transition: background 0.15s;
 }
-.mbn-copy:hover { background: oklch(1 0 0 / 0.22); }
-.mbn-copy svg.lucide { width: 10px; height: 10px; }
-.mbn-copy .ic-check { display: none; color: oklch(0.78 0.14 160); }
-.mbn-copy.copied .ic-copy { display: none; }
-.mbn-copy.copied .ic-check { display: block; }
-.mbn-body {
-  position: absolute; top: 25px; left: 13px; right: 13px;
-  text-align: left;
-  opacity: 0; visibility: hidden;
-  transition: opacity 0.2s ease, visibility 0s linear 0.2s;
-  overflow: hidden;
-}
-.mb-notch.teaser .mbn-avatar,
-.mb-notch.teaser .mbn-copy,
-.mb-notch.teaser .mbn-body {
-  opacity: 1; visibility: visible;
-  transition: opacity 0.25s ease 0.15s, visibility 0s;
-}
-.mbn-msg {
-  font-size: 13px; font-weight: 600; color: #fff;
+.nt-copy:hover { background: oklch(1 0 0 / 0.18); }
+/* Channel icon leads the line and is vertically centered with the single-line
+   text; it stays put (flex: none) so it's always visible as the text tickers. */
+.nt-line { position: absolute; top: 34px; left: 30px; right: 30px; display: flex; align-items: center; gap: 5px; }
+.nt-text {
+  flex: 0 1 auto; min-width: 0;
+  /* .rounded design in the app → SF Pro Rounded (ui-rounded on macOS). */
+  font-family: ui-rounded, system-ui, sans-serif;
+  font-size: 12px; font-weight: 500; line-height: 1.2;
+  color: oklch(1 0 0 / 0.85);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  margin-top: 4px; line-height: 1.35;
 }
+.nt-chan { flex: none; width: 11px; height: 11px; color: oklch(1 0 0 / 0.55); }
+.nt-chan.is-globe { width: 9.5px; height: 9.5px; }
+
+/* Pulse ring behind the avatar — the app's CompactAvatarView "ping": a 1px
+   stroke in the sender's color that scales out and fades once. */
+.nt-ping {
+  position: absolute; top: var(--av-y); left: var(--av-x); width: var(--av-d); height: var(--av-d);
+  border-radius: 50%; border: 1px solid var(--ring, #fff);
+  pointer-events: none;
+  animation: nt-ping 1s ease-out 0.55s both;
+}
+@keyframes nt-ping {
+  from { transform: scale(0.8); opacity: 0.9; }
+  to { transform: scale(1.6); opacity: 0; }
+}
+
+/* ----- Expanded card (1:1 with MessageNotchView + reply + history) ----- */
+.nx { display: flex; flex-direction: column; padding: 32px 30px 15px; gap: 5px; text-align: left; }
+.nx-msg { display: flex; align-items: flex-start; gap: 12px; padding: 4px 6px; }
+.nx-avatar {
+  flex: none; width: 34px; height: 34px;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-family: ui-rounded, system-ui, sans-serif; font-weight: 700;
+  font-size: 13px; line-height: 1; color: #fff;
+}
+.nx-col { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.nx-head { display: flex; align-items: center; gap: 4px; line-height: 1.1; color: oklch(1 0 0 / 0.55); }
+.nx-sender { font-size: 11px; font-weight: 600; }
+.nx-chan { flex: none; width: 10px; height: 10px; }
+.nx-chan.is-globe { width: 8.5px; height: 8.5px; }
+.nx-sep { font-size: 12px; }
+.nx-cdot { flex: none; width: 6px; height: 6px; border-radius: 50%; }
+.nx-circle {
+  /* .monospaced design in the app → SF Mono (ui-monospace on macOS). */
+  font-size: 10px; font-family: ui-monospace, monospace;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.nx-text { font-size: 14px; font-weight: 500; line-height: 1.2; color: #fff; }
+.nx-copy {
+  flex: none; margin-top: -2px; width: 20px; height: 20px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: none; padding: 0; cursor: pointer;
+  background: oklch(1 0 0 / 0.1); color: oklch(1 0 0 / 0.65);
+  transition: background 0.15s;
+}
+.nx-copy:hover { background: oklch(1 0 0 / 0.18); }
+
+/* Inline reply — channel chip + a placeholder field. */
+.nx-reply { display: flex; align-items: center; gap: 6px; padding: 0 6px 4px; }
+.nx-chip {
+  flex: none; width: 20px; height: 20px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: oklch(1 0 0 / 0.12); color: oklch(1 0 0 / 0.7);
+}
+.nx-chip svg { width: 12px; height: 12px; }
+.nx-chip svg.is-globe { width: 11px; height: 11px; }
+.nx-input {
+  flex: 1; min-width: 0;
+  padding: 5px 8px; border-radius: 7px;
+  background: oklch(1 0 0 / 0.12);
+  font-size: 13px; line-height: 1.2; color: oklch(1 0 0 / 0.7);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+/* History — last-minute backlog stacked under the current message. */
+.nx-history { display: flex; flex-direction: column; padding: 0 6px 6px; }
+.nx-rule { height: 1px; background: oklch(1 0 0 / 0.15); margin-bottom: 3px; }
+.nx-row {
+  display: flex; align-items: center; gap: 4px;
+  width: 100%; min-height: 20px; padding: 0;
+  border: none; background: none; cursor: pointer; text-align: left;
+}
+.nx-rhead { flex: none; display: flex; align-items: center; gap: 4px; }
+.nx-rdot { flex: none; width: 5px; height: 5px; border-radius: 50%; }
+.nx-rsender { font-size: 10px; font-weight: 600; color: oklch(1 0 0 / 0.4); }
+.nx-rchan { flex: none; width: 9px; height: 9px; color: oklch(1 0 0 / 0.3); }
+.nx-rchan.is-globe { width: 8px; height: 8px; }
+.nx-rtext {
+  flex: 0 1 auto; min-width: 0; margin-right: auto;
+  font-size: 11px; color: oklch(1 0 0 / 0.55);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.nx-rcopy {
+  flex: none; width: 20px; height: 20px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: oklch(1 0 0 / 0.1); color: oklch(1 0 0 / 0.65);
+  opacity: 0; transition: opacity 0.12s ease;
+}
+.nx-row:hover .nx-rcopy, .nx-row.copied .nx-rcopy { opacity: 1; }
+.nx-rcopy svg { width: 9px; height: 9px; }
+
+/* Shared copy ⇄ check glyph swap (CopyGlyph: doc.on.doc, size diameter*0.43). */
+.nt-copy svg.lucide, .nx-copy svg.lucide { width: 9px; height: 9px; }
+.nt-copy .ic-check, .nx-copy .ic-check, .nx-rcopy .ic-check { display: none; color: oklch(0.78 0.14 160); }
+.nt-copy.copied .ic-copy, .nx-copy.copied .ic-copy, .nx-row.copied .ic-copy { display: none; }
+.nt-copy.copied .ic-check, .nx-copy.copied .ic-check, .nx-row.copied .ic-check { display: block; }
 
 /* ---------- Buttons → shadcn <Button> (components/ui/button.tsx) ---------- */
 /* .btn / .btn-primary / .btn-outline are now CVA variants on <Button>; the
@@ -887,28 +1014,29 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0; }
   .hero-stage { height: 200vh; }
   .hero-copy { padding-top: 8vh; }
   .mockup-wrap { margin-top: 3rem; }
-  .mb-notch { width: 92px; height: 17px; border-radius: 0 0 6px 6px; }
-  .mb-notch .notch-cam { width: 5px; height: 5px; top: 6px; }
-  .mb-notch.teaser { width: 220px; height: 44px; }
-  .mbn-avatar { width: 13px; height: 13px; top: 2px; }
-  .mbn-copy { width: 13px; height: 13px; top: 2px; }
-  .mbn-copy svg.lucide { width: 8px; height: 8px; }
-  .mbn-body { top: 17px; }
-  .mbn-msg { font-size: 12px; }
-  .mb-menubar { height: 20px; font-size: 10px; }
+  /* The notch is internally 1:1 with the app (310pt etc.); on narrow viewports
+     scale the WHOLE notch down uniformly rather than hand-tuning each element —
+     so the ping ring, icon sizes and every spacing stay perfectly aligned. */
+  .mb-notch { transform: translateX(-50%) scale(0.75); transform-origin: top center; }
+  .mb-menubar { height: 19px; font-size: 10px; }
   .mb-menu span:not(.mb-app) { display: none; }
   .share-compare { grid-template-columns: 1fr; }
   section { padding: 5rem 0; }
   .section-head { margin-bottom: 3rem; }
 }
+/* Even narrower (phones): scale the notch down further so it doesn't dominate
+   the shrinking mockup. Same uniform transform — proportions stay intact. */
+@media (max-width: 600px) {
+  .mb-notch { transform: translateX(-50%) scale(0.58); }
+  .mb-menubar { height: 15px; }
+}
 @media (prefers-reduced-motion: reduce) {
   .pulse, .cursor { animation: none; }
   .mb-notch { transition: none; }
-  /* Static teaser (set by the director's reduced-motion branch): children
-     appear instantly, no fade-in. */
-  .mb-notch.teaser .mbn-avatar,
-  .mb-notch.teaser .mbn-copy,
-  .mb-notch.teaser .mbn-body { transition: none; }
+  /* Static teaser (set by the director's reduced-motion branch): content
+     appears instantly, no fade-in. */
+  .mb-notch.docked .nt, .mb-notch.expanded .nx { transition: none; }
+  .nt-fade { animation: none; }
   .macbook { transform: none !important; opacity: 1 !important; }
   .hero-stage { height: auto; }
   .hero-sticky { position: static; height: auto; overflow: visible; padding: 6rem 0; }

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -355,12 +355,14 @@ struct MessageNotchContainer: View {
     /// Text below the notch; avatar lifted into the strip left of the cutout,
     /// flush with the text's leading edge so the line starts right under it.
     private var notchedTeaser: some View {
-        HStack(alignment: .top, spacing: 6) {
-            TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
+        // The channel icon leads the line and is vertically centered with the
+        // single-line message; being outside the ticker window it stays put
+        // (always visible at the start) while the text scrolls.
+        HStack(spacing: 6) {
             Image(systemName: message.isDirect ? "lock.fill" : "globe")
                 .font(.system(size: 9))
                 .foregroundStyle(.white.opacity(0.55))
-                .padding(.top, 2)
+            TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
         }
         .padding(.top, 2)
         .padding(.bottom, -6)
@@ -377,10 +379,13 @@ struct MessageNotchContainer: View {
     private var fallbackTeaser: some View {
         HStack(spacing: 10) {
             CompactAvatarView(name: message.sender, avatarData: message.avatarData)
-            TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
-            Image(systemName: message.isDirect ? "lock.fill" : "globe")
-                .font(.system(size: 9))
-                .foregroundStyle(.white.opacity(0.55))
+            // Channel icon leads the message (mirrors notchedTeaser).
+            HStack(spacing: 6) {
+                Image(systemName: message.isDirect ? "lock.fill" : "globe")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.white.opacity(0.55))
+                TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
+            }
         }
         .padding(.vertical, 4)
         .background(AreaMarker { [weak model] in model?.teaserMarker = $0 })


### PR DESCRIPTION
## Why

The hero notch demo on the landing page didn't match how the notch actually looks in the app. This rebuilds it to be a faithful, pixel-level reproduction of the real SwiftUI notch — verified by rendering the actual `MessageNotchView` / `notchedTeaser` views to PNGs (`ImageRenderer`) and comparing side-by-side / by overlay.

## What

**Landing (`apps/landing`)**
- **Two faithful states with a hover morph:** compact teaser ↔ expanded card (message + reply field + history). All metrics are 1:1 with the SwiftUI source.
- **Real `NotchShape`** via an animatable `clip-path` (concave top corners, side walls inset by the top radius, convex bottom) instead of a rounded rectangle; shadow as `drop-shadow` to match the app's `.shadow(.black 0.5, radius 10)`.
- **Native system fonts** (`system-ui` / `ui-rounded` / `ui-monospace`) so on macOS the text renders in SF Pro / SF Pro Rounded / SF Mono — the same faces as the app.
- **macOS-style avatar** (initial on a gradient) ported 1:1 from `AvatarView` — same 6 palettes and FNV-1a name hash, so a sender gets the exact color the app assigns — plus the `CompactAvatarView` pulse ring ("ping").
- System group colors, filled `lock.fill` icon, thinner/smaller globe.
- **Bounce-free expand easing** matching the app's `spring(response 0.35, dampingFraction 0.75)` (was overshooting ~40%).
- Channel icon now leads the teaser line, vertically centered and always visible while the text tickers.
- Avatar and ping share CSS vars; narrow viewports scale the whole 1:1 notch uniformly (`transform: scale`) so the ping and every spacing stay proportional.

**App (`apps/macos`)**
- Mirror the teaser change in the product: the channel icon leads the message (vertically centered, always visible outside the ticker window) in both `notchedTeaser` and `fallbackTeaser`.

## Test plan
- [x] `apps/landing` `tsc --noEmit` + `vite build` green
- [x] `apps/macos` `swift build` green
- [x] Both notch states verified against ImageRenderer ground-truth (font, shape, colors, avatar, spacings)
- [x] Ping stays centered on the avatar across viewport widths (CDP-measured)
- [ ] Visual check of the live hero on `munkel.app` after deploy
- [ ] Run the macOS app and confirm the teaser leads with the channel icon on a real notch
