### PR TITLE
feat(landing): add Imprint, Privacy & Contact legal pages

### DIFF
--- a/apps/landing/src/components/legal/legal-header.tsx
+++ b/apps/landing/src/components/legal/legal-header.tsx
@@ -1,0 +1,21 @@
+import { Link } from '@tanstack/react-router'
+
+/**
+ * Slim standalone header for the legal/content pages. Reuses the exact
+ * `.wordmark` markup (dot + "munkel") so the brand matches the landing nav
+ * 1:1, but links HOME via the TanStack Router <Link> since it renders inside
+ * the router tree. It is NOT the bespoke landing <nav> — no hash anchors, no
+ * scroll/Motion machinery.
+ */
+export function LegalHeader() {
+  return (
+    <header className="legal-header">
+      <div className="container legal-header-inner">
+        <Link to="/" className="wordmark">
+          <span className="dot" />
+          munkel
+        </Link>
+      </div>
+    </header>
+  )
+}

--- a/apps/landing/src/components/legal/legal-page.tsx
+++ b/apps/landing/src/components/legal/legal-page.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react'
+
+import { LegalHeader } from './legal-header'
+import { SiteFooter } from '@/components/sections/site-footer'
+
+/**
+ * Shared layout wrapper for the legal/content pages (Imprint, Privacy,
+ * Contact). Renders the slim LegalHeader, a centered prose column, and the
+ * shared SiteFooter so all three pages are pixel-consistent.
+ */
+export function LegalPage({
+  title,
+  intro,
+  children,
+}: {
+  title: string
+  intro?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <>
+      <LegalHeader />
+      <main className="legal">
+        <div className="container legal-container">
+          <h1 className="legal-title">{title}</h1>
+          {intro ? <p className="legal-lead">{intro}</p> : null}
+          <div className="legal-prose">{children}</div>
+        </div>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/apps/landing/src/components/sections/site-footer.tsx
+++ b/apps/landing/src/components/sections/site-footer.tsx
@@ -1,3 +1,5 @@
+import { Link } from '@tanstack/react-router'
+
 import { CLI_URL, GITHUB_URL, LICENSE_URL, PROTOCOL_URL } from '@/lib/constants'
 
 export function SiteFooter() {
@@ -6,6 +8,9 @@ export function SiteFooter() {
       <div className="container footer-inner">
         <span className="muted">munkel · ephemeral messages between friends.</span>
         <div className="footer-links">
+          <Link to="/imprint">Imprint</Link>
+          <Link to="/privacy">Privacy</Link>
+          <Link to="/contact">Contact</Link>
           <a href={GITHUB_URL}>GitHub</a>
           <a href={PROTOCOL_URL}>Protocol v1</a>
           <a href={CLI_URL}>munkel CLI</a>

--- a/apps/landing/src/routeTree.gen.ts
+++ b/apps/landing/src/routeTree.gen.ts
@@ -9,9 +9,27 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as PrivacyRouteImport } from './routes/privacy'
+import { Route as ImprintRouteImport } from './routes/imprint'
+import { Route as ContactRouteImport } from './routes/contact'
 import { Route as AppcastDotxmlRouteImport } from './routes/appcast[.]xml'
 import { Route as IndexRouteImport } from './routes/index'
 
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ImprintRoute = ImprintRouteImport.update({
+  id: '/imprint',
+  path: '/imprint',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ContactRoute = ContactRouteImport.update({
+  id: '/contact',
+  path: '/contact',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AppcastDotxmlRoute = AppcastDotxmlRouteImport.update({
   id: '/appcast.xml',
   path: '/appcast.xml',
@@ -26,31 +44,64 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/appcast.xml': typeof AppcastDotxmlRoute
+  '/contact': typeof ContactRoute
+  '/imprint': typeof ImprintRoute
+  '/privacy': typeof PrivacyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/appcast.xml': typeof AppcastDotxmlRoute
+  '/contact': typeof ContactRoute
+  '/imprint': typeof ImprintRoute
+  '/privacy': typeof PrivacyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/appcast.xml': typeof AppcastDotxmlRoute
+  '/contact': typeof ContactRoute
+  '/imprint': typeof ImprintRoute
+  '/privacy': typeof PrivacyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/appcast.xml'
+  fullPaths: '/' | '/appcast.xml' | '/contact' | '/imprint' | '/privacy'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/appcast.xml'
-  id: '__root__' | '/' | '/appcast.xml'
+  to: '/' | '/appcast.xml' | '/contact' | '/imprint' | '/privacy'
+  id: '__root__' | '/' | '/appcast.xml' | '/contact' | '/imprint' | '/privacy'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AppcastDotxmlRoute: typeof AppcastDotxmlRoute
+  ContactRoute: typeof ContactRoute
+  ImprintRoute: typeof ImprintRoute
+  PrivacyRoute: typeof PrivacyRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/imprint': {
+      id: '/imprint'
+      path: '/imprint'
+      fullPath: '/imprint'
+      preLoaderRoute: typeof ImprintRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contact': {
+      id: '/contact'
+      path: '/contact'
+      fullPath: '/contact'
+      preLoaderRoute: typeof ContactRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/appcast.xml': {
       id: '/appcast.xml'
       path: '/appcast.xml'
@@ -71,6 +122,9 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AppcastDotxmlRoute: AppcastDotxmlRoute,
+  ContactRoute: ContactRoute,
+  ImprintRoute: ImprintRoute,
+  PrivacyRoute: PrivacyRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/landing/src/routes/contact.tsx
+++ b/apps/landing/src/routes/contact.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { LegalPage } from '@/components/legal/legal-page'
+
+export const Route = createFileRoute('/contact')({
+  head: () => ({
+    meta: [
+      { title: 'Contact · Munkel' },
+      {
+        name: 'description',
+        content: 'How to reach the team behind Munkel.',
+      },
+    ],
+  }),
+  component: ContactPage,
+})
+
+function ContactPage() {
+  return (
+    <LegalPage title="Contact" intro="How to reach the team behind Munkel.">
+      <h2>General enquiries</h2>
+      <p>
+        For questions about Munkel — the product, the protocol, or anything
+        else — reach us by e-mail or phone.
+      </p>
+      <dl className="legal-dl">
+        <dt>E-Mail</dt>
+        <dd>
+          <a href="mailto:hey@munkel.app">hey@munkel.app</a>
+        </dd>
+        <dt>Phone</dt>
+        <dd>
+          <a href="tel:+4940227187">+49 (0) 40 227 187 – 0</a>
+        </dd>
+      </dl>
+
+      <h2>Editorial responsibility</h2>
+      <p>
+        For matters concerning editorial content, contact the person
+        responsible under § 18 Abs. 2 MStV.
+      </p>
+      <dl className="legal-dl">
+        <dt>Name</dt>
+        <dd>Jurij Koch</dd>
+        <dt>Phone</dt>
+        <dd>
+          <a href="tel:+494022718715">+49 (0) 40 227 187 – 15</a>
+        </dd>
+        <dt>E-Mail</dt>
+        <dd>
+          <a href="mailto:hey@munkel.app">hey@munkel.app</a>
+        </dd>
+      </dl>
+    </LegalPage>
+  )
+}

--- a/apps/landing/src/routes/imprint.tsx
+++ b/apps/landing/src/routes/imprint.tsx
@@ -1,0 +1,73 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { LegalPage } from '@/components/legal/legal-page'
+
+export const Route = createFileRoute('/imprint')({
+  head: () => ({
+    meta: [
+      { title: 'Imprint · Munkel' },
+      {
+        name: 'description',
+        content: 'Legal disclosure and provider identification for Munkel.',
+      },
+    ],
+  }),
+  component: ImprintPage,
+})
+
+function ImprintPage() {
+  return (
+    <LegalPage
+      title="Imprint"
+      intro="Information according to § 5 DDG (formerly § 5 TMG)."
+    >
+      <h2>Provider</h2>
+      <dl className="legal-dl">
+        <dt>Company</dt>
+        <dd>Unique (Deutschland) GmbH</dd>
+        <dt>Address</dt>
+        <dd>
+          Bei den Mühren 1
+          <br />
+          20457 Hamburg
+        </dd>
+        <dt>Register</dt>
+        <dd>Commercial register: HRB 40590</dd>
+        <dt>Register court</dt>
+        <dd>Amtsgericht Hamburg</dd>
+      </dl>
+
+      <h2>Contact</h2>
+      <dl className="legal-dl">
+        <dt>Phone</dt>
+        <dd>
+          <a href="tel:+4940227187">+49 (0) 40 227 187 – 0</a>
+        </dd>
+        <dt>E-Mail</dt>
+        <dd>
+          <a href="mailto:hey@munkel.app">hey@munkel.app</a>
+        </dd>
+      </dl>
+
+      <h2>VAT identification number</h2>
+      <p>
+        VAT ID according to § 27 a of the German Value Added Tax Act (UStG):
+        DE118689805
+      </p>
+
+      <h2>Editorial responsibility (§ 18 Abs. 2 MStV)</h2>
+      <dl className="legal-dl">
+        <dt>Name</dt>
+        <dd>Jurij Koch</dd>
+        <dt>Phone</dt>
+        <dd>
+          <a href="tel:+494022718715">+49 (0) 40 227 187 – 15</a>
+        </dd>
+        <dt>E-Mail</dt>
+        <dd>
+          <a href="mailto:hey@munkel.app">hey@munkel.app</a>
+        </dd>
+      </dl>
+    </LegalPage>
+  )
+}

--- a/apps/landing/src/routes/privacy.tsx
+++ b/apps/landing/src/routes/privacy.tsx
@@ -1,0 +1,136 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { LegalPage } from '@/components/legal/legal-page'
+import { PROTOCOL_URL } from '@/lib/constants'
+
+export const Route = createFileRoute('/privacy')({
+  head: () => ({
+    meta: [
+      { title: 'Privacy · Munkel' },
+      {
+        name: 'description',
+        content:
+          'How Munkel handles personal data: no analytics, no tracking, self-hosted fonts, and end-to-end encrypted, ephemeral messaging.',
+      },
+    ],
+  }),
+  component: PrivacyPage,
+})
+
+function PrivacyPage() {
+  return (
+    <LegalPage
+      title="Privacy Policy"
+      intro="How we handle personal data when you visit this website and use Munkel — written to be honest about how little we collect."
+    >
+      <p className="legal-updated">Last updated: 19 June 2026</p>
+
+      <h2>1. Controller</h2>
+      <p>
+        The controller responsible for data processing on this website within
+        the meaning of the General Data Protection Regulation (GDPR) is:
+      </p>
+      <dl className="legal-dl">
+        <dt>Company</dt>
+        <dd>Unique (Deutschland) GmbH</dd>
+        <dt>Address</dt>
+        <dd>
+          Bei den Mühren 1
+          <br />
+          20457 Hamburg
+        </dd>
+        <dt>E-Mail</dt>
+        <dd>
+          <a href="mailto:hey@munkel.app">hey@munkel.app</a>
+        </dd>
+        <dt>Phone</dt>
+        <dd>
+          <a href="tel:+4940227187">+49 (0) 40 227 187 – 0</a>
+        </dd>
+      </dl>
+
+      <h2>2. Hosting and server logs</h2>
+      <p>
+        This website is hosted on the infrastructure of Cloudflare, Inc., which
+        also provides content-delivery and edge-computing services for the
+        site. When you access the site, Cloudflare necessarily processes
+        connection data, including your IP address, to deliver the requested
+        content and to ensure the security, stability, and integrity of the
+        service. Server-side observability is enabled for this site, so request
+        logs — which may include your IP address and request metadata — are
+        generated to operate, secure, and troubleshoot the service.
+      </p>
+      <p>
+        The legal basis for this processing is our legitimate interest in
+        providing a secure and reliable website under Art. 6(1)(f) GDPR. We have
+        concluded a data processing agreement (Auftragsverarbeitungsvertrag) with
+        our hosting provider as required by Art. 28 GDPR.
+      </p>
+
+      <h2>3. Fonts</h2>
+      <p>
+        All fonts used on this website are self-hosted and served from our own
+        origin. We do <strong>not</strong> use the Google Fonts CDN or any other
+        third-party font service, so no font request is made to an external
+        provider and no data is transmitted to a third party for the purpose of
+        displaying fonts.
+      </p>
+
+      <h2>4. Analytics and tracking</h2>
+      <p>
+        We do not use any web analytics, tracking, or telemetry on this website.
+        There are no analytics scripts, no tracking pixels, no advertising
+        networks, and no third-party measurement services. We do not build
+        profiles of visitors and we do not track you across sites.
+      </p>
+
+      <h2>5. Cookies and local storage</h2>
+      <p>
+        This website does not set any cookies. It uses a single, strictly
+        functional browser local-storage entry to remember your light/dark theme
+        preference (the key <span className="code">munkel-theme</span>). This
+        value never leaves your browser, is not used for tracking, and exists
+        only so the site renders in your chosen appearance on your next visit.
+      </p>
+
+      <h2>6. The Munkel app and relay</h2>
+      <p>
+        Munkel itself is built around data minimisation. Messages are
+        end-to-end encrypted and ephemeral: they are relayed between devices and
+        then vanish — nothing is stored on the server. The relay cannot read
+        message contents. For the technical details of how this works, see the{' '}
+        <a href={PROTOCOL_URL} rel="noopener noreferrer">
+          protocol specification
+        </a>
+        .
+      </p>
+
+      <h2>7. Your rights</h2>
+      <p>
+        Under the GDPR you have the following rights regarding your personal
+        data:
+      </p>
+      <ul>
+        <li>Right of access (Art. 15 GDPR)</li>
+        <li>Right to rectification (Art. 16 GDPR)</li>
+        <li>Right to erasure (Art. 17 GDPR)</li>
+        <li>Right to restriction of processing (Art. 18 GDPR)</li>
+        <li>Right to data portability (Art. 20 GDPR)</li>
+        <li>Right to object to processing (Art. 21 GDPR)</li>
+      </ul>
+      <p>
+        To exercise any of these rights, contact us at{' '}
+        <a href="mailto:hey@munkel.app">hey@munkel.app</a>. You also have the
+        right to lodge a complaint with a supervisory authority, in particular in
+        the EU member state of your habitual residence, place of work, or the
+        place of the alleged infringement.
+      </p>
+
+      <h2>8. Changes to this policy</h2>
+      <p>
+        We may update this privacy policy to reflect changes to the website or to
+        legal requirements. The current version always applies.
+      </p>
+    </LegalPage>
+  )
+}

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -1050,3 +1050,116 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0; }
   .badge-marquee-row { animation: none; flex-wrap: wrap; justify-content: center; width: auto; }
   .badge-dup { display: none; }
 }
+
+/* ============================================================
+ * Legal / content pages (Imprint, Privacy, Contact)
+ * Slim header + centered prose column + shared SiteFooter.
+ * ============================================================ */
+
+/* Slim standalone header — NOT the bespoke landing <nav>. Static, no float,
+   no hash links. Same sticky height token so the layout rhythm matches. */
+.legal-header {
+  position: sticky; top: 0; z-index: 100;
+  height: var(--nav-h);
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklab, var(--background) 86%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+.legal-header-inner {
+  height: 100%;
+  display: flex; align-items: center;
+}
+
+/* Outer page region: clears the sticky header and gives generous bottom air
+   before the footer. */
+.legal {
+  padding: 5rem 0 7rem;
+  border-top: 1px solid var(--border);
+}
+
+/* Reading column: narrow the measure inside the existing .container gutters. */
+.legal-container { max-width: 1100px; } /* .container already sets this + padding */
+.legal-prose,
+.legal-title,
+.legal-lead { max-width: 70ch; } /* ~68–72ch comfortable measure */
+
+/* Page heading + lead */
+.legal-title {
+  font-size: var(--text-4xl); font-weight: 700;
+  letter-spacing: var(--tracking-tight); line-height: var(--leading-tight);
+  text-wrap: balance;
+}
+.legal-lead {
+  margin-top: 1.125rem;
+  font-size: var(--text-lg); color: var(--muted-foreground);
+  line-height: var(--leading-relaxed); text-wrap: pretty;
+}
+
+/* Prose body */
+.legal-prose {
+  margin-top: 2.5rem;
+  font-size: var(--text-base); color: var(--foreground);
+  line-height: var(--leading-relaxed); text-wrap: pretty;
+}
+.legal-prose > * + * { margin-top: 1.25rem; } /* flow rhythm between blocks */
+
+.legal-prose h2 {
+  margin-top: 3rem;
+  font-size: var(--text-2xl); font-weight: 600;
+  letter-spacing: var(--tracking-tight); line-height: var(--leading-snug);
+  text-wrap: balance;
+}
+.legal-prose h3 {
+  margin-top: 2rem;
+  font-size: var(--text-lg); font-weight: 600;
+  letter-spacing: var(--tracking-tight); line-height: var(--leading-snug);
+}
+/* First heading shouldn't fight the .legal-prose top margin. */
+.legal-prose > :first-child { margin-top: 0; }
+
+.legal-prose p { color: var(--foreground); }
+
+/* Lists */
+.legal-prose ul { padding-left: 1.25rem; list-style: disc; }
+.legal-prose li { margin-top: 0.5rem; }
+.legal-prose li::marker { color: var(--muted-foreground); }
+
+/* Links — match the existing `.honest a` / `.faq-foot a` treatment exactly:
+   foreground text, subtle border-colored underline brightening on hover. */
+.legal-prose a {
+  color: var(--foreground);
+  text-decoration: underline; text-underline-offset: 3px;
+  text-decoration-color: var(--border);
+  transition: text-decoration-color 0.2s ease;
+}
+.legal-prose a:hover { text-decoration-color: var(--foreground); }
+
+/* Inline code reuses the global `.code` role (already defined above). */
+
+/* "Last updated" line for the privacy page — an understated muted note. */
+.legal-updated {
+  margin-top: 0.5rem;
+  color: var(--muted-foreground);
+  font-size: var(--text-sm);
+}
+
+/* Key/value blocks for the imprint (name/address/email …). Two-column on
+   wide viewports, stacked on narrow. dt is the muted label, dd the value. */
+.legal-dl {
+  display: grid;
+  grid-template-columns: minmax(7rem, 12rem) 1fr;
+  gap: 0.5rem 1.5rem;
+  margin-top: 1.25rem;
+}
+.legal-dl dt {
+  font-size: var(--text-sm); color: var(--muted-foreground);
+  font-family: var(--font-mono); letter-spacing: var(--tracking-wide);
+}
+.legal-dl dd { color: var(--foreground); }
+
+@media (max-width: 600px) {
+  .legal { padding: 3.5rem 0 5rem; }
+  .legal-dl { grid-template-columns: 1fr; gap: 0.125rem 0; }
+  .legal-dl dd { margin-bottom: 0.75rem; }
+}


### PR DESCRIPTION
## Summary

Adds the legal pages the landing site was missing. Operated by a German GmbH, the site legally requires an Impressum (§ 5 DDG) and a GDPR/DSGVO privacy policy; there was previously no Imprint, Privacy, or Contact page (the existing `privacy.tsx` section is marketing copy, not a legal Datenschutzerklärung).

Three new English-only file-based routes, wired into the footer:

| Route | Content |
|-------|---------|
| `/imprint` | Impressum per § 5 DDG — verbatim company details (Unique (Deutschland) GmbH, HRB 40590, AG Hamburg), VAT ID, editorial responsibility (§ 18 Abs. 2 MStV) |
| `/contact` | Contact details only — no form (no anti-bot needed); reuses the imprint phone/e-mail |
| `/privacy` | GDPR Datenschutzerklärung |

A shared `LegalPage` / `LegalHeader` layout keeps all three visually consistent (slim header → wordmark links home, centered prose column, existing `SiteFooter`). The appended `.legal-*` CSS reuses existing design tokens only, so the dark/light toggle keeps working.

## Privacy policy is grounded in actual behavior

Rather than boilerplate, the policy reflects what the site really does (verified against the codebase):

- **Hosting:** Cloudflare, with observability/request logging enabled (`apps/landing/wrangler.jsonc`) — IP/server-log processing on Art. 6(1)(f) + Art. 28 DPA note
- **Fonts:** self-hosted via `@fontsource` — explicitly no Google Fonts CDN / no third-party font request
- **Analytics:** none — no analytics, tracking pixels, ad networks, or telemetry (confirmed by audit)
- **Cookies/storage:** no cookies; a single functional `munkel-theme` localStorage key
- **App/relay:** E2E-encrypted, ephemeral, nothing stored — links to the protocol spec (verified against `apps/server/src/protocol.ts`: "It stores nothing", AES-256-GCM, relay sees only `groupId`)
- Full GDPR data-subject rights (Art. 15–21) + supervisory-authority complaint
- Effective date set: **Last updated 19 June 2026**

## How it was built

Implemented in an isolated git worktree via a multi-agent workflow: parallel research (data-processing audit + page-shell/CSS spec) → single implementing agent → parallel verification (build + legal-completeness + adversarial fact-check of the privacy claims + code review). The fact-check caught one understated logging claim (Cloudflare observability), which was tightened.

## Test plan

- [x] `bun run generate-routes` registers `/imprint`, `/privacy`, `/contact`
- [x] `bun run typecheck` clean
- [x] `bun run build` clean (client + SSR)
- [x] All three routes return 200 with correct SSR `<title>`
- [x] Imprint content verified verbatim (entity, address, HRB, VAT, MStV editorial)
- [x] Contact has no form; mailto:/tel: links work
- [x] Privacy renders all sections; no analytics/cookie claims contradicted by the code
- [x] Footer links to all three pages; visual layout consistent across pages (screenshots reviewed)

Closes #73
