### PR TITLE
Landing notch: hover cue, macOS menu bar, top hairline fix

### DIFF
--- a/apps/landing/src/components/sections/hero.tsx
+++ b/apps/landing/src/components/sections/hero.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type { CSSProperties, SVGProps } from 'react'
-import { Check, ChevronDown, Copy, Download, Globe, Wifi } from 'lucide-react'
+import { BatteryMedium, Check, ChevronDown, ChevronUp, Copy, Download, Globe, Wifi } from 'lucide-react'
 import { motion, useMotionValueEvent, useReducedMotion, useScroll, useTransform } from 'motion/react'
 
 import { Button } from '@/components/ui/button'
@@ -104,13 +104,15 @@ export function Hero() {
   const wrapRef = useRef<HTMLDivElement>(null)
   const macRef = useRef<HTMLDivElement>(null)
   const notchRef = useRef<HTMLDivElement>(null)
-  const demoHintRef = useRef<HTMLDivElement>(null)
 
   const [clock, setClock] = useState('Thu 9:41')
   const [msgCopied, setMsgCopied] = useState(false)
   const [copiedRow, setCopiedRow] = useState<number | null>(null)
   const [teaserOpen, setTeaserOpen] = useState(false)
   const [expanded, setExpanded] = useState(false)
+  // "hover for details" cue under the docked notch: shown when it docks,
+  // dismissed once hovered, brought back on a fresh dock.
+  const [hintVisible, setHintVisible] = useState(false)
   const [msgIdx, setMsgIdx] = useState(0)
   const hoveredRef = useRef(false)
   const dockedRef = useRef(false)
@@ -189,12 +191,12 @@ export function Hero() {
     if (p >= DOCK_AT && !dockedRef.current) {
       dockedRef.current = true
       setTeaserOpen(true)
-      demoHintRef.current?.classList.add('show')
+      setHintVisible(true)
     } else if (p < DOCK_AT && dockedRef.current) {
       dockedRef.current = false
       setTeaserOpen(false)
       setExpanded(false)
-      demoHintRef.current?.classList.remove('show')
+      setHintVisible(false)
     }
   })
 
@@ -209,8 +211,8 @@ export function Hero() {
       // Hover swells the docked teaser into the full message card — like the
       // real notch. Hovering the closed pill (pre-dock) does nothing.
       if (dockedRef.current) setExpanded(true)
-      const cap = demoHintRef.current
-      if (cap?.classList.contains('show')) cap.classList.add('off')
+      // Dismiss the cue once they've taken the hint; it returns on a fresh dock.
+      setHintVisible(false)
     }
     const onLeave = () => {
       hoveredRef.current = false
@@ -328,14 +330,18 @@ export function Hero() {
                   <div className="mb-wallpaper"></div>
                   <div className="mb-menubar">
                     <div className="mb-menu">
+                      {/* U+F8FF renders as the Apple logo in the system font on
+                          Apple devices (the landing's audience). */}
+                      <span className="mb-apple" aria-hidden>&#xF8FF;</span>
                       <span className="mb-app">munkel</span>
                       <span>Circles</span>
                       <span>Identity</span>
                       <span>Help</span>
                     </div>
                     <div className="mb-menu-right">
+                      <BatteryMedium aria-hidden />
                       <Wifi aria-hidden />
-                      <span>{clock}</span>
+                      <span className="mb-clock">{clock}</span>
                     </div>
                   </div>
                   <div
@@ -456,13 +462,17 @@ export function Hero() {
                       </div>
                     </div>
                   </div>
+                  {/* "hover for details" cue, just below the docked notch (so it
+                      tracks the notch under the zoom); fades on hover, returns
+                      on a fresh dock. */}
+                  <div className={`notch-hint${hintVisible ? ' show' : ''}`} aria-hidden>
+                    <ChevronUp aria-hidden />
+                    <span>hover for details</span>
+                  </div>
                 </div>
               </motion.div>
             </motion.div>
           </motion.div>
-          <div className="demo-caption" ref={demoHintRef} aria-hidden>
-            hover to hold a munkel open — just like the real thing
-          </div>
           <motion.div className="scroll-hint" style={reduce ? undefined : { opacity: hintOpacity }}>
             <span>See it munkel</span>
             <ChevronDown aria-hidden />

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -325,22 +325,32 @@ nav.floating .nav-inner {
     radial-gradient(50% 45% at 12% 70%, color-mix(in oklab, var(--brand) 12%, oklch(0.13 0 0)), transparent 70%),
     linear-gradient(180deg, oklch(0.14 0.008 250), oklch(0.1 0.005 260));
 }
+/* The menu bar sits a touch taller than the (closed) notch, like real macOS,
+   and uses the native system font so it reads as the user's own desktop. */
 .mb-menubar {
-  position: absolute; top: 0; left: 0; right: 0; height: 25px;
+  position: absolute; top: 0; left: 0; right: 0; height: 28px;
   display: flex; align-items: center; justify-content: space-between;
-  padding: 0 16px;
-  font-size: 12px; color: oklch(0.97 0 0 / 0.8);
+  padding: 0 14px;
+  font-family: -apple-system, system-ui, sans-serif;
+  font-size: 13px; color: oklch(0.97 0 0 / 0.85);
   background: oklch(0 0 0 / 0.26);
 }
-.mb-menu { display: flex; align-items: center; gap: 16px; }
+.mb-menu { display: flex; align-items: center; gap: 15px; }
+/* U+F8FF = the Apple logo glyph in the system font on Apple devices. */
+.mb-apple { font-size: 15px; line-height: 0; opacity: 0.92; }
 .mb-menu .mb-app { font-weight: 600; }
-.mb-menu-right { display: flex; align-items: center; gap: 12px; font-variant-numeric: tabular-nums; }
-.mb-menu-right svg.lucide { width: 13px; height: 13px; }
+.mb-menu-right { display: flex; align-items: center; gap: 11px; font-variant-numeric: tabular-nums; }
+.mb-menu-right svg.lucide { width: 15px; height: 15px; }
+.mb-clock { font-weight: 500; }
 .mb-notch {
-  position: absolute; top: 0; left: 50%; transform: translateX(-50%);
+  position: absolute; top: -1px; left: 50%; transform: translateX(-50%);
   width: 128px; height: 25px;
   background: #000;
   z-index: 5;
+  /* Bleed 1px over the display's top edge (clipped by .mb-display's overflow)
+     so the notch's anti-aliased top — which lands on a sub-pixel row under the
+     scroll-zoom — can't leak the green wallpaper as a hairline; the visible
+     edge stays solid-black and flush. */
   /* The real NotchShape, not a rounded rectangle: concave top corners that
      blend into the menu bar, side walls inset by the top radius, convex bottom
      corners. Built as an animatable clip-path so the demo's silhouette is
@@ -548,16 +558,20 @@ nav.floating .nav-inner {
 .scroll-hint span { font-size: var(--text-xs); }
 .scroll-hint svg.lucide { width: 20px; height: 20px; animation: hint-bob 2s ease-in-out infinite; }
 @keyframes hint-bob { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(6px); } }
-/* One-time interactivity nudge, shown while the notch demo is docked */
-.demo-caption {
-  position: absolute; bottom: 26px; left: 50%; transform: translateX(-50%);
-  font-size: var(--text-xs); color: var(--muted-foreground);
-  opacity: 0; transition: opacity 0.45s ease;
-  pointer-events: none; white-space: nowrap;
+/* "Hover for details" cue right under the docked notch. It lives inside the
+   mockup display, so the macbook's zoom transform carries it with the notch. */
+.notch-hint {
+  position: absolute; top: 64px; left: 50%; transform: translateX(-50%);
+  z-index: 4; pointer-events: none;
+  display: flex; flex-direction: column; align-items: center; gap: 1px;
+  font-size: 11px; line-height: 1; white-space: nowrap;
+  color: oklch(1 0 0 / 0.62); text-shadow: 0 1px 3px oklch(0 0 0 / 0.6);
+  opacity: 0; transition: opacity 0.4s ease;
 }
-.demo-caption.show { opacity: 1; }
-.demo-caption.off { opacity: 0 !important; }
-@media (hover: none) { .demo-caption { display: none; } }
+.notch-hint.show { opacity: 1; }
+.notch-hint svg.lucide { width: 13px; height: 13px; animation: hint-bob-up 2s ease-in-out infinite; }
+@keyframes hint-bob-up { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-3px); } }
+@media (hover: none) { .notch-hint { display: none; } }
 .hero > .container { position: relative; }
 .pulse { width: 6px; height: 6px; border-radius: 50%; background: var(--brand); box-shadow: 0 0 calc(var(--glow) * 12px) 1px var(--brand); animation: pulse 2s ease-in-out infinite; }
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
@@ -1018,8 +1032,11 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0; }
      scale the WHOLE notch down uniformly rather than hand-tuning each element —
      so the ping ring, icon sizes and every spacing stay perfectly aligned. */
   .mb-notch { transform: translateX(-50%) scale(0.75); transform-origin: top center; }
-  .mb-menubar { height: 19px; font-size: 10px; }
-  .mb-menu span:not(.mb-app) { display: none; }
+  .mb-menubar { height: 21px; font-size: 11px; }
+  .mb-apple { font-size: 13px; }
+  /* keep the Apple logo + app name, drop the rest of the menu titles */
+  .mb-menu span:not(.mb-app):not(.mb-apple) { display: none; }
+  .mb-menu-right svg.lucide { width: 13px; height: 13px; }
   .share-compare { grid-template-columns: 1fr; }
   section { padding: 5rem 0; }
   .section-head { margin-bottom: 3rem; }
@@ -1028,7 +1045,8 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0; }
    the shrinking mockup. Same uniform transform — proportions stay intact. */
 @media (max-width: 600px) {
   .mb-notch { transform: translateX(-50%) scale(0.58); }
-  .mb-menubar { height: 15px; }
+  .mb-menubar { height: 16px; font-size: 9px; }
+  .mb-apple { font-size: 11px; }
 }
 @media (prefers-reduced-motion: reduce) {
   .pulse, .cursor { animation: none; }
@@ -1041,7 +1059,7 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0; }
   .hero-stage { height: auto; }
   .hero-sticky { position: static; height: auto; overflow: visible; padding: 6rem 0; }
   .scroll-hint { display: none; }
-  .demo-caption { display: none; }
+  .notch-hint { display: none; }
   /* .meanwhile reveal is Motion-driven; MotionConfig reducedMotion="user" handles it. */
   [data-slot="accordion-content"] { animation-duration: 1ms; }
   [data-slot="accordion-trigger"] span { transition: none; }


### PR DESCRIPTION
Follow-ups to #75 (the pixel-perfect notch demo).

## What

- **"Hover for details" cue under the docked notch.** Replaces the old caption that sat at the bottom edge of the viewport (far from the notch). The cue now lives inside the mockup display, just below the notch — so the macbook's zoom transform carries it along — with an up-chevron pointing at the notch. It fades on hover and returns on a fresh dock (state-driven, no longer a one-time CSS dismiss).
- **macOS-style menu bar.** Made the mockup menu bar feel like the user's own desktop: a touch taller than the notch, native system font (`-apple-system`), the Apple logo (U+F8FF) at the far left, and battery + Wi-Fi + the current clock at the right. Scales down with the notch on narrow viewports; the Apple logo and app name survive the mobile collapse.
- **Killed the top hairline.** A faint green line showed directly above the docked notch: its anti-aliased top edge lands on a sub-pixel row under the scroll-zoom, leaking the green wallpaper. The notch now bleeds 1px over the display's top edge (clipped by the display's `overflow: hidden`), so the visible edge stays solid-black and flush.

## Test plan
- [x] `apps/landing` `tsc --noEmit` + `vite build` green
- [x] Pixel-sampled the notch top edge: the green hairline row is now `(0,0,0)`
- [x] Captured the docked state: cue sits under the notch; menu bar shows Apple logo + battery/Wi-Fi/clock
- [ ] Visual check on the live hero after deploy (hover cue fade + return on re-dock)
