### PR TITLE
fix(macos): pack ~4 album thumbnails per row in the notch

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -11,9 +11,16 @@ struct MessageNotchView: View {
     let message: IncomingMessage
     @ObservedObject var model: MessageDisplayModel
 
-    /// Matches the expanded container width.
+    /// The expanded panel width (matches the container's `tickerWindow`).
     private let contentWidth: CGFloat = 250
+    /// Horizontal inset of the message body — keep in sync with the
+    /// `.padding(.horizontal, hInset)` on textBody/imageBody. The picture(s)
+    /// fit this inset width, not the full panel width, or the album sits flush
+    /// against the right edge while keeping a left margin.
+    private let hInset: CGFloat = 6
     private let gridSpacing: CGFloat = 6
+    /// Usable width for the picture(s): the panel minus both body insets.
+    private var imageWidth: CGFloat { contentWidth - 2 * hInset }
 
     var body: some View {
         if message.isImage {
@@ -38,7 +45,7 @@ struct MessageNotchView: View {
 
             Spacer(minLength: 12)
         }
-        .padding(.horizontal, 6)
+        .padding(.horizontal, hInset)
         .padding(.vertical, 4)
     }
 
@@ -61,12 +68,12 @@ struct MessageNotchView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .padding(.horizontal, 6)
+        .padding(.horizontal, hInset)
         .padding(.vertical, 4)
     }
 
-    /// A lone image fills the width at its own aspect; an album is a 2-column
-    /// grid of square cells.
+    /// A lone image fills the width at its own aspect; an album is a grid of
+    /// square cells, up to four per row.
     @ViewBuilder private var imageContent: some View {
         if message.images.count == 1, let only = message.images.first {
             let size = fittedSize(width: only.width, height: only.height)
@@ -74,11 +81,14 @@ struct MessageNotchView: View {
                 .frame(width: size.width, height: size.height)
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         } else {
-            let side = (contentWidth - gridSpacing) / 2
-            let columns = [
-                GridItem(.fixed(side), spacing: gridSpacing),
-                GridItem(.fixed(side), spacing: gridSpacing),
-            ]
+            // Pack up to four thumbnails per row; smaller albums use fewer,
+            // larger columns (2 → two-up, 3 → three-up, 4+ → four per row).
+            let columnCount = min(4, message.images.count)
+            let side = (imageWidth - CGFloat(columnCount - 1) * gridSpacing) / CGFloat(columnCount)
+            let columns = Array(
+                repeating: GridItem(.fixed(side), spacing: gridSpacing),
+                count: columnCount
+            )
             LazyVGrid(columns: columns, alignment: .leading, spacing: gridSpacing) {
                 ForEach(message.images) { img in
                     AlbumCell(model: model, image: img, fill: true)
@@ -86,7 +96,7 @@ struct MessageNotchView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                 }
             }
-            .frame(width: contentWidth, alignment: .leading)
+            .frame(width: imageWidth, alignment: .leading)
         }
     }
 
@@ -115,8 +125,8 @@ struct MessageNotchView: View {
         let w = CGFloat(width)
         let h = CGFloat(height)
         let maxHeight: CGFloat = 260
-        guard w > 0, h > 0 else { return CGSize(width: contentWidth, height: contentWidth * 0.6) }
-        let scale = min(contentWidth / w, maxHeight / h)
+        guard w > 0, h > 0 else { return CGSize(width: imageWidth, height: imageWidth * 0.6) }
+        let scale = min(imageWidth / w, maxHeight / h)
         return CGSize(width: max(1, w * scale), height: max(1, h * scale))
     }
 }


### PR DESCRIPTION
## What
Received image albums in the expanded notch were a fixed 2-column `LazyVGrid`, so 4- and 8-image albums wasted vertical space and rendered oversized cells. This packs up to four thumbnails per row.

## Changes
- **Adaptive album columns** — `min(4, imageCount)`: 2 → two-up, 3 → three-up, 4+ → four per row (8 = two rows of four). Small albums keep their comfortable larger cells; only 4+ albums pack tighter. Single-image full-width aspect-fit treatment is unchanged.
- **Symmetric margins** — the picture(s) were sized to the full panel width (250pt) but sit inside the body's 6pt horizontal padding, so the album (and a lone image) overflowed the right edge: more margin on the left than the right. Both now bind to the inset content width (238pt) → equal 6pt margins, matching the header/text.

## Verification
- `swift build` green; two adversarial review passes (layout-correctness + checklist/scope), 0 blocking findings.
- Rendered the album at the real container geometry (counts 1/2/3/4/5/8) via `ImageRenderer`, with the panel edges marked — confirmed 4-per-row packing and equal left/right margins.
- Manually tested live in the notch (dev-echo album sends).

## Test plan
- [ ] Send a 2-image album → two-up, comfortable cells, equal margins
- [ ] Send a 4-image album → single row of four
- [ ] Send an 8-image album → two rows of four, no wasted vertical space
- [ ] Send a single image → unchanged full-width aspect-fit, no right-edge overflow
- [ ] Confirm cells stay square + cropped and tap targets are usable at ~55pt

Closes #67