### PR TITLE
feat(macos): free-floating Quick Look hover preview for album images (#69)

### DIFF
--- a/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
+++ b/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
@@ -1,0 +1,124 @@
+import AppKit
+import MunkelKit
+import SwiftUI
+
+/// The free-floating "Quick Look" preview: when an `AlbumCell` is hovered it
+/// sets `model.previewImageID`, and this view — mounted by ``NotchHostingContent``
+/// as a sibling of the masked notch (so it escapes the NotchShape clip yet stays
+/// inside the capture-excluded panel window) — pops the enlarged image just below
+/// the notch. Hover-driven and `allowsHitTesting(false)`, so it is a pure peek:
+/// it never steals a click and dismisses the moment the pointer leaves the cell
+/// (or any teardown path clears `previewImageID`).
+///
+/// Capture safety: this lives in the notch panel window, whose `sharingType` is
+/// `.none` from birth (``NotchPanelWindow``); the `.excludedFromScreenCapture()`
+/// below is the same belt-and-suspenders backup the rest of the notch uses. No
+/// `NSPanel`/`QLPreviewPanel`/`.help()` — those draw in their own window and
+/// would leak into a screen share while the notch itself stays hidden.
+struct ImagePreviewOverlay: View {
+    @ObservedObject var model: MessageDisplayModel
+    /// The current message's images, to resolve `previewImageID` → image.
+    let images: [IncomingImage]
+
+    var body: some View {
+        // The reader's size is the room left BELOW the notch chrome (the parent
+        // pads it down by the measured clearance), so the card can be bounded to
+        // what actually fits and never runs off the bottom of the screen.
+        GeometryReader { proxy in
+            ZStack {
+                if let id = model.previewImageID,
+                   let image = images.first(where: { $0.id == id }) {
+                    PreviewCard(model: model, image: image, available: proxy.size)
+                        .id(id)
+                        .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .top)))
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+        .colorScheme(.dark)
+        .excludedFromScreenCapture()
+    }
+}
+
+/// One enlarged image card. Paints its inline thumbnail immediately, then swaps
+/// in the full resolution the cell already fetched into `model.fullImages`
+/// (consumes the shared cache only — never triggers a second R2 fetch).
+private struct PreviewCard: View {
+    @ObservedObject var model: MessageDisplayModel
+    let image: IncomingImage
+    /// Space available below the notch chrome (from the overlay's GeometryReader).
+    let available: CGSize
+
+    @State private var decoded: CGImage?
+
+    private var didFail: Bool { model.failedImages.contains(image.id) }
+    private var fullLoaded: Bool { model.fullImages[image.id] != nil }
+
+    var body: some View {
+        let size = fittedSize(in: available)
+        ZStack {
+            if let decoded {
+                Image(decorative: decoded, scale: 1)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(.black.opacity(0.55))
+            }
+            if !fullLoaded, !didFail {
+                ProgressView().controlSize(.regular).tint(.white.opacity(0.85))
+            } else if didFail, decoded == nil {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 22))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.55), radius: 28, x: 0, y: 12)
+        // Structured so SwiftUI cancels it on teardown / image switch — which is
+        // what makes the `Task.isCancelled` guard in `decodeFull` meaningful.
+        // Thumbnail first, then wait for the cell's full bytes and upgrade once.
+        .task(id: image.id) {
+            await decodeThumb()
+            for await images in model.$fullImages.values {
+                if images[image.id] != nil {
+                    await decodeFull()
+                    break
+                }
+            }
+        }
+    }
+
+    private func decodeThumb() async {
+        guard decoded == nil else { return }
+        let thumb = image.thumb
+        let img = await Task.detached { ImageCodec.decode(thumb, maxPixels: 700) }.value
+        guard !Task.isCancelled else { return }
+        decoded = img
+    }
+
+    private func decodeFull() async {
+        guard let full = model.fullImages[image.id] else { return }
+        let img = await Task.detached { ImageCodec.decode(full, maxPixels: ImageCodec.maxFullPixels) }.value
+        guard !Task.isCancelled else { return }
+        decoded = img
+    }
+
+    /// The image's aspect scaled into the space actually available below the
+    /// notch (the panel is half the screen wide); small images are upscaled
+    /// modestly (≤3×) for a usable peek without turning to mush.
+    private func fittedSize(in available: CGSize) -> CGSize {
+        let w = CGFloat(max(image.width, 1))
+        let h = CGFloat(max(image.height, 1))
+        let maxW = max(80, min(available.width - 32, 620))
+        let maxH = max(80, available.height - 24)
+        let scale = min(min(maxW / w, maxH / h), 3)
+        return CGSize(width: max(1, w * scale), height: max(1, h * scale))
+    }
+}

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -14,6 +14,17 @@ final class MessageDisplayModel: ObservableObject {
     @Published var fullImages: [String: Data] = [:]
     /// Images whose full fetch failed (expired/offline) — show a warning glyph.
     @Published var failedImages: Set<String> = []
+    /// `id` (r2Key) of the album image currently shown in the large hover
+    /// "Quick Look" preview, or nil when none. Set by an `AlbumCell` on hover
+    /// (debounced) and force-cleared on every teardown path by NotchPresenter,
+    /// since `.onHover(false)` doesn't reliably fire when the notch is torn down.
+    /// Deliberately kept OUT of MessageNotchContainer's `.animation(value:)`
+    /// lists so toggling it never re-runs the container's expand/history springs.
+    @Published var previewImageID: String?
+    /// The pending hover-debounce, owned here (not per-cell) so every teardown
+    /// path can cancel it centrally — a per-cell `@State` Task would outlive its
+    /// cell and could resurrect a just-cleared preview.
+    private var previewDebounce: Task<Void, Never>?
     /// Per-image full-resolution loaders, set once by NotchPresenter. Not
     /// @Published: read by cells, it never needs to drive a refresh itself.
     var imageLoaders: [String: @Sendable () async -> Data?] = [:]
@@ -69,6 +80,47 @@ final class MessageDisplayModel: ObservableObject {
         pasteboard.clearContents()
         pasteboard.writeObjects([image])
         flashCopied()
+    }
+
+    /// Hover requested the large preview for `id`. Debounced on first appearance
+    /// (a fast album sweep shouldn't flash a card per cell); instant once a card
+    /// is already up, so an adjacent-cell hand-off cross-fades via `.id(id)`
+    /// instead of blanking for the debounce. The debounce is owned by the model
+    /// so a leave/teardown can cancel it (see `clearPreview`).
+    func requestPreview(_ id: String) {
+        previewDebounce?.cancel()
+        if previewImageID != nil {
+            withAnimation(.easeOut(duration: 0.18)) { previewImageID = id }
+            return
+        }
+        previewDebounce = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(180))
+            guard !Task.isCancelled, let self else { return }
+            withAnimation(.easeOut(duration: 0.18)) { self.previewImageID = id }
+        }
+    }
+
+    /// A cell reports hover-out: drop the pending request and, if this cell owns
+    /// the visible preview, dismiss it (owner-check so an adjacent cell's enter,
+    /// which can land before this leave, isn't undone).
+    func endPreview(forCell id: String) {
+        previewDebounce?.cancel()
+        if previewImageID == id {
+            withAnimation(.easeOut(duration: 0.18)) { previewImageID = nil }
+        }
+    }
+
+    /// Hard clear for every teardown path (notch-leave, hide, reply): cancel any
+    /// pending request and drop the preview. A cell's `.onHover(false)` doesn't
+    /// reliably fire when the notch is torn down, so this must not depend on it.
+    func clearPreview(animated: Bool = false) {
+        previewDebounce?.cancel()
+        guard previewImageID != nil else { return }
+        if animated {
+            withAnimation(.easeOut(duration: 0.18)) { previewImageID = nil }
+        } else {
+            previewImageID = nil
+        }
     }
 
     private func flashCopied() {

--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -165,6 +165,18 @@ struct AlbumCell: View {
             }
         }
         .clipped()
+        // Hovering pops the large Quick-Look preview (ImagePreviewOverlay),
+        // rendered free-floating below the notch in the same capture-excluded
+        // panel window. The debounce + owner-checked dismissal live on the model
+        // (centrally cancellable) so a dropped leave or teardown can't resurrect
+        // a cleared preview.
+        .onHover { inside in
+            if inside {
+                model.requestPreview(image.id)
+            } else {
+                model.endPreview(forCell: image.id)
+            }
+        }
         .task { await load() }
     }
 

--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchHostingContent.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchHostingContent.swift
@@ -13,19 +13,36 @@ import SwiftUI
 struct NotchHostingContent<Content: View>: View {
     @ObservedObject var owner: NotchPanel<Content>
     @State private var floatingHeight: CGFloat = 0
+    /// Measured height of the notch/floating chrome, so the free-floating
+    /// overlay (Quick-Look preview) can sit just below it without overlap.
+    @State private var notchContentHeight: CGFloat = 0
 
     private let safeAreaInset: CGFloat = 15
     private let expandedTopCornerRadius: CGFloat = 15
     private let expandedBottomCornerRadius: CGFloat = 20
     private let floatingCornerRadius: CGFloat = 20
+    /// Gap between the bottom of the notch chrome and the floating overlay.
+    private let floatingOverlayGap: CGFloat = 14
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .top) {
             if owner.hasNotch {
                 notchBody
                     .foregroundStyle(.white)
             } else {
                 floatingBody
+            }
+            // The app's free-floating overlay (Quick-Look image preview): a
+            // sibling of the masked notch, so it escapes the NotchShape clip
+            // yet stays inside this capture-excluded panel window. Positioned
+            // just below the measured chrome; never intercepts clicks.
+            if let overlay = owner.floatingOverlay, owner.state == .expanded {
+                // Padding is outermost so the overlay is proposed only the room
+                // BELOW the chrome — its GeometryReader then bounds the card to
+                // what fits (no off-screen overflow). Never intercepts clicks.
+                overlay
+                    .allowsHitTesting(false)
+                    .padding(.top, overlayTopClearance + floatingOverlayGap)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -33,6 +50,11 @@ struct NotchHostingContent<Content: View>: View {
             color: .black.opacity(owner.state == .expanded ? 0.5 : 0),
             radius: owner.state == .hidden ? 0 : 10
         )
+    }
+
+    /// How far down the overlay must start to clear the notch (or floating pill).
+    private var overlayTopClearance: CGFloat {
+        owner.hasNotch ? notchContentHeight : floatingHeight + owner.notchSize.height
     }
 
     // MARK: - Notch
@@ -85,6 +107,14 @@ struct NotchHostingContent<Content: View>: View {
         .fixedSize()
         .frame(minWidth: minWidth, minHeight: owner.notchSize.height)
         .onHover(perform: owner.updateHoverState)
+        .background(
+            GeometryReader { proxy in
+                Color.clear
+                    .onChange(of: proxy.size.height, initial: true) { _, height in
+                        notchContentHeight = height
+                    }
+            }
+        )
     }
 
     // MARK: - Floating (no-notch screens)

--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchPanel.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchPanel.swift
@@ -63,6 +63,14 @@ final class NotchPanel<Content: View>: ObservableObject {
     var transitionConfiguration = TransitionConfiguration()
     let content: Content
 
+    /// Optional app-supplied view rendered as a free-floating layer BELOW the
+    /// notch — in the *same* capture-excluded panel window but OUTSIDE the
+    /// NotchShape mask, so it can be larger than the black blob (the Quick-Look
+    /// image preview). nil for panels that don't need it (e.g. the indicator).
+    /// Set once before ``expand()``, like ``transitionConfiguration``; it is
+    /// read when the hosting view is built, so it needs no @Published refresh.
+    var floatingOverlay: AnyView?
+
     private let hoverBehavior: HoverBehavior
     private let targetScreen: @MainActor () -> NSScreen?
 

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -211,6 +211,14 @@ final class NotchPresenter {
             openingAnimation: .spring(response: 0.6, dampingFraction: 0.7),
             skipIntermediateHides: true
         )
+        // Image messages get a free-floating Quick-Look preview that pops below
+        // the notch on cell hover (see ImagePreviewOverlay / AlbumCell). It
+        // renders inside this same capture-excluded panel window.
+        if message.isImage {
+            notch.floatingOverlay = AnyView(
+                ImagePreviewOverlay(model: model, images: message.images)
+            )
+        }
         currentNotch = notch
 
         hoverObservation = notch.$isHovering
@@ -229,10 +237,17 @@ final class NotchPresenter {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
                             self.currentModel?.fullyExpanded = true
                         }
-                    } else if self.currentModel?.replying != true {
-                        // While the reply field is open, leaving the notch
-                        // must not tear it down mid-typing.
-                        self.scheduleHide(of: notch, after: self.afterReadDelay)
+                    } else {
+                        // Leaving the notch entirely dismisses the hover image
+                        // preview even if a cell's own `.onHover(false)` didn't
+                        // fire (the same teardown-unreliability the hover-copy
+                        // hotkey guards against).
+                        self.currentModel?.clearPreview(animated: true)
+                        if self.currentModel?.replying != true {
+                            // While the reply field is open, leaving the notch
+                            // must not tear it down mid-typing.
+                            self.scheduleHide(of: notch, after: self.afterReadDelay)
+                        }
                     }
                 }
             }
@@ -359,6 +374,11 @@ final class NotchPresenter {
     private func turnOffHoverCopy() {
         hoverCopyObservation = nil
         currentModel?.hoveredHistoryID = nil
+        // Same teardown rationale as the hover-copy hotkey: clear the hover
+        // image preview here, on every hide, since a cell's `.onHover(false)`
+        // doesn't reliably fire when the notch is torn down. clearPreview also
+        // cancels any in-flight debounce so it can't re-set the flag afterwards.
+        currentModel?.clearPreview()
         KeyboardShortcuts.disable(.copyHoveredHistory)
     }
 
@@ -376,6 +396,9 @@ final class NotchPresenter {
     private func beginReply(model: MessageDisplayModel, panel: NSWindow) {
         guard !model.replying, !model.replySent else { return }
         hideTask?.cancel()
+        // Opening the reply field dismisses any hover preview (and cancels a
+        // pending debounce) so it can't obscure the text field.
+        model.clearPreview()
         withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
             model.fullyExpanded = true
             model.replying = true
@@ -472,4 +495,5 @@ final class NotchPresenter {
             }
         }
     }
+
 }


### PR DESCRIPTION
## What

Hovering a received album/image cell in the expanded notch now pops a large **Quick Look-style** preview that floats just below the notch — a Finder "sneak peek". It upgrades from the inline thumbnail to full resolution as the cell's R2 fetch lands (reuses the shared `fullImages` cache — no second fetch). Works for both the single-image and album-grid layouts.

Implements #69.

## How it stays capture-safe

The preview renders as a **sibling of the masked notch** inside the *same* `NotchPanel` window — so it escapes the `NotchShape` clip yet inherits the window's capture exclusion (`sharingType = .none` from birth), with `.excludedFromScreenCapture()` as backup. No new `NSWindow`/`NSPanel`/`QLPreviewPanel`/tooltip that could leak into a Teams/Zoom share while the notch is hidden.

- New generic `NotchPanel.floatingOverlay` slot; `NotchHostingContent` renders it below the *measured* notch chrome, padded so its `GeometryReader` bounds the card to the room actually left on screen (a tall portrait can't run off the bottom).
- New `ImagePreviewOverlay` / `PreviewCard`: thumbnail-first decode, structured `.task` upgrade to full res, dark + rounded + shadowed card.
- Hover **debounce + owner-checked dismissal live on `MessageDisplayModel`** (`requestPreview`/`endPreview`/`clearPreview`) so every teardown path (notch-leave, hide, reply) cancels centrally — a per-cell task could otherwise resurrect a just-cleared preview. `previewImageID` is deliberately kept out of the container's `.animation(value:)` lists, so it never re-runs the expand/history springs.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — all 60 tests pass
- [x] Adversarial multi-lens review (capture-leak / animation+teardown+memory / concurrency / UX+positioning); all confirmed findings fixed
- [x] Manual on-device: hover an album thumbnail → large preview floats below the notch, full-res upgrade, dismisses on hover-out; capture-exclusion holds (invisible in screenshots unless the DEBUG "Allow in screenshots" toggle is on)

Closes #69