### PR TITLE
feat(macos): per-image and per-message copy controls in the notch

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -43,6 +43,10 @@ final class MessageDisplayModel: ObservableObject {
     /// Which history row just had its text copied — drives the per-row
     /// checkmark, independent of `copied` (the current message's button).
     @Published var copiedHistoryID: UUID?
+    /// Which album image just had its picture copied — drives the per-image
+    /// checkmark, independent of `copied` (the current message's button). The
+    /// id is the image's r2Key (IncomingImage.id).
+    @Published var copiedImageID: String?
     /// Which history row the pointer is over, or nil when it's over the current
     /// message (or a gap). Tells the hover-"C" shortcut which row to copy; nil
     /// means copy the current (newest) message.
@@ -57,6 +61,13 @@ final class MessageDisplayModel: ObservableObject {
     /// A row registers its target only while hovered, so a non-hovered row's
     /// trailing area still falls through to the expand toggle.
     var historyCopyTargets: [HistoryCopyTarget] = []
+    /// Hover-revealed per-image copy hit targets, mirroring historyCopyTargets:
+    /// the glyph is a plain visual (CopyGlyph) and the AppKit click monitor in
+    /// NotchPresenter matches clicks against these frames — checked FIRST, before
+    /// the reply/teaser markers, so copying a picture never also opens the reply
+    /// field. A cell registers its target only while hovered. Not @Published:
+    /// read by the monitor, it never needs to drive a refresh itself.
+    var imageCopyTargets: [ImageCopyTarget] = []
     /// Marker views registered by the container so NotchPresenter's click
     /// monitor can match clicks against their frames. NSHostingView's
     /// hitTest doesn't surface embedded NSViews, so frames it is.
@@ -69,16 +80,6 @@ final class MessageDisplayModel: ObservableObject {
 
     func copy(_ text: String) {
         writePasteboard(text)
-        flashCopied()
-    }
-
-    /// Copy a received image to the clipboard (full resolution if it has
-    /// loaded, otherwise the inline thumbnail).
-    func copyImage(_ data: Data) {
-        guard let image = NSImage(data: data) else { return }
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.writeObjects([image])
         flashCopied()
     }
 
@@ -153,6 +154,32 @@ final class MessageDisplayModel: ObservableObject {
         historyCopyTargets.append(HistoryCopyTarget(id: id, text: text, view: view))
     }
 
+    /// Copy one album image to the clipboard, flashing the checkmark on that
+    /// image's glyph alone. The bytes are resolved at click time (full
+    /// resolution if it has loaded, else the inline thumbnail).
+    func copyImage(id: String, data: Data) {
+        writeImagePasteboard(data)
+        withAnimation(.spring(duration: 0.3)) { copiedImageID = id }
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            // Only clear if this image is still the one showing the checkmark,
+            // so a fresh copy on another image isn't cut short.
+            if copiedImageID == id {
+                withAnimation(.spring(duration: 0.3)) { copiedImageID = nil }
+            }
+        }
+    }
+
+    /// Register an image's copy hit target (called from the hover-revealed
+    /// glyph). Replaces any prior target for the same image and drops dead ones,
+    /// so the list never grows past the handful of cells hovered in one panel's
+    /// life. The `resolve` closure is stored so full-vs-thumb is decided at the
+    /// moment the click lands, not when the cell was first hovered.
+    func registerImageCopy(id: String, resolve: @escaping () -> Data, view: NSView) {
+        imageCopyTargets.removeAll { $0.view == nil || $0.id == id }
+        imageCopyTargets.append(ImageCopyTarget(id: id, resolve: resolve, view: view))
+    }
+
     /// The hover-"C" shortcut target: the hovered history row, or — when the
     /// pointer isn't over a row — the current (newest) message.
     func copyHovered() {
@@ -167,6 +194,13 @@ final class MessageDisplayModel: ObservableObject {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
+    }
+
+    private func writeImagePasteboard(_ data: Data) {
+        guard let image = NSImage(data: data) else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.writeObjects([image])
     }
 }
 
@@ -183,6 +217,25 @@ final class HistoryCopyTarget {
     init(id: UUID, text: String, view: NSView) {
         self.id = id
         self.text = text
+        self.view = view
+    }
+}
+
+/// A hover-revealed copy affordance on an album image. Holds the image's id
+/// (its r2Key) and a `resolve` closure returning the bytes to copy — evaluated
+/// at click time so the full resolution is preferred once it has loaded — plus
+/// a weak reference to the marker NSView laid out under the glyph;
+/// NotchPresenter's click monitor copies the image whose view contains the
+/// click. Weak view: once the cell un-hovers the marker leaves the hierarchy
+/// and this target goes stale (matched against nothing, pruned on next use).
+final class ImageCopyTarget {
+    let id: String
+    let resolve: () -> Data
+    weak var view: NSView?
+
+    init(id: String, resolve: @escaping () -> Data, view: NSView) {
+        self.id = id
+        self.resolve = resolve
         self.view = view
     }
 }
@@ -224,14 +277,18 @@ struct MessageNotchContainer: View {
                         // message itself, not anywhere on the shape.
                         .background(AreaMarker { [weak model] in model?.replyMarker = $0 })
                         // Expanded, the copy button travels down to sit on
-                        // the message it copies. For an image it copies the
-                        // picture (full resolution if loaded, else the thumb).
+                        // the message it copies. It copies the text/caption;
+                        // pictures are copied per-image via the cell glyphs, so
+                        // a captionless image message hides it (see
+                        // showsMessageCopyButton).
                         .overlay(alignment: .topTrailing) {
-                            CopyMessageButton(copied: model.copied, diameter: avatarSize) {
-                                copyCurrent()
+                            if showsMessageCopyButton {
+                                CopyMessageButton(copied: model.copied, diameter: avatarSize) {
+                                    copyCurrent()
+                                }
+                                .padding(.top, 2)
+                                .padding(.trailing, 4)
                             }
-                            .padding(.top, 2)
-                            .padding(.trailing, 4)
                         }
                     if model.replySent {
                         sentConfirmation
@@ -256,7 +313,7 @@ struct MessageNotchContainer: View {
         // In the teaser the copy button sits in the strip right of the
         // cutout; expanded it moves onto the message itself (see above).
         .overlay(alignment: .topTrailing) {
-            if !model.fullyExpanded {
+            if !model.fullyExpanded, showsMessageCopyButton {
                 CopyMessageButton(copied: model.copied, diameter: avatarSize) {
                     copyCurrent()
                 }
@@ -507,14 +564,19 @@ struct MessageNotchContainer: View {
         return message.images.count == 1 ? "Image" : "\(message.images.count) images"
     }
 
-    /// Copies the current message: the first picture for an album (full
-    /// resolution if it has loaded, else its thumbnail), otherwise its text.
+    /// Copies the current message's text — a plain message's body, or an
+    /// album's caption. Pictures are copied per-image via the glyph on each
+    /// cell (see AlbumCell), so a captionless image message has nothing to copy
+    /// here and hides this button entirely (see showsMessageCopyButton).
     private func copyCurrent() {
-        if let first = message.images.first {
-            model.copyImage(model.fullImages[first.id] ?? first.thumb)
-        } else {
-            model.copy(message.text)
-        }
+        model.copy(message.text)
+    }
+
+    /// Whether the per-message copy button is shown at all. It copies
+    /// text/caption, so an image message with no caption — which has no text —
+    /// drops it and relies solely on the per-image copy glyphs.
+    private var showsMessageCopyButton: Bool {
+        !message.isImage || !message.text.isEmpty
     }
 
     /// Vertically centers the avatar in the menu-bar-height strip above.

--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -142,9 +142,13 @@ struct AlbumCell: View {
     let fill: Bool
 
     @State private var decoded: CGImage?
+    @State private var hovering = false
 
     private var isLoaded: Bool { model.fullImages[image.id] != nil }
     private var didFail: Bool { model.failedImages.contains(image.id) }
+
+    /// Matches the history rows' copy glyph.
+    private let glyphDiameter: CGFloat = 20
 
     var body: some View {
         ZStack {
@@ -165,12 +169,19 @@ struct AlbumCell: View {
             }
         }
         .clipped()
-        // Hovering pops the large Quick-Look preview (ImagePreviewOverlay),
+        // Per-image copy: a hover-revealed glyph on the picture, mirroring the
+        // history rows. The glyph is purely visual — clicking it is caught by
+        // NotchPresenter's event monitor, which matches the hover-registered
+        // hit target laid out beneath it (a SwiftUI Button here would sit inside
+        // the reply marker and a click would both copy AND open the reply).
+        .overlay(alignment: .topTrailing) { copyGlyph }
+        // One hover handler drives both per-image affordances: the copy glyph
+        // (local `hovering`) and the large Quick-Look preview (ImagePreviewOverlay,
         // rendered free-floating below the notch in the same capture-excluded
-        // panel window. The debounce + owner-checked dismissal live on the model
-        // (centrally cancellable) so a dropped leave or teardown can't resurrect
-        // a cleared preview.
+        // panel window). The preview's debounce + owner-checked dismissal live on
+        // the model, so a dropped leave or teardown can't resurrect a cleared one.
         .onHover { inside in
+            hovering = inside
             if inside {
                 model.requestPreview(image.id)
             } else {
@@ -178,6 +189,36 @@ struct AlbumCell: View {
             }
         }
         .task { await load() }
+    }
+
+    /// Copy affordance: hidden until hover (or while its checkmark lingers),
+    /// flashing the checkmark on this image alone via copiedImageID. The hit
+    /// target only exists while hovered — NotchPresenter copies the image whose
+    /// target the click lands in, resolving full-vs-thumb at that moment.
+    private var copyGlyph: some View {
+        let isCopied = model.copiedImageID == image.id
+        let show = hovering || isCopied
+        return CopyGlyph(copied: isCopied, diameter: glyphDiameter)
+            .opacity(show ? 1 : 0)
+            .background {
+                if hovering {
+                    ImageCopyHitTarget(
+                        id: image.id,
+                        // [weak model]: the resolve closure is stored on the
+                        // model (via imageCopyTargets) — a strong capture would
+                        // retain-cycle the model and leak its full-res image
+                        // bytes past the message's RAM-only lifetime. At click
+                        // time the monitor already holds the live model, so the
+                        // weak ref is never nil then; after teardown it lets the
+                        // model deallocate.
+                        resolve: { [weak model] in model?.fullImages[image.id] ?? image.thumb }
+                    ) { [weak model] id, resolve, view in
+                        model?.registerImageCopy(id: id, resolve: resolve, view: view)
+                    }
+                }
+            }
+            .padding(4)
+            .animation(.easeInOut(duration: 0.12), value: show)
     }
 
     private func load() async {
@@ -199,6 +240,24 @@ struct AlbumCell: View {
             model.failedImages.insert(image.id)
         }
     }
+}
+
+/// Invisible NSView laid out under an album image's copy glyph. Like AreaMarker
+/// but carries the image id and a `resolve` closure (full bytes if loaded, else
+/// the thumbnail), registered into the model so the click monitor can copy the
+/// matching image (NSHostingView's hitTest can't surface it).
+private struct ImageCopyHitTarget: NSViewRepresentable {
+    let id: String
+    let resolve: () -> Data
+    let register: (String, @escaping () -> Data, NSView) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        register(id, resolve, view)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
 /// A tiny thumbnail-only image (no R2 fetch) for the collapsed teaser strip.

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -334,12 +334,17 @@ final class NotchPresenter {
                     // hitTest is useless here (NSHostingView returns
                     // itself wherever SwiftUI content covers the marker),
                     // so clicks are matched against the marker frames via
-                    // AppKit coordinate conversion instead. A hovered history
-                    // row's copy glyph wins first (copy that row), then history
-                    // clicks toggle the truncation, then clicks on the current
-                    // message open the reply — everything else on the shape is
-                    // inert (buttons handle themselves).
-                    if let target = model.historyCopyTargets.first(where: { Self.click(event, lands: $0.view) }) {
+                    // AppKit coordinate conversion instead. A hovered album
+                    // image's copy glyph wins first (copy that picture, bytes
+                    // resolved now so full-vs-thumb is decided at click time),
+                    // then a hovered history row's copy glyph (copy that row),
+                    // then history clicks toggle the truncation, then clicks on
+                    // the current message open the reply — everything else on the
+                    // shape is inert (buttons handle themselves). The image copy
+                    // falls through to nothing else, so reply does not open.
+                    if let target = model.imageCopyTargets.first(where: { Self.click(event, lands: $0.view) }) {
+                        model.copyImage(id: target.id, data: target.resolve())
+                    } else if let target = model.historyCopyTargets.first(where: { Self.click(event, lands: $0.view) }) {
                         model.copyHistory(id: target.id, text: target.text)
                     } else if Self.click(event, lands: model.historyMarker) {
                         withAnimation(.spring(duration: 0.3)) {


### PR DESCRIPTION
Closes #71.

## Summary

Makes "copy" explicit for messages with image attachments in the expanded notch:

- **Per-image copy** — hovering an individual album image reveals a copy glyph; clicking it copies *that* picture to the clipboard (full resolution if it has loaded into `fullImages`, else the inline thumbnail — resolved at click time). Works for both the single-image and the album-grid layouts.
- **Per-message copy** — the message copy button (`CopyMessageButton`) now copies the message **text/caption**, distinct from per-image copy. A captionless image message has no text to copy, so the button is hidden (`showsMessageCopyButton`) and you copy pictures via the per-image glyphs.

## Implementation

Per-image copy mirrors the existing **history-row copy** mechanism exactly, because clicks in the notch are caught by an AppKit local event monitor in `NotchPresenter`, not by SwiftUI buttons (a `Button` over an `AlbumCell` would sit inside the reply marker, and a click would both copy *and* open the reply field):

- `MessageDisplayModel`: `copiedImageID` (per-image flash, independent of the shared `copied`), `imageCopyTargets`, `registerImageCopy(id:resolve:view:)`, `copyImage(id:data:)`, and an `ImageCopyTarget` class. The dead single-arg `copyImage(_:)` was removed.
- `AlbumCell`: a hover-revealed `CopyGlyph` (top-trailing) backed by an invisible `ImageCopyHitTarget` NSView.
- `NotchPresenter.installClickMonitors`: a new branch checked **first** (before history/reply markers), so a picture-copy click never falls through to the reply.
- The `resolve` closure is `[weak model]` so it never retains the model — and its decrypted full-resolution image bytes — past the message's RAM-only lifetime.

## Screen-capture exclusion

No `.help()`, tooltip, popover, or separate window is introduced. The glyph and hit target live entirely inside content already covered by `.excludedFromScreenCapture()`, same as the history-copy affordance — nothing can leak into a Teams/Zoom share.

## Out of scope

- Per-image copy in **expanded history** — depends on #70 (history images), which hasn't landed; history rows are still text-only.
- Collapsed teaser thumbnails (`NotchThumb`) keep no per-image affordance.

## Design decision (please confirm)

The per-message button now copies text/caption only; captionless image messages rely solely on the per-image glyphs and lose the previous teaser-level "copy the first image" shortcut. If keeping a message-level image-copy fallback is preferred, say so.

> Cell-size note: this rebases onto #82 (≤4 thumbnails per row), so 4-up album cells are ~55pt — the 20pt copy glyph reads prominently in the corner there. Worth a glance during live QA.

## Test plan

- [x] `swift build` (apps/macos) — clean
- [x] `swift test` — 60/60 passing
- [ ] Live notch QA: per-image hover glyph; click copies that image without opening reply; per-image checkmark flash; per-message button copies caption / hides when captionless; glyph size on a 4-/8-image album
