### PR TITLE
fix(macos): harden auth-code notch (review follow-ups)

### DIFF
--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -24,7 +24,10 @@ final class AppModel: ObservableObject {
         }
     }
     @Published private(set) var githubLoginState: GitHubLoginState = .idle {
-        didSet { syncAuthCodeNotch() }
+        didSet {
+            guard githubLoginState != oldValue else { return }
+            syncAuthCodeNotch()
+        }
     }
     @Published private(set) var githubUserLogin: String? = Identity.githubLogin
     @Published var relayURLString: String {

--- a/apps/macos/Sources/MunkelApp/AuthCodeNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/AuthCodeNotchView.swift
@@ -28,11 +28,11 @@ struct AuthCodeNotchView: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 4)
-        // The device code must never leak into a screen share. The panel
-        // window is already non-capturable (sharingType), but the rule wants
-        // the content layer covered too — on the root, outside any conditional
-        // branch — so nothing slips through while the view is mounting. See
-        // CaptureExclusion, and MessageNotchContainer / CommandPaletteView.
+        // The device code must never leak into a screen share. The panel window
+        // is born non-capturable (NotchPanelWindow sets sharingType at birth) —
+        // that's the primary guarantee. This content-root exclusion is the
+        // second layer the project's rule wants, matching MessageNotchContainer
+        // and CommandPaletteView. Keep it on the root, never inside a branch.
         .excludedFromScreenCapture()
     }
 }

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -517,7 +517,15 @@ final class NotchPresenter {
         let previous = authCodeOp
         authCodeOp = Task { [weak self] in
             await previous?.value
+            // Idempotent: a panel is already up for this flow. This relies on
+            // every new `.awaitingUser` being preceded by a non-`.awaitingUser`
+            // state (startGitHubLogin sets `.requestingCode`), which runs
+            // hideAuthCode and nils this first — so a fresh code always rebuilds.
             guard let self, self.authCodeNotch == nil else { return }
+            // The notch slot holds one panel: clear a stale unread indicator
+            // that could linger into a re-login. No message notch can race here
+            // — sessions are login-gated, so none are live mid-sign-in.
+            self.hideIndicator()
             let targetScreen: @MainActor () -> NSScreen? = { NSScreen.main }
             let notch = AuthCodeNotch(hoverBehavior: .none, targetScreen: targetScreen) {
                 AuthCodeNotchView(code: code)


### PR DESCRIPTION
Follow-up hardening for the GitHub sign-in-code notch shipped in #85, from a `/review` adversarial pass. No happy-path behavior change.

## Changes
- **`AppModel.swift`** — guard the `githubLoginState` `didSet` on `oldValue != newValue`, so the notch sync only fires on real transitions (mirrors the existing `displayName` guard in the same file). Prevents redundant show/hide churn on any equal-value reassignment.
- **`NotchPresenter.swift`** — `hideIndicator()` when showing the auth code, so a stale unread indicator can't share the single-occupant notch slot across a re-login. Plus a comment documenting the invariant the `authCodeNotch == nil` guard relies on: every new `.awaitingUser` is preceded by a non-`.awaitingUser` state (`startGitHubLogin` sets `.requestingCode`), which hides + nils the panel first, so a fresh code always rebuilds.
- **`AuthCodeNotchView.swift`** — correct the capture-exclusion comment. The primary non-capturable guarantee is the panel window's birth `sharingType` (`NotchPanelWindow`); the content-root `.excludedFromScreenCapture()` is the redundant second layer, matching `MessageNotchContainer`. The old comment over-claimed the content layer as the "while mounting" protection.

## Review notes (flagged but verified as not reachable, no code change)
The adversarial pass also raised a "stale code shown" guard and a "capture leak" as CRITICAL. Both verified against the merged code: `.awaitingUser` is written exactly once per flow with an interceding state, and the device code is never composited capturable (panel born `.none`). A latent `NotchPanel.hide()` continuation-leak on cancellation is pre-existing (not introduced by the notch work).

## Test plan
- [x] `swift build` green on top of current `main` (includes #85 + #86).
- [ ] Manual: sign-in code still appears on `.awaitingUser` and clears on success/cancel (unchanged from #85).