### PR TITLE
fix(macos): keep the notch reply alive while the image picker is open

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -557,7 +557,12 @@ struct MessageNotchContainer: View {
     /// clipboard image into model.attachedImages. Copied from
     /// MenuView.updatePasteMonitor; plain-text paste falls through to the field.
     private func updatePasteMonitor(_ focused: Bool) {
-        if focused, pasteMonitor == nil {
+        // Gate the install on an actually-open reply: the field's 80ms focus
+        // Task can fire after the reply was dismissed (onDisappear already tore
+        // the monitor down). Without this guard that late focus write would
+        // re-install a monitor nothing then removes — a leak that swallows ⌘V
+        // globally. model.replying is false by then, so the install is skipped.
+        if focused, model.replying, pasteMonitor == nil {
             pasteMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
                 var consume = false
                 MainActor.assumeIsolated {

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -33,6 +33,11 @@ final class NotchPresenter {
     private var indicatorHoverObservation: AnyCancellable?
     private var clickMonitor: Any?
     private var outsideClickMonitor: Any?
+    /// While a modal file picker (NSOpenPanel) is up, its in-process clicks
+    /// would be read as "clicked outside the notch" by the click monitors and
+    /// collapse the open reply. Set during pickImageFile to suppress the
+    /// dismiss, mirroring CommandPalettePresenter.suppressResignHide.
+    private var suppressReplyDismiss = false
     /// Tracks whether user has interacted with the current message.
     private var userInteractedWithMessage = false
 
@@ -365,7 +370,7 @@ final class NotchPresenter {
                         || Self.click(event, lands: model.teaserMarker) {
                         self.beginReply(model: model, panel: panel)
                     }
-                } else {
+                } else if !self.suppressReplyDismiss {
                     self.cancelReply()
                 }
             }
@@ -373,7 +378,8 @@ final class NotchPresenter {
         }
         outsideClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.cancelReply()
+                guard let self, !self.suppressReplyDismiss else { return }
+                self.cancelReply()
             }
         }
     }
@@ -446,35 +452,32 @@ final class NotchPresenter {
     /// window, which this dialog does not do).
     private func pickImageFile(model: MessageDisplayModel) {
         guard model.replying, model.canAttachMore, let panel = currentNotch?.panel else { return }
-        // Suspend dismiss-on-outside-click and the auto-hide while modal.
+        // The modal NSOpenPanel runs in-process (the app isn't sandboxed), so its
+        // clicks reach both click monitors carrying the dialog's own window — which
+        // the monitors would read as "clicked outside the notch" and collapse the
+        // reply, dropping the images just picked. Suppress the dismiss for the
+        // modal's duration (mirrors CommandPalettePresenter.suppressResignHide)
+        // instead of tearing the monitors down. Also pause the auto-hide.
+        suppressReplyDismiss = true
         hideTask?.cancel()
-        if let outsideClickMonitor {
-            NSEvent.removeMonitor(outsideClickMonitor)
-            self.outsideClickMonitor = nil
+        defer {
+            suppressReplyDismiss = false
+            // The open dialog took key focus; hand it back so the reply field
+            // stays live and keeps accepting input.
+            panel.makeKeyAndOrderFront(nil)
         }
         let open = NSOpenPanel()
         open.allowedContentTypes = [.image]
         open.allowsMultipleSelection = true
         open.canChooseDirectories = false
         NSApp.activate(ignoringOtherApps: true)
-        let response = open.runModal()
-        if response == .OK {
-            for url in open.urls {
-                guard model.canAttachMore else { break }
-                // Skip an unreadable selection rather than abandoning the rest.
-                guard let data = try? Data(contentsOf: url) else { continue }
-                model.attach(data)
-            }
+        guard open.runModal() == .OK else { return }
+        for url in open.urls {
+            guard model.canAttachMore else { break }
+            // Skip an unreadable selection rather than abandoning the rest.
+            guard let data = try? Data(contentsOf: url) else { continue }
+            model.attach(data)
         }
-        // Re-arm the outside-click dismiss and restore key focus so the field
-        // keeps accepting input. (clickMonitor — the local one — was never
-        // removed, so only the global monitor needs re-adding.)
-        if outsideClickMonitor == nil {
-            outsideClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { [weak self] _ in
-                MainActor.assumeIsolated { self?.cancelReply() }
-            }
-        }
-        panel.makeKeyAndOrderFront(nil)
     }
 
     private func replyWasSent() {


### PR DESCRIPTION
Follow-up to #88 (Closes the regressions found in its pre-landing review). #88 squash-merged the inline-reply image attach; review caught two focus/monitor-lifecycle bugs in it.

## Fixes
- **Paperclip collapsed the reply (CRITICAL).** `NSOpenPanel.runModal()` runs in-process (the app isn't sandboxed), so its clicks reached the notch's local click monitor and were read as "clicked outside the notch" → `cancelReply()` → the reply field collapsed and the just-picked images were discarded. The feature was broken on its primary attach path. Fix: suppress the dismiss for the modal's duration via a `suppressReplyDismiss` flag that **both** click monitors check, set in `pickImageFile` with a `defer` reset + panel re-key — mirrors the established `CommandPalettePresenter.suppressResignHide`. Replaces the previous code that removed only the global monitor and left the local one armed (also adds the missing `defer`).
- **⌘V paste-monitor leak (Medium).** The reply field's delayed (80ms) focus `Task` could fire after `onDisappear` teardown and reinstall the local ⌘V monitor post-dismiss, leaking it (swallows ⌘V globally). Fix: gate the install on `model.replying`.

## Review provenance
Found by an independent adversarial pass during `/review`; the `suppressReplyDismiss` fix was cross-model-confirmed correct (both monitors guarded, `defer` restores, no stuck-true path).

## Known minor (deferred, not data-loss)
After the picker closes, SwiftUI `replyFocused` may not auto-restore (only the AppKit key window is), so ⌘V right after the paperclip might need one click back into the field. Tracked for an on-device check.

## Test plan
- [ ] Reply → 📎 → pick image(s): reply stays open, thumbnails appear (the CRITICAL fix)
- [ ] ⌘V stages a clipboard image; plain-text ⌘V still types
- [ ] Remove via ✕; 8-image cap disables 📎/⌘V
- [ ] Return sends image(s)+caption; private (lock) and broadcast (globe) both deliver
- [ ] Escape cancels; reopen shows no stale staged images
- [ ] Screen share excludes notch + strip