### PR TITLE
fix(macos): notch image thumbnails — per-image copy, layout & hover fixes

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -54,6 +54,12 @@ final class MessageDisplayModel: ObservableObject {
     /// Text of the current (newest) message, so the hover-"C" shortcut can copy
     /// it when the pointer isn't over a history row.
     var currentText = ""
+    /// `id` (r2Key) of the album image the pointer is over, set immediately on
+    /// hover (no debounce, unlike the visual `previewImageID`) and cleared on the
+    /// same lifecycle paths (endPreview / clearPreview). Lets the hover-"C"
+    /// shortcut copy the hovered picture instead of the message text. Not
+    /// @Published: read only at key-press time, it never drives a refresh.
+    var hoveredImageID: String?
     /// Hover-revealed per-row copy hit targets. The glyph itself is a plain
     /// visual (CopyGlyph); the AppKit click monitor in NotchPresenter matches
     /// clicks against these frames — just like historyMarker/replyMarker —
@@ -89,6 +95,9 @@ final class MessageDisplayModel: ObservableObject {
     /// instead of blanking for the debounce. The debounce is owned by the model
     /// so a leave/teardown can cancel it (see `clearPreview`).
     func requestPreview(_ id: String) {
+        // Immediate (the visual preview below is debounced, but the hover-"C"
+        // copy must work the instant the pointer is over the image).
+        hoveredImageID = id
         previewDebounce?.cancel()
         if previewImageID != nil {
             withAnimation(.easeOut(duration: 0.18)) { previewImageID = id }
@@ -106,6 +115,9 @@ final class MessageDisplayModel: ObservableObject {
     /// which can land before this leave, isn't undone).
     func endPreview(forCell id: String) {
         previewDebounce?.cancel()
+        // Owner-check (mirrors previewImageID): an adjacent cell's enter can set
+        // hoveredImageID before this leave fires, so only clear our own id.
+        if hoveredImageID == id { hoveredImageID = nil }
         if previewImageID == id {
             withAnimation(.easeOut(duration: 0.18)) { previewImageID = nil }
         }
@@ -116,6 +128,7 @@ final class MessageDisplayModel: ObservableObject {
     /// reliably fire when the notch is torn down, so this must not depend on it.
     func clearPreview(animated: Bool = false) {
         previewDebounce?.cancel()
+        hoveredImageID = nil
         guard previewImageID != nil else { return }
         if animated {
             withAnimation(.easeOut(duration: 0.18)) { previewImageID = nil }
@@ -180,10 +193,17 @@ final class MessageDisplayModel: ObservableObject {
         imageCopyTargets.append(ImageCopyTarget(id: id, resolve: resolve, view: view))
     }
 
-    /// The hover-"C" shortcut target: the hovered history row, or — when the
-    /// pointer isn't over a row — the current (newest) message.
+    /// The hover-"C" shortcut target, in priority order: the hovered album image
+    /// (resolved through its registered copy target, exactly like a click on the
+    /// per-image glyph), then the hovered history row, then — when the pointer
+    /// isn't over either — the current (newest) message. Images sit on the
+    /// current message, so without the image branch "C" over a picture fell
+    /// through to the message text instead of copying the picture.
     func copyHovered() {
-        if let id = hoveredHistoryID, let entry = history.first(where: { $0.id == id }) {
+        if let id = hoveredImageID,
+           let target = imageCopyTargets.first(where: { $0.id == id }) {
+            copyImage(id: id, data: target.resolve())
+        } else if let id = hoveredHistoryID, let entry = history.first(where: { $0.id == id }) {
             copyHistory(id: id, text: entry.text)
         } else if !currentText.isEmpty {
             copy(currentText)

--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -72,32 +72,34 @@ struct MessageNotchView: View {
         .padding(.vertical, 4)
     }
 
-    /// A lone image fills the width at its own aspect; an album is a grid of
-    /// square cells, up to four per row.
+    /// Every picture is a square, fill-cropped thumbnail — a lone image included
+    /// — so a row of mixed aspect ratios stays tidy and a single image lines up
+    /// with album cells; the hover preview shows each one whole. Up to four per
+    /// row, fewer-but-larger cells for smaller albums.
+    ///
+    /// A non-lazy VStack/HStack grid (not LazyVGrid): an album is at most eight
+    /// cells, so laziness buys nothing, and LazyVGrid's per-cell `.onHover` only
+    /// fires reliably for the first cell — which hid the copy glyph on the rest.
     @ViewBuilder private var imageContent: some View {
-        if message.images.count == 1, let only = message.images.first {
-            let size = fittedSize(width: only.width, height: only.height)
-            AlbumCell(model: model, image: only, fill: false)
-                .frame(width: size.width, height: size.height)
-                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        } else {
-            // Pack up to four thumbnails per row; smaller albums use fewer,
-            // larger columns (2 → two-up, 3 → three-up, 4+ → four per row).
-            let columnCount = min(4, message.images.count)
-            let side = (imageWidth - CGFloat(columnCount - 1) * gridSpacing) / CGFloat(columnCount)
-            let columns = Array(
-                repeating: GridItem(.fixed(side), spacing: gridSpacing),
-                count: columnCount
-            )
-            LazyVGrid(columns: columns, alignment: .leading, spacing: gridSpacing) {
-                ForEach(message.images) { img in
-                    AlbumCell(model: model, image: img, fill: true)
-                        .frame(width: side, height: side)
-                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        let count = message.images.count
+        let columnCount = min(4, count)
+        let side = (imageWidth - CGFloat(columnCount - 1) * gridSpacing) / CGFloat(columnCount)
+        // A lone image gets a slightly softer corner than the tighter album cells.
+        let radius: CGFloat = count == 1 ? 10 : 8
+        let rows = stride(from: 0, to: count, by: columnCount).map { start in
+            Array(message.images[start..<min(start + columnCount, count)])
+        }
+        VStack(alignment: .leading, spacing: gridSpacing) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack(spacing: gridSpacing) {
+                    ForEach(row) { img in
+                        AlbumCell(model: model, image: img, cornerRadius: radius,
+                                  displaySize: CGSize(width: side, height: side))
+                    }
                 }
             }
-            .frame(width: imageWidth, alignment: .leading)
         }
+        .frame(width: imageWidth, alignment: .leading)
     }
 
     private var header: some View {
@@ -118,17 +120,6 @@ struct MessageNotchView: View {
         }
         .foregroundStyle(.white.opacity(0.55))
     }
-
-    /// A lone image's display size: its aspect scaled to fit the bounding box
-    /// (never upscaled past it).
-    private func fittedSize(width: Int, height: Int) -> CGSize {
-        let w = CGFloat(width)
-        let h = CGFloat(height)
-        let maxHeight: CGFloat = 260
-        guard w > 0, h > 0 else { return CGSize(width: imageWidth, height: imageWidth * 0.6) }
-        let scale = min(imageWidth / w, maxHeight / h)
-        return CGSize(width: max(1, w * scale), height: max(1, h * scale))
-    }
 }
 
 /// One image cell: paints its inline thumbnail instantly, then fetches its full
@@ -138,8 +129,15 @@ struct MessageNotchView: View {
 struct AlbumCell: View {
     @ObservedObject var model: MessageDisplayModel
     let image: IncomingImage
-    /// Grid cells fill+crop to a square; a lone image fits its aspect.
-    let fill: Bool
+    /// Corner radius for the picture. Applied to the image here (not by the
+    /// caller) so the copy glyph can sit OUTSIDE the rounded clip — a clip on
+    /// the whole cell would shave the glyph's top-right corner.
+    let cornerRadius: CGFloat
+    /// Final on-screen size of the picture. Sized + clipped HERE (not by the
+    /// caller) so the frame constrains the layout BEFORE the clip: a `.fill`
+    /// image reports an oversized intrinsic frame, and clipping before the frame
+    /// let that overflow spill over and overlap neighbouring content.
+    let displaySize: CGSize
 
     @State private var decoded: CGImage?
     @State private var hovering = false
@@ -156,7 +154,7 @@ struct AlbumCell: View {
                 Image(decorative: decoded, scale: 1)
                     .resizable()
                     .interpolation(.medium)
-                    .aspectRatio(contentMode: fill ? .fill : .fit)
+                    .aspectRatio(contentMode: .fill)
             } else {
                 Rectangle().fill(.white.opacity(0.08))
             }
@@ -168,13 +166,25 @@ struct AlbumCell: View {
                     .foregroundStyle(.white.opacity(0.6))
             }
         }
-        .clipped()
+        // Size + round the picture HERE, before the copy-glyph overlay: the
+        // frame pins the layout to the final cell size so a `.fill` image's
+        // overflow can't spill onto neighbours, the clip crops that overflow and
+        // rounds the corner, and the glyph (added next, outside the clip) is
+        // never shaved by the rounding.
+        .frame(width: displaySize.width, height: displaySize.height)
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         // Per-image copy: a hover-revealed glyph on the picture, mirroring the
         // history rows. The glyph is purely visual — clicking it is caught by
         // NotchPresenter's event monitor, which matches the hover-registered
         // hit target laid out beneath it (a SwiftUI Button here would sit inside
         // the reply marker and a click would both copy AND open the reply).
         .overlay(alignment: .topTrailing) { copyGlyph }
+        // Hit-test the cell as its plain square. `.clipShape` only clips the
+        // pixels: a `.fill` image still reports its oversized (overflowing) frame
+        // for hit-testing, so without this the wider image of an adjacent cell
+        // (drawn on top) steals the hover over this cell's edge — the glyph then
+        // only appeared near the side the neighbour's overflow didn't reach.
+        .contentShape(Rectangle())
         // One hover handler drives both per-image affordances: the copy glyph
         // (local `hovering`) and the large Quick-Look preview (ImagePreviewOverlay,
         // rendered free-floating below the notch in the same capture-excluded

--- a/apps/macos/Sources/MunkelApp/MunkelApp.swift
+++ b/apps/macos/Sources/MunkelApp/MunkelApp.swift
@@ -55,18 +55,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         popover.delegate = self
 
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-        #if DEBUG
-        // The debug build runs as "Munkel Dev" next to an installed release; a
-        // distinct icon tells the two menu-bar items apart at a glance.
-        item.button?.image = NSImage(
-            systemSymbolName: "ladybug.fill",
-            accessibilityDescription: "Munkel Dev"
-        )
-        #else
         // Brand silhouette as a template image (monochrome, auto-inverting),
         // sized to sit in the menu bar; falls back to the old SF Symbol if the
         // glyph resource is ever missing. Copy first so menu-bar sizing never
         // mutates the shared BrandGlyph.templateImage the popover also uses.
+        // Debug and release share the brand glyph — the dev build is told apart
+        // by its "Munkel Dev" name in the popover, not a separate menu-bar icon.
         if let glyph = BrandGlyph.templateImage?.copy() as? NSImage {
             glyph.isTemplate = true
             glyph.size = NSSize(width: 18, height: 18)
@@ -78,7 +72,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 accessibilityDescription: "Munkel"
             )
         }
-        #endif
         item.button?.target = self
         item.button?.action = #selector(togglePopover(_:))
         statusItem = item


### PR DESCRIPTION
## What & why

A round of fixes to how shared images look and behave in the notch, found while dogfooding image sharing. Each was reproduced and the fix verified live.

### Image rendering & copy (`MessageNotchView`, `MessageNotchContainer`)
- **Hover + C copies the hovered image**, not the message text. `copyHovered()` now checks the hovered album image first and resolves its bytes through the same per-image copy target a glyph click uses (a new immediate, debounce-free `hoveredImageID` on the model, cleared on the same lifecycle paths as the preview).
- **The copy glyph shows on every image, not just the first.** Root cause: `LazyVGrid`'s per-cell `.onHover` only fires reliably for the first cell. Swapped for a plain non-lazy `VStack`/`HStack` grid (an album is ≤ 8 cells, so laziness bought nothing).
- **The glyph is no longer shaved at the top-right corner.** The rounded clip is applied to the picture *inside* the cell, with the glyph overlaid outside the clip.
- **Images no longer overlap neighbouring content.** Each cell is framed to its final size *before* the clip, so a `.fill` image's overflow can't spill onto its neighbours.
- **Hover is hit-tested as the cell's plain square** (`.contentShape(Rectangle())`), so an adjacent cell's overflowing image can't steal the hover near the shared edge (the glyph used to appear only near one side).
- **Thumbnails are now uniform square crops** — a lone image included — so mixed aspect ratios line up tidily; the hover preview still shows each picture whole.

### Menu bar (`MunkelApp`)
- The debug build's menu-bar **ladybug is dropped for the brand glyph**; debug vs. release is still told apart by the "Munkel Dev" popover title.

## Test plan
- [x] Hover any image in a 1- / 2- / …​ / 8-image album → copy glyph appears anywhere over each cell
- [x] Hover an image + press **C** → that image lands on the clipboard (not the caption)
- [x] Single image renders as a square crop; hover preview shows it whole
- [x] 8-image album packs 4×2 with no overlap onto surrounding content
- [x] Copy glyph fully visible (corner not clipped)
- [x] `swift test` green (60 tests)
- [ ] Sanity-check on a notch-less external display