### PR TITLE
feat(macos): render past image messages in the expanded notch history

### DIFF
--- a/apps/macos/Sources/MunkelApp/IncomingMessage.swift
+++ b/apps/macos/Sources/MunkelApp/IncomingMessage.swift
@@ -36,9 +36,27 @@ struct IncomingImage: Equatable, Identifiable, Sendable {
 struct HistoryEntry: Identifiable, Equatable {
     let id = UUID()
     let sender: String
+    /// Collapsed-row label — the body text, or a `📷 …` caption/count for an
+    /// album. Also what the per-row copy affordance copies.
     let text: String
     let isDirect: Bool
     let group: String
     let groupColor: Color
     let receivedAt: Date
+    /// Album images for an image message (empty for plain text), carried so the
+    /// EXPANDED history can render thumbnails that upgrade to full resolution
+    /// just like the current message. RAM-only — gone when the entry is pruned.
+    var images: [IncomingImage] = []
+    /// The album's real caption (no `📷` prefix), shown beneath the thumbnails
+    /// in the expanded view; empty when the album had none.
+    var caption: String = ""
+    /// Per-image full-resolution loader (R2 fetch keyed by r2Key); nil for a
+    /// text entry. Excluded from `Equatable` — closures aren't comparable, and
+    /// entries are never reassigned after construction and carry a unique id, so
+    /// `==` compares ids alone.
+    var loadFull: (@Sendable (String) async -> Data?)?
+
+    var isImage: Bool { !images.isEmpty }
+
+    static func == (lhs: HistoryEntry, rhs: HistoryEntry) -> Bool { lhs.id == rhs.id }
 }

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -730,7 +730,18 @@ private struct HistoryRow: View {
                 HStack(alignment: .top, spacing: 4) {
                     VStack(alignment: .leading, spacing: 1) {
                         header
-                        text.fixedSize(horizontal: false, vertical: true)
+                        if entry.isImage {
+                            // The album that the collapsed 📷 row stands in for —
+                            // thumbnails upgrading to full resolution like the
+                            // current message, with the real caption beneath.
+                            HistoryAlbumGrid(model: model, entry: entry)
+                                .padding(.top, 2)
+                            if !entry.caption.isEmpty {
+                                caption
+                            }
+                        } else {
+                            text.fixedSize(horizontal: false, vertical: true)
+                        }
                     }
                     Spacer(minLength: 4)
                     glyph
@@ -791,6 +802,16 @@ private struct HistoryRow: View {
             .foregroundStyle(.white.opacity(0.55))
     }
 
+    /// The album's real caption, shown under the thumbnails in the expanded
+    /// view (the collapsed row uses the 📷 label in `text` instead).
+    private var caption: some View {
+        Text(entry.caption)
+            .font(.system(size: 11))
+            .foregroundStyle(.white.opacity(0.55))
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.top, 2)
+    }
+
     /// Copy affordance: hidden until hover (or while its checkmark lingers),
     /// always reserving its slot so the text doesn't reflow on reveal. The
     /// hit target only exists while hovered — NotchPresenter copies the row
@@ -808,6 +829,122 @@ private struct HistoryRow: View {
                 }
             }
             .animation(.easeInOut(duration: 0.12), value: show)
+    }
+}
+
+/// The album of a past image message, laid out for the expanded history: a lone
+/// picture fits its aspect, an album packs up to four square thumbnails per row —
+/// a compact echo of the current message's grid (MessageNotchView.imageContent),
+/// scaled down to suit the secondary, dimmed history area.
+private struct HistoryAlbumGrid: View {
+    @ObservedObject var model: MessageDisplayModel
+    let entry: HistoryEntry
+
+    /// Narrower than the current message's grid: the history block is inset and
+    /// leaves room for the trailing copy glyph.
+    private let maxWidth: CGFloat = 196
+    private let spacing: CGFloat = 4
+
+    var body: some View {
+        let images = entry.images
+        if images.count == 1, let only = images.first {
+            let size = fittedSize(width: only.width, height: only.height)
+            HistoryAlbumCell(model: model, image: only, loadFull: entry.loadFull, fill: false)
+                .frame(width: size.width, height: size.height)
+                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        } else {
+            let columnCount = min(4, images.count)
+            let side = (maxWidth - CGFloat(columnCount - 1) * spacing) / CGFloat(columnCount)
+            let columns = Array(
+                repeating: GridItem(.fixed(side), spacing: spacing),
+                count: columnCount
+            )
+            LazyVGrid(columns: columns, alignment: .leading, spacing: spacing) {
+                ForEach(images) { img in
+                    HistoryAlbumCell(model: model, image: img, loadFull: entry.loadFull, fill: true)
+                        .frame(width: side, height: side)
+                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                }
+            }
+            .frame(width: maxWidth, alignment: .leading)
+        }
+    }
+
+    /// A lone image's aspect scaled to fit the history box (never upscaled past it).
+    private func fittedSize(width: Int, height: Int) -> CGSize {
+        let w = CGFloat(width)
+        let h = CGFloat(height)
+        let maxHeight: CGFloat = 130
+        guard w > 0, h > 0 else { return CGSize(width: maxWidth, height: maxWidth * 0.6) }
+        let scale = min(maxWidth / w, maxHeight / h)
+        return CGSize(width: max(1, w * scale), height: max(1, h * scale))
+    }
+}
+
+/// One history image cell: paints its inline thumbnail at once, then upgrades to
+/// full resolution via the entry's loader, caching the bytes on the shared model
+/// (keyed by the unique r2Key) so a collapse→expand toggle re-decodes from cache
+/// instead of re-fetching from R2. A self-contained sibling of `AlbumCell`
+/// WITHOUT the per-image copy glyph or hover preview — those belong to the
+/// current message; the history echo is a read-only thumbnail.
+///
+/// Cells mount — and so fetch — only when the history is actually expanded, and
+/// only the FIRST expand fetches (later ones hit the cache). The resulting burst
+/// across the backlog is hard-bounded by the ≤60 s history window, and R2 GETs
+/// stay valid within that window (the blob TTL mirrors it, and a GET isn't
+/// delete-on-fetch), so concurrent re-fetches are safe.
+private struct HistoryAlbumCell: View {
+    @ObservedObject var model: MessageDisplayModel
+    let image: IncomingImage
+    let loadFull: (@Sendable (String) async -> Data?)?
+    /// Grid cells fill+crop to a square; a lone image fits its aspect.
+    let fill: Bool
+
+    @State private var decoded: CGImage?
+
+    private var isLoaded: Bool { model.fullImages[image.id] != nil }
+    private var didFail: Bool { model.failedImages.contains(image.id) }
+
+    var body: some View {
+        ZStack {
+            if let decoded {
+                Image(decorative: decoded, scale: 1)
+                    .resizable()
+                    .interpolation(.medium)
+                    .aspectRatio(contentMode: fill ? .fill : .fit)
+            } else {
+                Rectangle().fill(.white.opacity(0.08))
+            }
+            if !isLoaded, !didFail {
+                ProgressView().controlSize(.small).tint(.white.opacity(0.7))
+            } else if didFail {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+        }
+        .clipped()
+        .task { await load() }
+    }
+
+    private func load() async {
+        // Instant preview from the inline thumbnail.
+        if decoded == nil {
+            let thumb = image.thumb
+            decoded = await Task.detached { ImageCodec.decode(thumb, maxPixels: 300) }.value
+        }
+        // Full resolution: reuse the shared cache, else fetch once via the loader.
+        if let full = model.fullImages[image.id] {
+            decoded = await Task.detached { ImageCodec.decode(full, maxPixels: 900) }.value
+            return
+        }
+        guard !didFail, let loadFull else { return }
+        if let data = await loadFull(image.id) {
+            model.fullImages[image.id] = data
+            decoded = await Task.detached { ImageCodec.decode(data, maxPixels: 900) }.value
+        } else {
+            model.failedImages.insert(image.id)
+        }
     }
 }
 

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -121,7 +121,13 @@ final class NotchPresenter {
             isDirect: isDirect,
             group: group,
             groupColor: groupColor,
-            receivedAt: Date()
+            receivedAt: Date(),
+            // Carry the album so the expanded history can show it later; the
+            // collapsed row still reads as the 📷 label above. `text` is the
+            // raw caption here (empty for a captionless album / plain message).
+            images: images,
+            caption: images.isEmpty ? "" : text,
+            loadFull: loadFull
         )
         pruneHistory()
         history.append(entry)


### PR DESCRIPTION
Closes #70.

## Problem

Only the current/last message rendered its picture in the notch; older image messages in the history were text-only — a `📷` placeholder with a caption or count — so a past album could never be viewed.

## Change

- **`HistoryEntry`** now carries its `[IncomingImage]`, the album's raw `caption`, and the per-image full-resolution `loadFull` loader. `Equatable` becomes **by-id only** (a stored closure isn't comparable, and entries are never reassigned after construction).
- **`NotchPresenter`** populates those fields when it builds the entry — so even a **live-absorbed** message (one arriving while the notch is already expanded) keeps its images and loader, without routing through the per-message `model.imageLoaders`.
- **Collapsed history row is unchanged** (still the `📷` label, one line). When the history is **expanded**, an image entry renders a new `HistoryAlbumGrid`: a lone picture fits its aspect, an album packs up to four square thumbnails per row — a compact echo of the current message's grid. Each `HistoryAlbumCell` paints its inline thumbnail at once, then upgrades to full resolution via the entry's loader, **caching the bytes on the shared model** (keyed by the unique r2Key) so a collapse→expand toggle re-decodes from cache instead of re-fetching.
- The history cells carry **no per-image copy glyph or hover Quick-Look preview** — those stay on the current message; the history echo is a read-only thumbnail.

## Acceptance criteria

- [x] `HistoryEntry` carries its `[IncomingImage]` (+ per-image full-res loader)
- [x] Collapsed history row stays as-is (`📷` + caption/count)
- [x] Expanded history renders album thumbnails, lazily upgrading to full resolution like the current message
- [x] History stays RAM-only / ephemeral — no persistence of image bytes
- [ ] Verify several past image messages each show their own images *(code path verified; runtime visual check pending — see Test plan)*

## Ephemerality & capture safety

- RAM-only: entries live in `NotchPresenter.history`, pruned at the 60s window; full-res bytes live only in the `@Published` `model.fullImages` cache and deallocate when the next message replaces the model. No persistence path (`FileManager`/`UserDefaults`/`.write(to:)` etc. — none added).
- The loader's R2 GETs stay valid within the window: the blob TTL (66s) mirrors the 60s notch window and a GET is **not** delete-on-fetch, so concurrent re-fetches on expand are safe.
- New views render strictly inside the capture-excluded notch panel — no new `NSWindow`/`NSPanel`/`QLPreviewPanel`/`.help()`.

## Review

Ran a 4-dimension adversarial review (correctness/concurrency, ephemerality+capture invariants, acceptance completeness, layout/UX). **No actionable defects.** One LOW, intentional trade-off surfaced and documented in-code: the expanded history `VStack` is non-lazy (a `LazyVStack` would break the `HistoryHeightKey` measurement that caps the scroll region), so the first expand fetches the whole backlog — bounded by the 60s window, cached thereafter.

## Test plan

- [x] `swift build` (apps/macos) passes
- [ ] Send several image albums, let them scroll into history, expand → each row shows its own album, thumbnails upgrade to full-res
- [ ] Collapse→expand toggle does not re-fetch (served from cache)
- [ ] Captionless album, single portrait/landscape image, 2/3/4/5+ image albums
- [ ] Confirm history images never leak into a screen share (capture exclusion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Known limitation (tracked: #94)

Cross-model review (`/review`) found that history image full-resolution **plaintext** is cached in `MessageDisplayModel.fullImages`, which is not pruned in step with the 60s history window (nor cleared on hide). So a viewed history album's decrypted bytes linger in RAM past their 60s row until the next message rebuilds the model. RAM-only (nothing on disk) and partly pre-existing for the current message, but #70 extends it to the strictly-bounded history tier. Shipping this PR as-is by decision; fix tracked in **#94** (P1, ~15 lines).
