### PR TITLE
feat(macos): notch display picker, ⌥M quick-send default, Launch-at-Login fix

### DIFF
--- a/apps/macos/Sources/MunkelApp/DisplayPreference.swift
+++ b/apps/macos/Sources/MunkelApp/DisplayPreference.swift
@@ -1,0 +1,75 @@
+import AppKit
+import Combine
+
+/// Which physical display the notch — and its unread-indicator and auth-code
+/// panels — appears on. The choice persists by the display's stable UUID, which
+/// survives reconnects and resolution changes (unlike the volatile
+/// `CGDirectDisplayID`), and resolution always falls back to the active screen
+/// when the chosen display is absent, so unplugging a monitor never hides the
+/// notch. Empty/unset means "automatic": follow the active screen.
+enum DisplayPreference {
+    /// UserDefaults key holding the chosen display's UUID string.
+    static let key = "preferredDisplayID"
+
+    /// One connected display, for the settings picker.
+    struct Option: Identifiable, Hashable {
+        let id: String   // stable UUID string
+        let name: String
+    }
+
+    /// Stable UUID string for a screen, or nil if it can't be derived.
+    @MainActor
+    static func id(of screen: NSScreen) -> String? {
+        guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber
+        else { return nil }
+        let displayID = CGDirectDisplayID(number.uint32Value)
+        guard let uuid = CGDisplayCreateUUIDFromDisplayID(displayID)?.takeRetainedValue() else { return nil }
+        return CFUUIDCreateString(nil, uuid) as String
+    }
+
+    /// Connected displays in system order, for the settings picker.
+    @MainActor
+    static func connected() -> [Option] {
+        NSScreen.screens.compactMap { screen in
+            id(of: screen).map { Option(id: $0, name: screen.localizedName) }
+        }
+    }
+
+    /// The screen the notch should use: the saved display if it is still
+    /// connected, otherwise the active screen.
+    @MainActor
+    static func resolvedScreen() -> NSScreen? {
+        let saved = UserDefaults.standard.string(forKey: key) ?? ""
+        guard !saved.isEmpty else { return NSScreen.main }
+        return NSScreen.screens.first { id(of: $0) == saved } ?? NSScreen.main
+    }
+}
+
+/// Always-current, observable list of connected displays for the settings
+/// picker. A plain `DisplayPreference.connected()` read in a SwiftUI body is
+/// inert — nothing tells the view to re-run it when a monitor is plugged in. So
+/// this publishes the list and refreshes on `didChangeScreenParametersNotification`
+/// (connect / disconnect / resolution / arrangement), which re-renders the picker
+/// live, even while the menu is open. The notification can land a runloop tick
+/// before `NSScreen.screens` settles, so it re-reads once more next tick; the
+/// equality guard makes that extra read a no-op when nothing actually changed.
+@MainActor
+final class DisplayList: ObservableObject {
+    @Published private(set) var displays: [DisplayPreference.Option] = []
+    private var observation: AnyCancellable?
+
+    init() {
+        refresh()
+        observation = NotificationCenter.default
+            .publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .sink { [weak self] _ in
+                self?.refresh()
+                DispatchQueue.main.async { self?.refresh() }
+            }
+    }
+
+    func refresh() {
+        let current = DisplayPreference.connected()
+        if current != displays { displays = current }
+    }
+}

--- a/apps/macos/Sources/MunkelApp/LoginItem.swift
+++ b/apps/macos/Sources/MunkelApp/LoginItem.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Combine
 import Foundation
 import ServiceManagement
 
@@ -50,5 +52,42 @@ enum LoginItem {
         } catch {
             NSLog("munkel: login-item auto-register failed: \(error)")
         }
+    }
+}
+
+/// Drives the "Launch at Login" toggle. Binding the toggle straight to
+/// `LoginItem.isEnabled` looked right but read stale: `SMAppService.status`
+/// doesn't update synchronously when `register()` returns, so SwiftUI re-read
+/// the old value the instant after the call and snapped the toggle back off
+/// even though registration had just succeeded.
+///
+/// Instead this reflects the user's intent optimistically the moment the call
+/// succeeds (or the true state if it threw), then reconciles with the real
+/// status whenever the app returns to the foreground — which also picks up
+/// changes the user made in System Settings › Login Items.
+@MainActor
+final class LoginItemModel: ObservableObject {
+    @Published var isEnabled: Bool
+    private var observation: AnyCancellable?
+
+    init() {
+        isEnabled = LoginItem.isEnabled
+        observation = NotificationCenter.default
+            .publisher(for: NSApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in self?.reconcile() }
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        do {
+            try LoginItem.setEnabled(enabled)
+            isEnabled = enabled
+        } catch {
+            isEnabled = LoginItem.isEnabled
+        }
+    }
+
+    private func reconcile() {
+        let real = LoginItem.isEnabled
+        if real != isEnabled { isEnabled = real }
     }
 }

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -8,6 +8,13 @@ struct MenuView: View {
     @State private var joinCode = ""
     @State private var userCodeCopied = false
     @State private var groupListHeight: CGFloat = 0
+    /// Live list of connected displays, refreshed on screen changes.
+    @StateObject private var displayList = DisplayList()
+    /// "Launch at Login" state that reflects intent immediately and reconciles
+    /// with the real SMAppService status on foreground.
+    @StateObject private var loginItem = LoginItemModel()
+    /// Empty = automatic (active display); otherwise a display's stable UUID.
+    @AppStorage(DisplayPreference.key) private var preferredDisplayID = ""
     #if DEBUG
     @AppStorage("devEchoBroadcasts") private var devEchoBroadcasts = true
     @AppStorage(CaptureScreenshotPreference.defaultsKey) private var allowInScreenshots = false
@@ -145,9 +152,21 @@ struct MenuView: View {
             // Items) and never crashes — `try?` snaps the toggle back to its
             // true state if a register/unregister fails.
             Toggle("Launch at Login", isOn: Binding(
-                get: { LoginItem.isEnabled },
-                set: { try? LoginItem.setEnabled($0) }
+                get: { loginItem.isEnabled },
+                set: { loginItem.setEnabled($0) }
             ))
+            Divider()
+            // Which display the notch appears on. "Automatic" follows the active
+            // screen; a specific pick is remembered by the display's stable UUID
+            // and applies to the next notch (panels are rebuilt per message).
+            Picker(selection: $preferredDisplayID) {
+                Text("Automatic").tag("")
+                ForEach(displayList.displays) { option in
+                    Text(option.name).tag(option.id)
+                }
+            } label: {
+                Label("Notch display", systemImage: "display")
+            }
             #if DEBUG
             Divider()
             Toggle("Echo my broadcasts to me", isOn: $devEchoBroadcasts)

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -199,9 +199,10 @@ final class NotchPresenter {
         // history row (see MessageDisplayModel.copyHovered).
         model.currentText = message.text
 
-        // Default to the main screen; a future setting (#7) supplies a different
-        // closure. One measurement drives both panel placement and content layout.
-        let targetScreen: @MainActor () -> NSScreen? = { NSScreen.main }
+        // The display chosen in Settings (or the active screen when set to
+        // automatic / the chosen one is unplugged). One measurement drives both
+        // panel placement and content layout.
+        let targetScreen: @MainActor () -> NSScreen? = { DisplayPreference.resolvedScreen() }
         let notchSize = NotchScreenMetrics.metrics(for: targetScreen()).notchSize
         let notch = NotchPanel(hoverBehavior: .all, targetScreen: targetScreen) {
             MessageNotchContainer(
@@ -517,7 +518,7 @@ final class NotchPresenter {
     private func showIndicator() {
         guard indicatorNotch == nil else { return }
 
-        let targetScreen: @MainActor () -> NSScreen? = { NSScreen.main }
+        let targetScreen: @MainActor () -> NSScreen? = { DisplayPreference.resolvedScreen() }
         let indicator = IndicatorNotch(hoverBehavior: .all, targetScreen: targetScreen) {
             UnreadIndicatorView()
         }
@@ -576,7 +577,7 @@ final class NotchPresenter {
             // that could linger into a re-login. No message notch can race here
             // — sessions are login-gated, so none are live mid-sign-in.
             self.hideIndicator()
-            let targetScreen: @MainActor () -> NSScreen? = { NSScreen.main }
+            let targetScreen: @MainActor () -> NSScreen? = { DisplayPreference.resolvedScreen() }
             let notch = AuthCodeNotch(hoverBehavior: .none, targetScreen: targetScreen) {
                 AuthCodeNotchView(code: code)
             }

--- a/apps/macos/Sources/MunkelApp/Shortcuts.swift
+++ b/apps/macos/Sources/MunkelApp/Shortcuts.swift
@@ -1,13 +1,13 @@
 import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
-    /// Opens the quick-send command palette from anywhere. Default ⌃⌘M:
-    /// two modifiers avoid the "greedy single-modifier" trap, ⌘M alone is
-    /// Minimize, and ⌥ would clash with character entry (µ). User-rebindable
-    /// via the Recorder in the menu.
+    /// Opens the quick-send command palette from anywhere. Default ⌥M: a quick
+    /// one-hand reach for the app's primary action. It shadows ⌥M's µ character
+    /// entry, an accepted trade-off for the convenience; user-rebindable via the
+    /// Recorder in the menu for anyone who needs µ.
     static let togglePalette = Self(
         "togglePalette",
-        initial: .init(.m, modifiers: [.control, .command])
+        initial: .init(.m, modifiers: [.option])
     )
 
     /// Copy the message under the pointer (a hovered history row, or the


### PR DESCRIPTION
Three Settings-area improvements to the notch app.

## Notch display picker
The gear menu gains **Notch display**: *Automatic* (the active screen — unchanged default) or a specific display. The choice is remembered by the display's **stable UUID** (survives reconnects / resolution changes) and falls back to the active screen whenever that display is unplugged, so the notch never disappears. All three notch surfaces — message, unread indicator, auth code — honour it. The panels are rebuilt per message, so a pick applies to the next notch.

## Two settings controls that now reflect reality reactively
A plain value read in a SwiftUI body is inert — nothing tells the view to re-evaluate it when the underlying state changes — so two controls showed stale:

- **Display list didn't update** when a monitor was plugged in. It's now an observable that refreshes on `didChangeScreenParametersNotification` (connect / disconnect / resolution / arrangement), updating the picker live even with the menu open, plus a next-tick re-read in case `NSScreen.screens` lags.
- **"Launch at Login" checkmark didn't stick.** The toggle was a `get/set` Binding with no observable backing, so after a successful `register()` SwiftUI never re-rendered — even though `SMAppService`'s status was already `.enabled` (verified: it updates synchronously, this was never a timing bug). It now reflects intent optimistically and reconciles with the real status on foreground (which also catches changes from System Settings › Login Items).

## ⌥M quick-send default
The global quick-send shortcut now defaults to **⌥M** (was ⌃⌘M) — a quicker one-hand reach. It shadows ⌥M's µ character entry, an accepted trade-off, rebindable via the menu Recorder. (Existing users who customised the shortcut keep their binding.)

## Test plan
- [x] Display picker lists Automatic + connected displays; plugging a monitor in updates the list live
- [x] Picking a display puts the notch there regardless of which screen has focus; unplugging it falls back to the active screen
- [x] "Launch at Login" on → checkmark sticks; off → clears (SMAppService status verified `.enabled`)
- [x] ⌥M opens quick send
- [x] `swift test` green (60 tests); builds against current `main` (post-#92, reply-with-images)
- [ ] Sanity-check the picker after sleep/wake and AirPlay