### PR TITLE
docs: OpenSSF Best Practices silver/gold documentation

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,88 @@
+name: DCO
+
+# Verifies that every non-merge commit in a pull request carries a
+# Signed-off-by trailer (Developer Certificate of Origin 1.1). Automated
+# authors (Dependabot, the Actions bot, Release Please) are skipped so their
+# PRs do not break. See CONTRIBUTING.md for how to sign off.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Check Signed-off-by on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Non-merge commits in the PR range, oldest first.
+          commits=$(git rev-list --no-merges --reverse "${BASE_SHA}..${HEAD_SHA}")
+
+          if [ -z "${commits}" ]; then
+            echo "No non-merge commits to check."
+            exit 0
+          fi
+
+          failed=0
+
+          for sha in ${commits}; do
+            author_name=$(git log -1 --format='%an' "${sha}")
+            author_email=$(git log -1 --format='%ae' "${sha}")
+            subject=$(git log -1 --format='%s' "${sha}")
+            identity="${author_name} <${author_email}>"
+
+            # Skip known automation authors so their PRs do not break.
+            case "${identity}" in
+              *dependabot\[bot\]*|*github-actions\[bot\]*|*release-please*)
+                echo "skip ${sha} (bot author: ${identity})"
+                continue
+                ;;
+            esac
+
+            # Look for the trailer anywhere in the commit body.
+            if git log -1 --format='%B' "${sha}" \
+                | grep -Eiq '^Signed-off-by: .+ <.+@.+>'; then
+              echo "ok   ${sha} ${subject}"
+            else
+              echo "FAIL ${sha} ${subject}"
+              echo "       missing Signed-off-by from ${identity}"
+              failed=1
+            fi
+          done
+
+          if [ "${failed}" -ne 0 ]; then
+            echo ""
+            echo "DCO check failed: one or more commits are not signed off."
+            echo ""
+            echo "Sign off your commits and re-push:"
+            echo ""
+            echo "  # newest commit only"
+            echo "  git commit --amend -s --no-edit"
+            echo ""
+            echo "  # every commit on this branch"
+            echo "  git rebase --signoff ${BASE_SHA}"
+            echo ""
+            echo "  git push --force-with-lease"
+            echo ""
+            echo "Each commit needs a trailer like:"
+            echo "  Signed-off-by: Your Name <your.email@example.com>"
+            echo ""
+            echo "See CONTRIBUTING.md and https://developercertificate.org/"
+            exit 1
+          fi
+
+          echo ""
+          echo "All commits are signed off."

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,13 +11,36 @@ and useful.
 - Avoid harassment, threats, sexualized language, slurs, or repeated unwanted
   attention.
 
-## Reporting
+## Scope
+
+This Code of Conduct applies in all project spaces: the repository, issues,
+pull requests, discussions, commit messages, and any other channel the project
+uses. It also applies when an individual is representing the project or its
+community in public spaces, such as posting from an official account or acting
+as a designated representative.
+
+## Enforcement
+
+Maintainers will review reports of unacceptable behavior and respond in a way
+they judge appropriate to the situation. Responses may include a private or
+public warning, editing or removing offending content, locking a thread, or
+temporarily or permanently banning a contributor from project spaces.
+
+Maintainers are expected to apply these measures fairly and consistently.
+Where a maintainer is involved in an incident, the other maintainer leads the
+response. Enforcement decisions rest with the maintainers.
+
+## Reporting / contact
 
 For ordinary conduct problems, open an issue asking a maintainer to review the
 interaction, without reposting private details.
 
-For security-sensitive abuse, vulnerabilities, or private reports, use GitHub
-private vulnerability reporting as described in [SECURITY.md](SECURITY.md).
+For sensitive cases, or anything you would rather not raise in public, contact
+the maintainers privately:
 
-Maintainers may edit, hide, or remove comments; lock conversations; or block
-contributors to keep the project usable.
+- Email the lead maintainer, Jurij Koch, at jurij@uq.dev.
+- Or use GitHub private vulnerability reporting, as described in
+  [SECURITY.md](SECURITY.md).
+
+Reports are handled discreetly. Maintainers may edit, hide, or remove comments;
+lock conversations; or block contributors to keep the project usable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,8 @@ Requirements:
 
 - Bun
 - Xcode command line tools
-- Wrangler login only if you deploy Workers
+- A `wrangler login` with access to the `limehq` account, only if you deploy
+  Workers
 
 ```sh
 bun install
@@ -22,10 +23,18 @@ bun run build
 Useful local commands:
 
 ```sh
-bunx turbo dev --filter=@munkel/server
-bunx turbo dev --filter=@munkel/landing
-cd apps/macos && ./make-bundle.sh && open .build/Munkel.app
+bunx turbo dev --filter=@munkel/server     # relay on ws://127.0.0.1:8787
+bunx turbo dev --filter=@munkel/landing    # landing on http://localhost:3000
+cd apps/macos && bun run dev               # builds & runs the Munkel Dev app
 ```
+
+The root `bun run dev` deliberately excludes the macOS app, which needs the
+Swift toolchain; run the per-app command above for it. `cd apps/macos && bun
+run dev` builds the **Munkel Dev** variant (a separate identity that runs side
+by side with an installed release) and launches it. For a release-style local
+bundle instead, run `cd apps/macos && ./make-bundle.sh release && open
+.build/Munkel.app`. See [`README.md`](README.md) for the full development
+workflow.
 
 ## Pull requests
 
@@ -35,7 +44,55 @@ cd apps/macos && ./make-bundle.sh && open .build/Munkel.app
 - Use Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`). Release
   Please uses those commits to maintain `CHANGELOG.md` and releases.
 
+## Developer Certificate of Origin (DCO)
+
+All contributions must be signed off. Every commit needs a `Signed-off-by`
+trailer in its message:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The easiest way to add it is the `-s` flag:
+
+```sh
+git commit -s -m "fix: correct circle-code derivation"
+```
+
+To fix a commit that is missing the trailer:
+
+```sh
+git commit --amend -s        # amend the most recent commit
+git rebase --signoff main    # add sign-off to every commit on the branch
+```
+
+Signing off certifies that you wrote the change, or otherwise have the right
+to submit it under the project's [MIT license](LICENSE), as described by the
+[Developer Certificate of Origin 1.1](https://developercertificate.org/). The
+name and email in the trailer must be real.
+
+CI enforces sign-off on pull requests: the DCO check
+(`.github/workflows/dco.yml`) fails any PR whose non-merge commits lack a
+`Signed-off-by` trailer. Re-push after amending or rebasing to clear it.
+
+## Keeping documentation current
+
+Documentation lives next to the code and is expected to match it. When a change
+affects behavior, update the relevant docs in the same pull request:
+
+- [`README.md`](README.md) — overview, install, security summary.
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — components and data flow.
+- [`SECURITY.md`](SECURITY.md) — security model and reporting.
+- [`PRIVACY.md`](PRIVACY.md) — what the relay can and cannot see.
+- [`ROADMAP.md`](ROADMAP.md) — planned and in-progress work.
+- Any other affected file (`GOVERNANCE.md`, `MAINTAINERS.md`, `RELEASING.md`,
+  `docs/ACCESSIBILITY.md`, `docs/INTERNATIONALIZATION.md`, and so on).
+
+Documentation that drifts from the code is treated as a bug: it is tracked in
+the issue tracker and fixed like any other defect. Reviewers check that the
+docs in a PR match the behavior it ships. CI runs `bun run typecheck` and
+`bun run test` on every pull request, so keep both green alongside the docs.
+
 ## Security reports
 
 Do not report vulnerabilities in public issues. Follow [SECURITY.md](SECURITY.md).
-

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,209 @@
+# Governance
+
+This document describes how the Munkel project is run: who holds which role,
+how decisions are made, how the project continues if a maintainer becomes
+unavailable, and how this document itself changes.
+
+## Overview
+
+Munkel is a small open-source project under the [`limehq`](https://github.com/limehq)
+GitHub organization, licensed under [MIT](LICENSE). It follows a
+**lead-maintainer model with a co-maintainer**: a Lead Maintainer holds final
+decision authority, and a second Maintainer shares day-to-day review, triage,
+and release duties. Both maintainers hold full administrative and signing
+access, so neither is a single point of failure.
+
+limehq (legal entity: Unique (Deutschland) GmbH) is the **organizational and
+legal backstop**. It owns the GitHub organization, the Cloudflare account that
+hosts the relay and landing page and the `munkel.app` DNS zone, the
+`munkel.app` domain registration, and the GitHub OAuth app registration. If the
+individual maintainers were both unavailable, limehq retains the legal rights
+needed to restore access and appoint new maintainers.
+
+The current maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md). Code
+ownership and required review are enforced through the
+`@limehq/munkel-maintainers` team referenced in
+[.github/CODEOWNERS](.github/CODEOWNERS).
+
+## Roles and responsibilities
+
+The project defines four roles. The people currently holding the maintainer
+roles are named in [MAINTAINERS.md](MAINTAINERS.md); membership of the
+`@limehq/munkel-maintainers` CODEOWNERS team is the authoritative record of who
+can approve and merge. (Other projects may record this differently; for Munkel
+the source of truth is MAINTAINERS.md plus the `@limehq/munkel-maintainers`
+team.)
+
+### Lead Maintainer
+
+Final decision authority for the project. Concretely, the Lead Maintainer:
+
+- Has the final say on technical direction, scope, and disputed pull requests,
+  and breaks ties when maintainers disagree.
+- Owns the release process end to end (see [RELEASING.md](RELEASING.md)):
+  cutting releases via Release Please, the signed/notarized desktop build, and
+  the Sparkle auto-update feed.
+- Coordinates security response: triaging private reports filed under
+  [SECURITY.md](SECURITY.md), driving fixes, and publishing advisories.
+- Is the primary holder of accounts and keys: the GitHub organization, the
+  Cloudflare account (relay, landing, `munkel.app` DNS zone), the Apple
+  Developer ID and notarization credentials, and the Sparkle EdDSA appcast
+  signing key.
+- Owns this governance document and the maintainer roster.
+
+### Maintainer
+
+A Maintainer shares the operational load and can act independently. Concretely,
+a Maintainer:
+
+- Reviews and merges pull requests, including approving on behalf of
+  `@limehq/munkel-maintainers` to satisfy the required CODEOWNERS review.
+- Triages issues: reproducing bugs, labeling, closing duplicates or
+  out-of-scope requests, and asking for missing detail.
+- Can cut a release independently following [RELEASING.md](RELEASING.md).
+- Participates in security triage and remediation.
+- Holds the same administrative and key access as the Lead Maintainer (see
+  [Continuity and succession](#continuity-and-succession)), so the project does
+  not stall when the Lead Maintainer is away.
+
+### Contributor
+
+Anyone who opens an issue or pull request. Contributors:
+
+- Follow [CONTRIBUTING.md](CONTRIBUTING.md): scope changes narrowly, add or
+  update tests when behavior changes, run `bun run typecheck` and `bun run test`
+  before opening a PR, and use Conventional Commits.
+- Have no merge rights; their changes are merged by a maintainer after review.
+- Are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Contributors are credited in [MAINTAINERS.md](MAINTAINERS.md) and in the git
+history; contribution does not by itself confer the maintainer role (see
+[Becoming a maintainer](#becoming-a-maintainer)).
+
+### Security contact
+
+Security reports are not handled in public. The security contact is the
+maintainer group, reachable through GitHub's private vulnerability reporting as
+described in [SECURITY.md](SECURITY.md). Both maintainers can receive and act
+on these reports, so a report is never blocked on one person. The Lead
+Maintainer coordinates the overall response.
+
+## Decision-making
+
+Munkel uses lightweight, pull-request-driven decision-making:
+
+- **Lazy consensus.** Most changes are proposed as pull requests or issues. A
+  change proceeds once a maintainer approves it and no other maintainer has
+  raised an unresolved objection. Silence is taken as assent.
+- **Required review.** Every change to `main` requires review from
+  `@limehq/munkel-maintainers` per [.github/CODEOWNERS](.github/CODEOWNERS).
+  Approval from one maintainer satisfies this gate; either maintainer can
+  provide it.
+- **Tie-breaking.** If maintainers disagree and cannot reach consensus, the
+  Lead Maintainer makes the final decision. This authority is used sparingly;
+  the default is to discuss until agreement.
+- **Escalation.** Disagreements are first worked out in the relevant issue or
+  pull-request thread. If that does not resolve them, they are escalated to the
+  Lead Maintainer. Matters touching accounts, legal rights, or the project's
+  continued existence escalate to limehq as the organizational backstop.
+- **Larger or contentious changes.** Significant or potentially controversial
+  changes (security model, wire protocol, public API, governance) should be
+  raised as an issue for discussion before a pull request, so maintainers can
+  agree on direction before code is written.
+
+### Changing this document
+
+Changes to this `GOVERNANCE.md` and to [MAINTAINERS.md](MAINTAINERS.md) are made
+by pull request and require approval from the Lead Maintainer (in addition to
+the standard CODEOWNERS review). This keeps the project's rules and its roster
+under the same review discipline as the code.
+
+## Becoming a maintainer
+
+There is no fixed quota. A contributor may be invited to become a Maintainer
+after a sustained track record of high-quality contributions and reviews, good
+judgment in discussions, and adherence to the [Code of Conduct](CODE_OF_CONDUCT.md).
+The invitation is proposed by an existing maintainer and confirmed by the Lead
+Maintainer. Onboarding a new maintainer means:
+
+1. Adding them to the `@limehq/munkel-maintainers` team so CODEOWNERS review and
+   merge rights apply.
+2. Recording them in [MAINTAINERS.md](MAINTAINERS.md) with their role, contact,
+   and areas of responsibility.
+3. Granting the administrative and key access appropriate to the role, and
+   ensuring the continuity guarantees below still hold.
+
+Maintainers who step back are moved to an emeritus note in
+[MAINTAINERS.md](MAINTAINERS.md), and their access is revoked.
+
+## Continuity and succession
+
+The project is designed to continue with minimal interruption if any single
+person is lost. There is no resource that only one maintainer can reach.
+
+**Shared administrative and key access.** Both maintainers hold:
+
+- **Admin** on the `limehq` GitHub organization and the `limehq/munkel`
+  repository, so either can create and close issues, accept pull requests,
+  manage CI, and publish releases.
+- Access to the **Cloudflare** account that runs the relay
+  (`relay.munkel.app`), the landing page (`munkel.app`), and the `munkel.app`
+  **DNS zone**, so either can deploy and operate the production services.
+- The **Sparkle EdDSA appcast signing key**, so either can sign and ship an
+  auto-update.
+
+Because of this, **either maintainer can independently create or close issues,
+accept and merge pull requests, and cut a full release within one week** if the
+other is unavailable.
+
+**Offline backups.** The Sparkle EdDSA signing key and account recovery codes
+are backed up offline, outside any single maintainer's machine, so the loss of
+one device does not lose irreplaceable credentials. The signing key in
+particular is unrecoverable if lost and would break updates for users who have
+not yet updated, so it is held by both maintainers and kept in offline backup.
+(This document does not contain any key material or recovery codes; operational
+locations are kept in a private operator note, as described in
+[RELEASING.md](RELEASING.md).)
+
+**Legal backstop.** limehq holds the legal rights to the `munkel.app` domain,
+the DNS zone, the Cloudflare account, and the GitHub OAuth / application
+registrations. If both individual maintainers were unavailable, limehq can
+recover access to these resources and appoint new maintainers, so the project's
+identity and infrastructure are not tied to any one individual.
+
+## Bus factor
+
+The project's **bus factor is 2 or greater**: there are two maintainers, and
+*each* of them holds full administrative access to the GitHub organization and
+repository, full access to the Cloudflare account (relay, landing, and DNS
+zone), and the Sparkle signing key. Either one can run the entire project,
+including issue management and releases, without the other.
+
+What keeps the bus factor at 2 or more:
+
+- Access is granted to the **role**, not held by one person — both maintainers
+  carry the same admin and key access rather than splitting it.
+- The Sparkle signing key and account recovery codes are kept in **offline
+  backup** outside any single machine.
+- **limehq** is the organizational/legal backstop for the domain, accounts, and
+  app registrations.
+- New maintainers are onboarded with the full access set
+  (see [Becoming a maintainer](#becoming-a-maintainer)), so adding people
+  raises the bus factor rather than fragmenting access.
+
+## Code of Conduct
+
+All participation in Munkel is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md). Maintainers are responsible for
+enforcement and may edit, hide, or remove comments, lock conversations, or
+block contributors to keep the project usable. Ordinary conduct concerns can be
+raised by opening an issue asking a maintainer to review; conduct issues that
+are security-sensitive or require privacy are reported through the private
+channel in [SECURITY.md](SECURITY.md).
+
+## Security
+
+Vulnerabilities are reported privately, never in public issues. See
+[SECURITY.md](SECURITY.md) for the reporting channel, what to include, and the
+supported-versions policy. The maintainers coordinate triage and remediation as
+described under [Roles and responsibilities](#roles-and-responsibilities).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,51 @@
+# Maintainers
+
+This file lists the people responsible for Munkel. Governance — how decisions
+are made, how someone becomes a maintainer, and how continuity is guaranteed —
+is described in [GOVERNANCE.md](GOVERNANCE.md).
+
+## Current maintainers
+
+| Name | Role | Contact | Areas of responsibility |
+|---|---|---|---|
+| Jurij Koch | Lead Maintainer | jurij@uq.dev | Final decision authority; releases (Release Please, signed/notarized build, Sparkle appcast); security coordination; accounts and keys (GitHub org, Cloudflare, Apple Developer ID, Sparkle signing key); overall direction across the macOS app, CLI, relay, and landing page. |
+| Sebil Satici | Maintainer | hallo@sebil.dev | Pull-request review and merge; issue triage; releases; security triage; shares administrative and key access. |
+
+Review and merge rights are enforced through the
+**`@limehq/munkel-maintainers`** team referenced in
+[.github/CODEOWNERS](.github/CODEOWNERS); membership of that team is the
+authoritative record of who can approve and merge to `main`. The maintainers
+listed above are the members of that team.
+
+## Continuity
+
+Both maintainers hold full administrative access to the `limehq` GitHub
+organization and the `limehq/munkel` repository, access to the Cloudflare
+account that runs the relay (`relay.munkel.app`), the landing page
+(`munkel.app`), and the `munkel.app` DNS zone, and the Sparkle EdDSA appcast
+signing key. As a result, **each maintainer can act alone** — creating and
+closing issues, reviewing and merging pull requests, and cutting a full release
+— **within one week** if the other is unavailable. The signing key and account
+recovery codes are kept in offline backup outside any single machine, and
+limehq (Unique (Deutschland) GmbH) is the legal backstop for the domain,
+accounts, and the GitHub OAuth / application registrations. See
+[GOVERNANCE.md](GOVERNANCE.md#continuity-and-succession) for the full policy.
+
+## Security and conduct contacts
+
+- **Security reports:** use GitHub private vulnerability reporting as described
+  in [SECURITY.md](SECURITY.md). Both maintainers can receive and act on
+  reports.
+- **Code of Conduct:** maintainers enforce the
+  [Code of Conduct](CODE_OF_CONDUCT.md); see it for how to raise a concern.
+
+## Contributors
+
+Munkel has also benefited from contributions by people who are not maintainers.
+Thanks in particular to:
+
+- Jasha Chec ([@devjasha](https://github.com/devjasha))
+
+Contributions do not by themselves confer the maintainer role; see
+[GOVERNANCE.md](GOVERNANCE.md#becoming-a-maintainer) for how maintainers are
+added. The full contribution history is in the project's git log.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ the plaintext code.
 
 Website: **[munkel.app](https://munkel.app)**
 
+## Quick start
+
+1. Install the app and CLI: `brew install limehq/tap/munkel`, then `open -a Munkel`.
+2. Sign in with GitHub (or just pick a display name) from the menu-bar icon.
+3. Create or join a circle with a shared, spoken code like `blue-table-42`.
+4. Send a message — to the whole circle or one member:
+   - From the app: type in the menu-bar popover.
+   - From the terminal: `munkel blue-table-42 all "coffee?"`
+5. Incoming messages slide out of each recipient's MacBook notch (a floating
+   panel on Macs without a notch).
+
+Full install options (direct download, from source) are in
+[Install](#install); how it all works is in
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 ## Install
 
 **Homebrew** (app plus the `munkel` CLI):
@@ -314,13 +329,19 @@ bun scripts/dev-send.ts blue-table-42 Alex "coffee?"
 
 ## Project health
 
+- [Architecture](docs/ARCHITECTURE.md)
+- [Roadmap](ROADMAP.md)
+- [Governance](GOVERNANCE.md)
+- [Maintainers](MAINTAINERS.md)
 - [Changelog](CHANGELOG.md)
 - [Security policy](SECURITY.md)
 - [Privacy notes](PRIVACY.md)
 - [Contributing guide](CONTRIBUTING.md)
 - [Code of conduct](CODE_OF_CONDUCT.md)
+- [Accessibility](docs/ACCESSIBILITY.md)
+- [Internationalization](docs/INTERNATIONALIZATION.md)
 - [Release process](RELEASING.md)
-- [OpenSSF Scorecard report](https://scorecard.dev/viewer/?uri=github.com/limehq/munkel)
+- [OpenSSF Best Practices](https://www.bestpractices.dev/projects/13278) · [OpenSSF Scorecard report](https://scorecard.dev/viewer/?uri=github.com/limehq/munkel)
 
 ## Star history
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,147 @@
+# Roadmap
+
+This roadmap describes what Munkel intends to do — and intends *not* to do —
+over roughly the next year (2026 H2 through 2027 H1). It exists so that users,
+contributors, and downstream packagers can see where the project is heading and
+whether a given idea is in scope before they invest effort.
+
+Munkel is ephemeral, end-to-end-encrypted messages between friends ("circles")
+that slide out of the MacBook notch: no accounts, no message history, no message
+storage. The roadmap below is grounded in the project's current state — the
+shipped work in [CHANGELOG.md](CHANGELOG.md), the security model in
+[README.md](README.md) and [SECURITY.md](SECURITY.md), and the explicitly
+deferred items recorded in the code (for example, pairwise direct-message keys
+are marked as deferred to protocol v2 in `apps/server/src/protocol.ts`).
+
+**This roadmap is a statement of intent, not a commitment.** Priorities,
+ordering, and scope are subject to change as we learn from real use. Dates are
+intentionally given as horizons ("Now", "Next", "Later") and half-year windows
+rather than exact calendar dates. Time-sensitive specifics live in GitHub
+issues and milestones, which take precedence over this document when they
+disagree.
+
+## Now (next ~3 months)
+
+Hardening the foundations of the current product and the things people touch
+every day.
+
+- **Harden the circle-code / invite format.** Generated circle codes are
+  documented today as convenience-grade shared secrets (see
+  [SECURITY.md](SECURITY.md) and [PRIVACY.md](PRIVACY.md)). The near-term goal
+  is a stronger, still human-shareable invite path — for example higher-entropy
+  generated codes and/or an invite link/QR alternative for the create-and-share
+  flow — without forcing users to read out long random strings at a café table.
+  This is the single most-referenced limitation in our own docs and is the
+  priority for this window.
+- **Notch UX polish.** The notch presentation is the product, and it is where
+  most recent work has landed (unread indicators, per-message and per-image
+  copy controls, the quick-send palette, keyboard shortcuts). Continue
+  tightening interaction details: hover/expand behavior, copy affordances,
+  reply ergonomics, the no-notch floating-panel fallback, and keyboard
+  navigation.
+- **Image-sharing maturation.** Inline AVIF preview with lazy full-resolution
+  fetch from R2 shipped in 0.10.0. Follow-through here means edge-case
+  robustness: failed/slow blob fetches, the ~66 s blob TTL interacting with
+  offline recipients, multi-image (1–8 item) layouts in the notch, and clear
+  feedback when a full-res image is no longer retrievable.
+- **Relay reliability basics.** Shore up reconnect behavior, idle-timeout
+  handling, and the per-group connection cap (32) so that flaky networks and
+  café Wi-Fi degrade gracefully rather than silently dropping messages.
+- **Documentation follow-through.** Keep the governance, security, and
+  architecture docs current as the project formalizes —
+  [GOVERNANCE.md](GOVERNANCE.md), [MAINTAINERS.md](MAINTAINERS.md),
+  [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), and this roadmap — and keep them
+  honest about what is and is not implemented.
+
+## Next (3–9 months)
+
+Larger pieces that change the protocol or the user model, plus accessibility
+and internationalization groundwork.
+
+- **Pairwise-encrypted direct messages.** Direct messages in v1 are
+  relay-targeted but share the circle's message key; pairwise keys are
+  explicitly deferred to v2 in `apps/server/src/protocol.ts` and called out in
+  [SECURITY.md](SECURITY.md). The intent is that a direct message becomes
+  readable only by its intended recipient, not by every current circle member
+  who knows the code. This is a wire-protocol change and will be versioned and
+  documented as such.
+- **Forward secrecy (investigation, then design).** Once pairwise keys exist,
+  evaluate adding forward secrecy so that compromise of a current key does not
+  retroactively expose past messages. Given the ephemeral, no-history design,
+  this is a deliberate study item first — we will publish the threat-model
+  reasoning before committing to a key-ratcheting scheme.
+- **Relay observability.** Add the minimum operational visibility needed to run
+  the relay responsibly — error rates, connection health, blob-sweep behavior —
+  while preserving the design property that the relay sees only derived group
+  IDs, member IDs, sizes, and timing, and never message content. Observability
+  must not become a back door to message data or a metadata store.
+- **Accessibility.** Make the notch and menu-bar surfaces work well with
+  VoiceOver and keyboard-only operation, and document the result in
+  [docs/ACCESSIBILITY.md](docs/ACCESSIBILITY.md). Note the inherent constraint:
+  capture-proof surfaces (`NSWindow.sharingType = .none`) and the no-tooltip
+  rule in notch content shape what is possible, and accessibility work must
+  respect the capture-exclusion guarantee.
+- **Internationalization groundwork.** The macOS app currently ships
+  English-only strings with no localization layer. Lay the i18n foundation
+  (externalize user-facing strings, establish a localization workflow) and
+  record the approach in [docs/INTERNATIONALIZATION.md](docs/INTERNATIONALIZATION.md).
+  Product copy stays English by default; this is about enabling translation,
+  not committing to a specific set of locales.
+
+## Later (9–12+ months)
+
+Directionally intended, lower certainty, and most subject to change.
+
+- **Shipping pairwise/forward-secret messaging.** Move the v2 protocol work
+  above from design to a shipped, documented, interop-tested release across the
+  Swift app, the relay, and the reference TypeScript sender.
+- **Invite-format v2 at rest.** Build on the near-term invite hardening with a
+  more complete sharing story (e.g. revocation/rotation semantics for a circle)
+  if real usage shows it is needed.
+- **Deeper agent / CLI ergonomics.** The `munkel` CLI and the
+  `skills/munkel/SKILL.md` agent skill are send-only by design. Later work may
+  refine the scripting surface and resolution behavior, while keeping the
+  send-only posture.
+- **Broader translations.** If and only if the i18n groundwork lands and there
+  is demand, add real translated locales.
+
+## Non-goals / Out of scope
+
+These define Munkel's identity as much as the roadmap above. They are choices,
+not missing features, and we do not intend to pursue them for the foreseeable
+future.
+
+- **No message history or storage.** Ephemerality is enforced by design: one
+  Durable Object per circle with no DO storage, and image blobs expire on a
+  short (~66 s) TTL swept by cron. We will not add server-side message history,
+  a searchable archive, sync-across-devices of past messages, or message
+  backup. Offline means missed, on purpose.
+- **No accounts.** A circle is born from a shared human-readable code, which is
+  the only credential and never leaves the clients. We will not add account
+  registration, passwords, server-side identity, or a contact directory.
+  GitHub login remains display-only identity, not authentication of peers.
+- **Not a general-purpose chat app.** Munkel is a notch-first, lightweight
+  "ping a friend" tool, not a Slack/Discord/iMessage replacement. We do not
+  intend to build threads, channels with roles/permissions, reactions feeds,
+  read receipts as a feature surface, large group management, bots/integrations
+  marketplaces, or a full chat window UI. The notch and menu-bar surfaces are
+  the product.
+- **Not for high-risk secret sharing.** Munkel is built for ephemeral,
+  lightweight messages. Even with the hardening above, it is not positioned as
+  a tool for journalists, whistleblowers, or other high-threat scenarios; use
+  purpose-built tools for that. See [SECURITY.md](SECURITY.md).
+- **Focused platform scope.** Munkel is a macOS app whose defining interaction
+  is the MacBook notch. There are no current plans for iOS, Android, Windows,
+  Linux, or web clients. The relay (Cloudflare Workers) and landing page are
+  supporting infrastructure, not separate end-user products. We would rather do
+  one platform well than spread thin.
+- **No telemetry / analytics in the app.** We will not add usage analytics,
+  tracking, or content-bearing telemetry. Operational relay metrics (see
+  *Next*) are deliberately limited to non-content signals.
+
+---
+
+Questions, corrections, or proposals about this roadmap are welcome via GitHub
+issues. For how decisions are made and who can accept them, see
+[GOVERNANCE.md](GOVERNANCE.md) and [MAINTAINERS.md](MAINTAINERS.md); for how to
+contribute changes, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,10 @@
 ## Supported versions
 
 Security fixes target the latest released version. Before the first stable
-release, fixes land on `main` and are included in the next release.
+release, fixes land on `main` and are included in the next release. Updates
+reach installed apps through [Sparkle](https://sparkle-project.org) as
+EdDSA-signed, notarized in-place updates; the Homebrew cask (`auto_updates
+true`) defers to Sparkle.
 
 ## Reporting a vulnerability
 
@@ -20,17 +23,131 @@ Please include:
 - Impact and any known mitigations.
 
 We will acknowledge valid reports, investigate, and publish a fix or advisory
-when appropriate.
+when appropriate. The maintainers who handle reports are listed in
+[MAINTAINERS.md](MAINTAINERS.md).
 
-## Security model
+## Security requirements — what you can and cannot expect
 
-Munkel is built for ephemeral, lightweight messaging:
+Munkel is built for ephemeral, lightweight messaging between friends, not
+high-risk secret sharing. Be precise about its guarantees before trusting it
+with anything sensitive.
 
-- The relay stores no message history.
-- Payloads are encrypted on-device before they reach the relay.
-- The relay still sees metadata: derived group IDs, member IDs, connection
-  timing, message size, and routing targets.
-- Generated circle codes are convenience-grade shared secrets. Use longer custom
-  codes for more sensitive conversations until the invite format is hardened.
-- Direct messages in v1 are relay-targeted, not pairwise encrypted.
+### What you CAN expect
 
+- **Payloads are encrypted on-device.** Message content is sealed with
+  AES-256-GCM before it reaches the relay (`payload = base64(nonce[12] ‖
+  ciphertext ‖ tag[16])`, random 12-byte nonce per message, empty AAD). The
+  key is derived on-device via HKDF-SHA256 from the circle code, with salt
+  `munkel-v1` and info `message-key` (32-byte key). See
+  `apps/macos/Sources/MunkelKit/GroupKey.swift`,
+  `apps/macos/Sources/MunkelKit/MessageCrypto.swift`, and the canonical wire
+  spec `apps/server/src/protocol.ts`. AES-256-GCM was chosen for CryptoKit /
+  WebCrypto interop; the Swift↔TypeScript derivation is pinned in
+  `CryptoTests.swift`.
+- **The relay stores no messages.** One Durable Object per circle
+  (`idFromName(groupId)`) uses the WebSocket Hibernation API and persists no
+  message data — messages are routed between live connections and never
+  stored (`apps/server/src/group-room.ts`, `apps/server/src/protocol.ts`). The
+  one persistence surface is full-resolution image blobs, which are stored as
+  opaque ciphertext in R2 (`munkel-blobs`) under a short logical TTL (~66 s)
+  and swept by a per-minute cron; the relay never holds the key
+  (`apps/server/src/blob.ts`).
+- **No accounts.** There is nothing to register, no password, and no server-
+  side identity. A circle is born from a shared human-readable code
+  (`blue-table-42`); the code never leaves the clients, and the relay only ever
+  sees the derived `groupId`.
+- **On-screen surfaces are excluded from screen capture.** Every window that
+  shows message content or circle codes (notch panel, menu popover, command
+  palette) is excluded from screen capture by setting `NSWindow.sharingType =
+  .none`, applied by the `CaptureExclusion` view
+  (`apps/macos/Sources/MunkelApp/CaptureExclusion.swift`). They stay visible on
+  the physical display but are hidden from the legacy CoreGraphics path (the
+  system screenshot tools and older recorders) and from ScreenCaptureKit on
+  macOS ≤ 15.3. Known limitation: on macOS 15.4+ Apple changed display
+  compositing so that ScreenCaptureKit full-display capture can ignore
+  `sharingType = .none`, so exclusion is best-effort against modern SCK display
+  recorders.
+- **Ephemerality by design.** With no message history, no message persistence
+  in the relay, and a short-TTL blob bucket, there is no chat log to leak; what
+  you missed while offline is simply gone.
+
+### What you CANNOT expect
+
+- **No protection from anyone who has the circle code.** The circle code is a
+  shared symmetric secret: every current circle member derives the same
+  `messageKey`. Anyone who knows the code can read and send messages for that
+  circle. Treat generated codes as convenience-grade secrets and use a longer
+  custom code for more sensitive conversations.
+- **No pairwise or forward-secret direct messages in v1.** Direct messages
+  (`to`) are relay-targeted: the server enforces delivery to one member, but
+  they are encrypted under the same shared circle key, not a pairwise key.
+  Pairwise keys and forward secrecy are deliberately deferred to a later
+  version (see `apps/server/src/protocol.ts` and [ROADMAP.md](ROADMAP.md)).
+- **No cryptographic proof of identity from GitHub login.** "Sign in with
+  GitHub" imports a display name and avatar only. It does not prove to peers
+  that a member controls a given GitHub account; profiles are self-asserted,
+  the same as a typed name.
+- **No hiding metadata from the relay.** The relay necessarily observes
+  connection metadata: derived group IDs, member IDs, connection timing,
+  message sizes, and routing targets. It cannot read content, but it is not a
+  metadata-private transport.
+- **Not suitable for high-risk or anonymity threat models.** Munkel is not
+  designed to defend against targeted or well-resourced adversaries, to
+  anonymize you, or to protect against a compromised device. Do not use it
+  where exposure carries serious personal, legal, or safety consequences.
+
+## Threat model
+
+The table below states which adversaries Munkel is designed to resist and how,
+followed by adversaries that are explicitly out of scope.
+
+### In scope
+
+| Adversary | Mitigation |
+|---|---|
+| **Passive network or relay observer** (anyone watching the wire or running the relay) | Payloads are end-to-end encrypted with AES-256-GCM on-device; the relay only sees the derived `groupId`, member IDs, sizes, and timing — never plaintext or the circle code. Image blobs in R2 are opaque ciphertext with a short TTL. |
+| **Screen capture / screen sharing** (Zoom, Teams, screenshots, recorders) | Notch panel, menu popover, and command palette set `NSWindow.sharingType = .none` via `CaptureExclusion`, so message content and circle codes are hidden from captured frames while staying visible on the physical display. This is reliable on the legacy capture path and on ScreenCaptureKit through macOS 15.3; full-display SCK capture on macOS 15.4+ can bypass it. |
+| **A malicious or curious circle member** | Limited by design: the message key is shared, so a member can read circle traffic. The relay enforces targeted delivery for direct messages, and there is no message history for a member to exfiltrate after the fact. To exclude someone, rotate to a new circle code. |
+| **A lost or unlocked device** | No message history is stored and no GitHub token is persisted (the token is RAM-only and discarded after one profile fetch). What remains locally is settings in the `dev.uq.munkel` defaults domain — joined circle codes, member ID, display name, GitHub login, and a downscaled avatar; ephemerality limits what can be recovered from the device. |
+
+### Out of scope
+
+- **Nation-state or targeted attackers.** Munkel does not aim to resist
+  well-resourced adversaries who can mount targeted attacks, traffic
+  correlation, or coercion.
+- **A compromised endpoint or OS.** If the macOS device, its keychain, the
+  user account, or the operating system is compromised (malware, a hostile
+  recorder that bypasses capture exclusion, a kernel exploit), Munkel's
+  on-screen and on-device protections do not hold.
+- **Supply-chain risks beyond our controls.** We sign and notarize releases
+  (EdDSA via Sparkle), pin and review dependencies, and run CI security checks
+  (CodeQL, OpenSSF Scorecard). Compromise of upstream toolchains, GitHub,
+  Cloudflare, or Apple infrastructure is outside what this project can
+  guarantee.
+
+## Credential & password storage
+
+The project's sites do **not** store passwords for authenticating external
+users, because there are no external user accounts anywhere in Munkel:
+
+- **Website (munkel.app).** The landing page (`apps/landing/`) is a static
+  marketing site served by a Cloudflare Worker. It has no login form, no user
+  accounts, and no password storage.
+- **GitHub repository (github.com/limehq/munkel).** Authentication and access
+  control are GitHub's; the repository does not run its own user-auth system
+  and stores no passwords.
+- **Download URLs and the relay.** Releases are served from GitHub Releases and
+  the Homebrew tap; the relay (`relay.munkel.app`) routes WebSocket traffic by
+  derived `groupId` with no login. None of these authenticate external users
+  with passwords.
+- **GitHub sign-in.** "Sign in with GitHub" in the macOS app uses the GitHub
+  OAuth device flow with empty scope. The access token is used once to fetch
+  `GET /user`, kept in memory only (an ephemeral `URLSession`), and then
+  discarded — it is never written to disk
+  (`apps/macos/Sources/MunkelKit/GitHubDeviceAuth.swift`). The app stores only
+  a display name and a downscaled avatar locally; no password or token is
+  retained.
+
+Because no project site stores passwords for authenticating external users, the
+OpenSSF Best Practices `sites_password_security` criterion is **Not
+Applicable** to Munkel.

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,0 +1,153 @@
+# Accessibility
+
+Munkel should be usable by people who rely on assistive technology. We treat
+accessibility as a real, ongoing part of the work, not a one-time checkbox:
+new UI is expected to be keyboard-operable, legible, and labelled for screen
+readers, and accessibility regressions are treated as bugs.
+
+This document is deliberately honest about the current state. Conformance is a
+goal we have partially met. Where a surface falls short today, we say so and
+track the work rather than overclaim. Accessibility items live alongside other
+planned work in [ROADMAP.md](../ROADMAP.md).
+
+The two surfaces a user interacts with directly are the **website**
+(`munkel.app`) and the **macOS app**. The relay and CLI have no graphical UI;
+the CLI's accessibility is the accessibility of the user's terminal.
+
+## Website (munkel.app)
+
+Source: `apps/landing` (TanStack Start, React, Tailwind v4).
+
+Target: **WCAG 2.1 AA**. The landing page is built with accessibility in mind
+and the following practices are in place today:
+
+- **Semantic HTML.** The page uses landmark and sectioning elements rather than
+  generic containers: `<nav>` for navigation, `<header>` for the hero, `<section>`
+  for each content block, and `<footer>` for the footer. Content sections carry a
+  stable `id` and a single `<h2>`; the hero carries the page's one `<h1>`.
+  Legal pages (privacy, imprint, contact) render their content inside `<main>`.
+- **Accessible interactive primitives.** The FAQ and tabbed regions use Radix UI
+  primitives (`@radix-ui/react-accordion` and `@radix-ui/react-tabs`), which ship
+  correct ARIA roles, state, and keyboard interaction (arrow keys, `Enter`/`Space`,
+  focus management) out of the box.
+- **Labels for icon-only controls.** Buttons and links that show only an icon
+  carry an explicit `aria-label` (for example the GitHub link, the download link,
+  the theme toggle, and the copy-to-clipboard buttons). Decorative icons are
+  marked `aria-hidden` so they are skipped by screen readers.
+- **Image alt text.** Decorative images (avatar montages, app icon, mockup
+  chrome) use `alt=""` so they are ignored; images that carry meaning (the
+  "featured on" launch badges) have descriptive `alt` text. The Open Graph share
+  image also has an `og:image:alt` description.
+- **Visible focus.** The shared button uses a `focus-visible` ring
+  (`focus-visible:ring-2`) so keyboard users get a clear focus indicator without
+  imposing an outline on mouse users.
+- **`prefers-reduced-motion`.** Motion is gated on the user's preference at
+  several layers: the landing page is wrapped in Motion's
+  `MotionConfig reducedMotion="user"`, the hero scroll choreography checks
+  `useReducedMotion()`, the CLI demo checks
+  `matchMedia('(prefers-reduced-motion: reduce)')`, and a
+  `@media (prefers-reduced-motion: reduce)` CSS block disables the remaining
+  animations (pulse/cursor, notch transitions, accordion easing, and the badge
+  marquee).
+- **Themes and contrast.** A dark (default) and light theme are both provided.
+  Colours are defined as design tokens, which makes contrast auditing and
+  adjustment straightforward.
+
+**Honest current status / what is tracked:**
+
+- The landing route does not yet expose a top-level `<main>` landmark or a
+  "skip to content" link. Sections are not wired to their headings with
+  `aria-labelledby`. These are tracked improvements.
+- We have not yet run a formal automated audit (for example axe or Lighthouse)
+  in CI, nor a full manual screen-reader pass, so AA conformance is asserted by
+  construction and review rather than verified end to end. Adding an automated
+  accessibility check to CI is on the roadmap.
+- Colour contrast has been chosen with care but has not been exhaustively
+  measured against every token pair in both themes.
+
+## macOS app
+
+Source: `apps/macos/Sources/MunkelApp` (SwiftUI + AppKit). The two main UI
+surfaces are the **menu-bar popover** (`MenuView`) and the **notch panel**
+(the sliding `NotchPanel` that shows incoming messages and login codes).
+
+What exists today:
+
+- **Native, labelled controls in the menu.** The popover is built from standard
+  SwiftUI controls. Text buttons (`Button("Join")`, `Button("Sign out")`,
+  `Button("Retry")`, and so on) expose their label to VoiceOver automatically.
+  Icon and status controls carry `.help(...)` tooltips ("Settings", "Copy code",
+  "Leave circle", "Connected"/"Connecting…", "Roll a random code", "Remove"),
+  which surface as VoiceOver help and as hover tooltips.
+- **Menu-bar item label.** The status-item glyph sets
+  `accessibilityDescription = "Munkel"` so the menu-bar control is identified.
+- **Keyboard access.** Standard AppKit/SwiftUI controls are reachable with the
+  system's keyboard navigation. The app also registers a global keyboard
+  shortcut (⌃⌘M by default, user-rebindable from the menu) that opens the
+  quick-send palette.
+- **Contrast and theme.** The UI uses system materials and semantic colours and
+  follows the active light/dark appearance.
+
+**Honest current status / known gaps (tracked):**
+
+- **Dynamic Type is not yet supported.** Most text in the notch and popover uses
+  fixed point sizes (`.font(.system(size: …))`) rather than scalable text styles,
+  so it does not grow with the user's preferred text size. Migrating to semantic
+  text styles (or `@ScaledMetric`) is tracked. A few views already use semantic
+  styles (`.title2`, `.subheadline`, `.caption`).
+- **VoiceOver labels are incomplete.** The app does not yet set any explicit
+  `accessibilityLabel`/`accessibilityValue` annotations: menu controls rely on
+  their text labels or `.help(...)` tooltips, and the notch panel deliberately
+  uses **no** `.help(...)` at all. That last choice is a privacy/security
+  constraint, not an oversight: the notch is excluded from screen capture
+  (`NSWindow.sharingType = .none`, see `CaptureExclusion.swift`), and AppKit
+  draws tooltips in a separate, non-excluded window that would leak message
+  content into a screen share. The notch therefore needs proper in-view
+  `accessibilityLabel`/`accessibilityValue` annotations rather than tooltips,
+  and that work is pending.
+- **Reduce Motion is not yet honoured.** The notch open/close and expand
+  transitions are spring animations that always run; the app does not currently
+  read the system "Reduce Motion" setting
+  (`accessibilityDisplayShouldReduceMotion`). Respecting it is tracked.
+- We have not completed a full VoiceOver walkthrough of every state, so VoiceOver
+  support should be considered partial.
+
+## Project spaces
+
+The places where people read about, discuss, and contribute to Munkel use
+accessible formats and tooling:
+
+- **Repository documentation** (this file, `README.md`, `SECURITY.md`,
+  `PRIVACY.md`, `CONTRIBUTING.md`, `docs/ARCHITECTURE.md`, and the rest) is plain
+  GitHub-flavored Markdown: heading-structured, link-text-bearing, and readable
+  as source or rendered HTML by a screen reader.
+- **Issues, pull requests, discussions, and code review** happen through
+  GitHub's web UI, which is maintained against its own accessibility standards.
+  We do not introduce a separate, less-accessible tracker.
+- **Releases and the changelog** are likewise plain Markdown
+  (`CHANGELOG.md`, GitHub Releases).
+
+## Known gaps & how to report
+
+Conformance is a goal we have partially reached. The concrete gaps we already
+know about:
+
+- Website: no `<main>` landmark or skip link on the landing route; no automated
+  accessibility check in CI; no full screen-reader audit; contrast not
+  exhaustively measured.
+- macOS app: no Dynamic Type scaling; incomplete VoiceOver labels (especially in
+  the notch); system "Reduce Motion" not yet honoured for notch animations.
+
+These are tracked in [ROADMAP.md](../ROADMAP.md).
+
+If you hit an accessibility barrier we have not listed — a control your screen
+reader cannot name, text that will not scale, motion that cannot be turned off,
+insufficient contrast, or anything else — please tell us. **Open an issue:**
+https://github.com/limehq/munkel/issues. Describe the surface (website or app),
+the assistive technology and OS version, and what you expected. Accessibility
+reports are welcome and are treated as bugs.
+
+You can also reach the maintainers directly:
+
+- Jurij Koch — jurij@uq.dev
+- Sebil Satici — hallo@sebil.dev

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,400 @@
+# Architecture
+
+Munkel is a system for ephemeral, end-to-end-encrypted messages between
+friends ("circles") that slide out of the MacBook notch. There are no
+accounts and no message storage: a circle is born from a shared,
+human-readable code (for example `blue-table-42`); each client derives the
+relay group ID and the message key from that code on-device, and a deliberately
+dumb Cloudflare Worker relay routes opaque ciphertext between the members of a
+group without ever seeing the code, the key, or the plaintext. This document is
+a navigable map of the components and the data flow; it links to the source
+files that are authoritative for each claim, rather than restating the code.
+
+## System overview
+
+```
+                                  ┌────────────────────────────────────┐
+                                  │             Cloudflare (limehq)             │
+                                  │                                             │
+  ┌──────────────────────┐  WSS  │  ┌──────────────────────────────────────┐ │
+  │  macOS app (Munkel)   │◄─────►│  │  Worker  munkel-relay                  │ │
+  │                       │  /ws  │  │  (Hono router)  relay.munkel.app       │ │
+  │  ┌────────────────┐   │       │  │                                        │ │
+  │  │   MunkelKit    │   │       │  │   GET /ws?group&member   ─┐            │ │
+  │  │  GroupKey      │   │       │  │   /blob/:group/:key       │            │ │
+  │  │  MessageCrypto │   │       │  │   /health                 │            │ │
+  │  │  RelayClient   │   │       │  │                           ▼            │ │
+  │  │  BlobClient    │   │  HTTPS│  │   ┌──────────────────────────────┐ │ │
+  │  │  AppPayload    │◄──┼──────►│  │   │  Durable Object  GroupRoom       │ │ │
+  │  │  GitHubDevice… │   │ /blob │  │   │  one per circle:                 │ │ │
+  │  └────────────────┘   │       │  │   │  idFromName(groupId)             │ │ │
+  │                       │       │  │   │  WebSocket Hibernation, NO storage│ │ │
+  │  MenuBarExtra UI      │       │  │   └────────────────────────────────┘ │ │
+  │  NotchPanel (notch)   │       │  └──────────────────────────────────────┘ │
+  │  ControlServer (sock) │       │                                             │
+  └──────────┬──────────┘       │  ┌──────────────┐    ┌────────────────────┐ │
+             │ Unix domain socket│  │ R2  munkel-  │    │  Worker  munkel    │ │
+             │ (control.sock)    │  │ blobs        │    │  (TanStack Start)  │ │
+  ┌──────────┴───────────┐       │  │ opaque       │    │  munkel.app        │ │
+  │  munkel CLI           │       │  │ ciphertext,  │    └────────────────────┘ │
+  │  (Bun / TypeScript)   │       │  │ ~66 s TTL,   │                           │
+  │  thin send-only client│       │  │ per-min cron │                           │
+  └──────────────────────┘       │  └──────────────┘                           │
+                                  └────────────────────────────────────┘
+```
+
+Solid arrows are network or IPC links. The relay and R2 see only ciphertext and
+derived identifiers; the human-readable circle code and message plaintext never
+leave the macOS app.
+
+## Components
+
+The repository is a Bun-workspaces + Turborepo monorepo. See the component
+table in [`README.md`](../README.md#components).
+
+### macOS app (`apps/macos`)
+
+A Swift/SwiftUI menu-bar app (`MenuBarExtra`, no Dock icon). It owns all crypto
+and relay connections; the CLI and the UI are clients of it. Source layout under
+[`apps/macos/Sources`](../apps/macos/Sources):
+
+- **`MunkelApp`** — the application module: menu-bar UI, notch presentation,
+  app state, and the CLI control socket.
+  - [`AppModel.swift`](../apps/macos/Sources/MunkelApp/AppModel.swift) — central
+    state: joined circles, identity, and the `handleControl` entry point that
+    resolves circle/recipient names for the CLI.
+  - [`GroupSession.swift`](../apps/macos/Sources/MunkelApp/GroupSession.swift) —
+    one joined circle: holds its `RelayClient`, seals/opens payloads, tracks
+    presence, and exchanges `profile` payloads. This is where send and receive
+    are wired end-to-end.
+  - [`NotchPanel/`](../apps/macos/Sources/MunkelApp/NotchPanel) +
+    [`NotchPresenter.swift`](../apps/macos/Sources/MunkelApp/NotchPresenter.swift)
+    — the notch display: a borderless `NotchPanelWindow` shaped to the physical
+    notch, with a floating fallback panel on Macs without one.
+  - [`ControlServer.swift`](../apps/macos/Sources/MunkelApp/ControlServer.swift)
+    — the Unix-domain-socket server that backs the CLI.
+  - [`CaptureExclusion.swift`](../apps/macos/Sources/MunkelApp/CaptureExclusion.swift)
+    — the screen-capture exclusion used by every surface that shows message
+    content or circle codes.
+- **`MunkelKit`** — the reusable library (crypto, protocol, relay/blob clients,
+  GitHub login):
+  - [`GroupKey.swift`](../apps/macos/Sources/MunkelKit/GroupKey.swift) — HKDF
+    derivation of `groupId` and `messageKey` from the circle code.
+  - [`MessageCrypto.swift`](../apps/macos/Sources/MunkelKit/MessageCrypto.swift)
+    — AES-256-GCM seal/open (base64 for relay frames, raw bytes for R2 blobs).
+  - [`AppPayload.swift`](../apps/macos/Sources/MunkelKit/AppPayload.swift) — the
+    `chat` / `profile` / `image` payloads that live *inside* the encrypted blob.
+  - [`WireMessage.swift`](../apps/macos/Sources/MunkelKit/WireMessage.swift) —
+    the `ClientMessage` / `ServerMessage` wire frames (Swift mirror of
+    `protocol.ts`).
+  - [`RelayClient.swift`](../apps/macos/Sources/MunkelKit/RelayClient.swift) —
+    the WebSocket client (auto-reconnect with exponential backoff capped at
+    30 s, 30 s pings).
+  - [`BlobClient.swift`](../apps/macos/Sources/MunkelKit/BlobClient.swift) —
+    the HTTP client for R2 image blobs (same origin as the relay).
+  - [`ImageCodec.swift`](../apps/macos/Sources/MunkelKit/ImageCodec.swift) /
+    [`AvatarCodec.swift`](../apps/macos/Sources/MunkelKit/AvatarCodec.swift) —
+    AVIF/JPEG transcoding and byte budgets.
+  - [`GitHubDeviceAuth.swift`](../apps/macos/Sources/MunkelKit/GitHubDeviceAuth.swift)
+    — the OAuth device flow that imports a display-only name and avatar.
+  - [`ControlProtocol.swift`](../apps/macos/Sources/MunkelKit/ControlProtocol.swift)
+    — the CLI ↔ app control contract.
+
+### munkel CLI (`apps/cli`)
+
+A thin, send-only Bun/TypeScript client. It does **no** crypto and holds **no**
+relay connection; it serializes a `ControlRequest` as one line of JSON over the
+app's control socket and prints the `ControlResponse`. If the app is not
+running, it launches it in the background and waits for the socket. See
+[`apps/cli/src/munkel.ts`](../apps/cli/src/munkel.ts) and the CLI section of
+[`README.md`](../README.md#munkel-cli).
+
+### Cloudflare Worker relay (`apps/server`)
+
+A Cloudflare Worker (Hono router, Worker name `munkel-relay`) fronting one
+Durable Object per circle:
+
+- [`index.ts`](../apps/server/src/index.ts) — the router. Mounts `/health`, the
+  blob routes, and `GET /ws`, which validates the `group`/`member` query
+  parameters and forwards the WebSocket upgrade to the circle's Durable Object
+  via `GROUP_ROOM.idFromName(group)`. It also exports the `scheduled` handler
+  for the per-minute blob sweep.
+- [`group-room.ts`](../apps/server/src/group-room.ts) — the `GroupRoom` Durable
+  Object (`partyserver` `Server`, `hibernate: true`). It validates frames
+  against the protocol schema, routes broadcasts and `to`-targeted messages,
+  derives presence from live connections, and enforces the per-group connection
+  cap (32) and the idle/stale timeout (120 s). **No Durable Object storage is
+  used for messages** — only a `setAlarm` to reap stale connections — so
+  messages are ephemeral by construction.
+- [`protocol.ts`](../apps/server/src/protocol.ts) — the authoritative wire
+  protocol v1 (see below).
+- [`blob.ts`](../apps/server/src/blob.ts) — the R2 image-blob routes and the
+  TTL sweep.
+
+The Worker is reachable at `munkel-relay.limehq.workers.dev` and via the custom
+domain **`relay.munkel.app`**, attached on deploy through the `routes` entry in
+[`apps/server/wrangler.toml`](../apps/server/wrangler.toml).
+
+### R2 blob store (`munkel-blobs`)
+
+A private R2 bucket bound to the relay Worker as `BLOBS`. It holds
+full-resolution image blobs as **opaque ciphertext** (sealed on the client
+before upload), namespaced by `groupId` and keyed by a client-generated random
+id. It is the only persistence surface in the system, and only briefly: a blob
+older than `BLOB_TTL_MS` (≈66 s = the 60 s notch-survival window plus 10 %
+grace) is treated as gone (404) and deleted on the next `GET`, and a per-minute
+cron (`crons = ["* * * * *"]` in `wrangler.toml`) physically sweeps blobs that
+were never fetched. See [`blob.ts`](../apps/server/src/blob.ts).
+
+### Landing page (`apps/landing`)
+
+A TanStack Start (React + Tailwind v4) app served by a separate Cloudflare
+Worker (Worker name `munkel`) with SSR, at the custom domains **`munkel.app`**
+and **`www.munkel.app`** declared in
+[`apps/landing/wrangler.jsonc`](../apps/landing/wrangler.jsonc). It is marketing
+and documentation only — it has no access to relay traffic, R2, or any keys.
+
+## Identity, keys, and groups
+
+There are no accounts. Everything derives on-device from the human-readable
+circle code, which never leaves the client. Derivation is pinned identically in
+Swift ([`GroupKey.swift`](../apps/macos/Sources/MunkelKit/GroupKey.swift)) and
+documented in [`protocol.ts`](../apps/server/src/protocol.ts):
+
+1. **Normalize** the code: Unicode NFC, trim, lowercase.
+2. **`groupId`** = `hex(HKDF-SHA256(ikm = utf8(code), salt = "munkel-v1",
+   info = "group-id", 16 bytes))` → a 32-hex-char, 128-bit identifier. This is
+   the only thing the relay ever sees for a circle.
+3. **`messageKey`** = `HKDF-SHA256(ikm = utf8(code), salt = "munkel-v1",
+   info = "message-key", 32 bytes)` → the AES-256-GCM key.
+
+HKDF-SHA256 → AES-256-GCM was chosen for clean CryptoKit ↔ WebCrypto interop;
+the Swift/TS cross-implementation is exercised by
+[`apps/server/scripts/dev-send.ts`](../apps/server/scripts/dev-send.ts), an
+independent TypeScript reference sender. `memberId` is a client-generated UUID,
+stable per installation
+([`Identity.swift`](../apps/macos/Sources/MunkelApp/Identity.swift)).
+
+## End-to-end data flow
+
+### Sending a message
+
+1. The app builds an `AppPayload` (`chat`, `profile`, or `image`) and
+   JSON-encodes it
+   ([`AppPayload.swift`](../apps/macos/Sources/MunkelKit/AppPayload.swift)).
+2. It seals the JSON with `messageKey`:
+   `payload = base64(nonce[12] ‖ ciphertext ‖ tag[16])`, random 12-byte nonce,
+   empty AAD ([`MessageCrypto.swift`](../apps/macos/Sources/MunkelKit/MessageCrypto.swift)).
+3. It sends a `{"type":"send", payload, to?}` frame over the circle's WebSocket
+   (`GET /ws?group=<32-hex>&member=<uuid>`). With `to` set to a `memberId` the
+   relay delivers to that member only; without it the relay broadcasts to the
+   rest of the group
+   ([`RelayClient.swift`](../apps/macos/Sources/MunkelKit/RelayClient.swift),
+   [`GroupSession`](../apps/macos/Sources/MunkelApp/GroupSession.swift)).
+4. The `GroupRoom` Durable Object validates the frame against the Zod schema and
+   relays the opaque `payload` to the target(s) as a `{"type":"message", from,
+   to?, payload}` frame — never echoing it back to the sender and never storing
+   it ([`group-room.ts`](../apps/server/src/group-room.ts)).
+
+For images, the full-resolution AVIF is sealed and `PUT` to R2 *before* the
+relay frame goes out; the relayed `image` payload carries only a tiny inline
+AVIF thumbnail plus an `r2Key` pointer per image (see
+[`GroupSession.sendImages`](../apps/macos/Sources/MunkelApp/GroupSession.swift)
+and [`blob.ts`](../apps/server/src/blob.ts)).
+
+### Receiving a message
+
+1. On connect the relay sends a `welcome` frame listing the other members
+   currently online; `peer-joined` / `peer-left` track presence thereafter.
+2. An incoming `message` frame's `payload` is opened with `messageKey`. A
+   payload that fails to decrypt or decode is dropped, not surfaced.
+3. The decoded `AppPayload` is dispatched: `chat` text and `image` albums are
+   shown in the notch via `NotchPanel` / `NotchPresenter`; `profile` payloads
+   update the sender's display name and avatar locally. Full-resolution images
+   are fetched and decrypted from R2 lazily, on demand, keyed by `r2Key`.
+4. Messages live only in memory and only for the notch-survival window
+   (~60 s); there is no history and nothing is written to disk. See
+   [`GroupSession.handleIncoming`](../apps/macos/Sources/MunkelApp/GroupSession.swift).
+
+Ephemerality is enforced by the relay's design (no Durable Object storage of
+messages, no message buffer) rather than by a retention policy: an offline
+member simply never receives a message.
+
+## Wire protocol v1
+
+The protocol is specified where it is enforced:
+[`apps/server/src/protocol.ts`](../apps/server/src/protocol.ts) is the
+**authoritative source**. Swift mirrors it in
+[`WireMessage.swift`](../apps/macos/Sources/MunkelKit/WireMessage.swift); the
+TypeScript reference sender is
+[`dev-send.ts`](../apps/server/scripts/dev-send.ts). Summary:
+
+- **Transport.** WebSocket (WSS in production), JSON text frames. A connection
+  *is* a group membership — there is no hello/join/leave handshake; presence
+  derives from live connections. Reconnecting with the same `memberId` silently
+  replaces the old connection.
+- **Connect.** `GET /ws?group=<32-hex>&member=<uuid>`. `group` must match
+  `GROUP_ID_REGEX`; `member` must match `MEMBER_ID_REGEX`.
+- **Client → server frames.** `{"type":"send", payload, to?}` and
+  `{"type":"ping"}`.
+- **Server → client frames.** `welcome` (with the online member list),
+  `peer-joined`, `peer-left`, `message` (`from`, optional `to`, `payload`),
+  `pong`, and `error` (`invalid-message` | `unknown-recipient`).
+- **Limits.** 64 KiB per WebSocket frame; `MAX_PAYLOAD_CHARS` = 48 KiB of
+  base64 ciphertext per payload; 32 connections per group. Clients ping
+  every ≤60 s (the macOS client every 30 s); the server answers `pong` and
+  closes connections idle for more than 120 s.
+- **Application payloads** (inside the encrypted blob, invisible to the relay):
+  a `kind`-discriminated JSON object — `chat` (`text`, `sentAt`), `profile`
+  (`displayName`, optional base64 `avatar`), or `image` (1–8 `items`, shared
+  `caption`, `sentAt`; each item is an `r2Key` pointer plus an inline AVIF
+  `thumb`). See
+  [`AppPayload.swift`](../apps/macos/Sources/MunkelKit/AppPayload.swift).
+
+### Image blobs (R2)
+
+Full-resolution images never fit a 48 KiB relay frame, so they travel
+out-of-band over HTTP on the relay's own origin
+(`http(s)://host/blob/<group>/<key>`):
+
+- `PUT /blob/:group/:key` — store opaque ciphertext. Bounded to `MAX_BLOB_BYTES`
+  (3 MiB) per object. The only access control is knowing the unguessable
+  `groupId` *and* the random per-image `key`.
+- `GET /blob/:group/:key` — serve the ciphertext, or `404` (and delete) once it
+  is past `BLOB_TTL_MS` (~66 s).
+- A per-minute cron runs `sweepExpiredBlobs` to physically delete blobs that
+  were never fetched.
+
+Clients seal with `messageKey` before upload, so R2 only ever holds ciphertext.
+See [`blob.ts`](../apps/server/src/blob.ts) and
+[`BlobClient.swift`](../apps/macos/Sources/MunkelKit/BlobClient.swift).
+
+## CLI ↔ app control socket
+
+The CLI talks to the running app over a Unix domain socket at
+`~/Library/Application Support/Munkel/control.sock` (the `Munkel Dev` directory
+for debug builds), using **newline-delimited JSON**, one request/response per
+connection. The contract is
+[`ControlProtocol.swift`](../apps/macos/Sources/MunkelKit/ControlProtocol.swift),
+mirrored in [`apps/cli/src/munkel.ts`](../apps/cli/src/munkel.ts); the server is
+[`ControlServer.swift`](../apps/macos/Sources/MunkelApp/ControlServer.swift),
+dispatched by
+[`AppModel.handleControl`](../apps/macos/Sources/MunkelApp/AppModel.swift):
+
+- `ControlRequest`: `action`, optional `group`, `to`, `text`, and `imagePaths`
+  (absolute paths to images to send as one album — the app reads, encodes,
+  seals, and uploads them, so image bytes never cross the socket or argv).
+- `ControlResponse`: `ok`, optional `error`, optional `groups`
+  (`code` / `connected` / `members`).
+
+The app resolves circle-code prefixes and recipient display names (or `memberId`
+prefixes) before sending, which is what makes the one-call `munkel dm <name>`
+path and agent skills possible. The socket path can be overridden with
+`MUNKEL_SOCKET` (used by the tests). The CLI is **send-only** by design; it can
+list circles and send, but cannot read message history (there is none).
+
+## Capture-proof UI surfaces
+
+Every window that shows message content or a circle code is excluded from screen
+capture by setting `NSWindow.sharingType` (`.none` in release builds), applied
+by the `CaptureExclusion` view in the same SwiftUI update pass that mounts the
+content. This makes those surfaces invisible in Teams/Zoom shares and
+screenshots while remaining visible on the physical display. The exclusion
+covers the notch panel
+([`NotchPanelWindow`](../apps/macos/Sources/MunkelApp/NotchPanel/NotchPanelWindow.swift),
+[`NotchPresenter`](../apps/macos/Sources/MunkelApp/NotchPresenter.swift)), the
+menu popover
+([`MenuView`](../apps/macos/Sources/MunkelApp/MenuView.swift)), the command
+palette
+([`CommandPalettePanel`](../apps/macos/Sources/MunkelApp/CommandPalettePanel.swift)),
+the GitHub auth-code notch
+([`AuthCodeNotchView`](../apps/macos/Sources/MunkelApp/AuthCodeNotchView.swift)),
+and the image preview overlay
+([`ImagePreviewOverlay`](../apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift)).
+
+Honest limits, documented in
+[`CaptureExclusion.swift`](../apps/macos/Sources/MunkelApp/CaptureExclusion.swift):
+the exclusion reliably hides the window from the legacy CoreGraphics path
+(system screenshot tools, older recorders) and from ScreenCaptureKit on
+macOS ≤ 15.3, but on macOS 15.4+ ScreenCaptureKit *full-display* capture can
+ignore `sharingType = .none`. It is therefore best-effort against modern SCK
+display recorders. A corollary the code enforces: notch content uses no
+`.help()` tooltips, because AppKit draws tooltips in a separate window that
+cannot inherit the exclusion. A DEBUG-only "Allow in screenshots" toggle switches
+these surfaces to `.readOnly` so the notch can be captured for docs; release
+builds have no such path.
+
+## Trust boundaries
+
+The circle code is the only credential. It never leaves the client, and the
+relay cannot derive the `messageKey` from anything it sees.
+
+**What the relay can see:** the derived `groupId` (a random-looking 128-bit
+hash), `memberId` UUIDs, message sizes, and timing. For blobs it additionally
+sees ciphertext size and the `groupId`/`key` pair used to address an object.
+
+**What the relay cannot see:** the circle code, the message key, message
+content, display names, avatars, image bytes (all ciphertext), or which human a
+`memberId` belongs to. Joining requires no server round-trip — knowing the code
+is knowing the group — so unguessable 128-bit group IDs are the only access
+control in v1.
+
+Honest non-goals and limitations (see also
+[`README.md`](../README.md#security-model),
+[`SECURITY.md`](../SECURITY.md), and
+[`PRIVACY.md`](../PRIVACY.md)):
+
+- **Generated circle codes are convenience-grade shared secrets**, optimized
+  for being spoken at a table. Any current member with the code shares the same
+  message key.
+- **Direct messages are relay-targeted in v1, not pairwise-encrypted.** Pairwise
+  keys are deferred to v2.
+- **GitHub login is display identity only.** It runs the OAuth device flow with
+  empty scope, fetches `GET /user` once, downloads the avatar, and discards the
+  token; the imported name/avatar are self-asserted, with no cryptographic proof
+  that a member controls the GitHub account, and travel to peers only inside the
+  E2E-encrypted `profile` payload.
+
+Munkel is designed for lightweight, ephemeral messages, not high-risk secret
+sharing.
+
+## Deployment topology
+
+- **Relay** (`apps/server`) → Cloudflare Worker `munkel-relay` + the `GroupRoom`
+  Durable Object + the `munkel-blobs` R2 bucket + the per-minute cron, all
+  declared in [`apps/server/wrangler.toml`](../apps/server/wrangler.toml).
+  Custom domain **`relay.munkel.app`**. The R2 bucket must be created once
+  before the first deploy that includes the binding
+  (`wrangler r2 bucket create munkel-blobs`); see
+  [`README.md`](../README.md#development).
+- **Landing** (`apps/landing`) → Cloudflare Worker `munkel`, custom domains
+  **`munkel.app`** / **`www.munkel.app`**, configured in
+  [`apps/landing/wrangler.jsonc`](../apps/landing/wrangler.jsonc).
+- **macOS app + CLI** → distributed as a signed, notarized DMG and via the
+  Homebrew cask `limehq/tap/munkel`. Sparkle delivers signed (EdDSA) auto-updates
+  with the appcast at `munkel.app/appcast.xml`.
+
+Both Cloudflare Workers deploy automatically from GitHub Actions on pushes to
+`main` that touch their paths
+([`deploy-server.yml`](../.github/workflows/deploy-server.yml),
+[`deploy-landing.yml`](../.github/workflows/deploy-landing.yml)),
+authenticating with the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`
+secrets (the `limehq` account); the R2 binding, the cron trigger, and the custom
+domains all apply from the wrangler config on deploy. The app release pipeline
+is [`release.yml`](../.github/workflows/release.yml), driven by Release Please
+([`release-please.yml`](../.github/workflows/release-please.yml)). Quality gates
+run in [`ci.yml`](../.github/workflows/ci.yml),
+[`codeql.yml`](../.github/workflows/codeql.yml),
+[`codeql-swift.yml`](../.github/workflows/codeql-swift.yml), and
+[`scorecard.yml`](../.github/workflows/scorecard.yml). All workflows run on
+GitHub-hosted runners. See [`RELEASING.md`](../RELEASING.md) for the release
+process.
+
+## Related documents
+
+- [`README.md`](../README.md) — overview, install, components.
+- [`SECURITY.md`](../SECURITY.md) — security model and vulnerability reporting.
+- [`PRIVACY.md`](../PRIVACY.md) — what data exists and for how long.
+- [`docs/ACCESSIBILITY.md`](ACCESSIBILITY.md) — accessibility of the macOS UI.
+- [`docs/INTERNATIONALIZATION.md`](INTERNATIONALIZATION.md) — i18n status.
+- [`RELEASING.md`](../RELEASING.md) — release and deploy process.

--- a/docs/INTERNATIONALIZATION.md
+++ b/docs/INTERNATIONALIZATION.md
@@ -1,0 +1,123 @@
+# Internationalization
+
+Munkel is an English-only product today. This document is deliberately honest
+about that: **no non-English locale ships yet, and there is no translation
+workflow in place.** What we have done is keep the codebase in a state where
+localization is a tractable, additive change rather than a rewrite. This
+document records that approach and what is still missing, so the gap is visible
+rather than hidden. Internationalization work lives alongside other planned
+work in [ROADMAP.md](../ROADMAP.md).
+
+The two surfaces a user reads are the **website** (`munkel.app`) and the
+**macOS app**. The relay and the `munkel` CLI have no graphical UI of their own;
+the CLI's output is plain English text in the user's terminal.
+
+## Current state at a glance
+
+| Surface | Localizable today | Translations shipped | Notes |
+| --- | --- | --- | --- |
+| macOS app | Partially (strings are localizable primitives) | None | No `.xcstrings` catalog yet |
+| Website | No (copy is hardcoded English JSX) | None | No i18n library yet |
+| CLI | No | None | Plain English terminal output |
+
+Everything below explains what "partially" means and where the line is.
+
+## macOS app
+
+Source: `apps/macos/Sources/MunkelApp` (SwiftUI + AppKit).
+
+The UI is built from standard SwiftUI views — `Text`, `Label`, `Button`,
+`Toggle`, and `.help(...)` — that take string literals. There are around 40 such
+user-facing literals, concentrated in `MenuView.swift` (the menu-bar popover)
+with a handful more in the notch views (`AuthCodeNotchView.swift`,
+`MessageNotchContainer.swift`, `MessageNotchView.swift`) and the command palette
+(`CommandPaletteView.swift`). Most notch content is the user's own message text,
+which is not translatable copy.
+
+Why this matters for localization:
+
+- **String literals are localizable keys.** When you write `Text("Join")` or
+  `Label("GitHub sign-in", systemImage: …)`, SwiftUI uses the
+  `LocalizedStringKey` initializer for the literal automatically. These strings
+  are therefore mechanically extractable into an Xcode String Catalog
+  (`.xcstrings`) without code changes. The app does not use `Text(verbatim:)`
+  anywhere, so no UI string is explicitly opted out of localization.
+- **Dynamic strings use interpolation, not concatenation.** User-specific text
+  is built with string interpolation that keeps a full sentence in one
+  translatable unit — for example `Text("Signed in as \(model.displayName)
+  (@\(login))")` in `MenuView.swift`, and the image-overflow badge
+  `Text("+\(message.images.count - 3)")` in `MessageNotchContainer.swift`.
+  Translators see the whole phrase, not glued-together fragments.
+- **No locale-unsafe formatting in the UI.** Munkel is ephemeral: it shows no
+  message history and no timestamps, so the UI layer
+  (`apps/macos/Sources/MunkelApp`) has no hand-rolled `DateFormatter` or
+  `String(format:)` calls. (The `MunkelKit` library does use
+  `ISO8601DateFormatter` for wire serialization and `String(format: "%02x", …)`
+  for hex encoding in `GroupKey.swift`; both are intentionally
+  locale-independent machine formats, not user-facing text.) When user-facing
+  formatting is eventually needed, it should use locale-aware system APIs.
+
+What is **not** done:
+
+- No String Catalog exists in source. `apps/macos/Package.swift` declares the
+  app target's resources as `resources: [.process("Resources")]`; there is no
+  `.xcstrings` file to populate yet.
+- No non-English `.lproj`/catalog translations ship.
+- Pluralization (e.g. "1 image" vs "2 images") and right-to-left (RTL) layout
+  have not been audited or implemented.
+
+## Website (munkel.app)
+
+Source: `apps/landing` (TanStack Start, React, Tailwind v4).
+
+What is in place:
+
+- The document language is declared explicitly: the root document sets
+  `<html lang="en">` in `src/routes/__root.tsx`. This is correct for the only
+  language currently shipped and is the right starting point for adding more.
+
+What is **not** done:
+
+- There is no internationalization library in the project. `package.json`
+  pulls in none of `i18next`, `react-intl`/`formatjs`, or `lingui`.
+- All copy is hardcoded English JSX in the section components under
+  `src/components/sections` (hero, features, CLI, FAQ, footer, and so on) and
+  in the legal routes. Strings are not externalized into message catalogs.
+- The `lang` attribute is a static literal, not driven by a locale.
+
+Localizing the website would mean introducing a message-catalog approach,
+extracting the hardcoded strings, and driving `lang` (and any future RTL
+`dir`) from the active locale.
+
+## CLI and relay
+
+The `munkel` CLI (`apps/cli`) prints plain English status and error text to the
+terminal; it has no localization layer. The relay (`apps/server`) has no
+user-facing strings — it speaks the wire protocol defined in
+`apps/server/src/protocol.ts` and is never read by an end user.
+
+## What localizing Munkel would take
+
+We have not committed to specific locales. The path, if and when we add one, is
+additive:
+
+1. **macOS app:** add an `.xcstrings` String Catalog to the app target, let
+   Xcode extract the existing `LocalizedStringKey` literals, add per-language
+   translations, and audit pluralization and RTL layout.
+2. **Website:** adopt a message-catalog approach, extract the hardcoded JSX
+   copy, and make `lang`/`dir` follow the active locale.
+3. **CLI:** decide whether terminal output is worth localizing at all; agent
+   and developer tooling output is often deliberately kept in English.
+
+## Reporting and contributing
+
+If the lack of a translation is a barrier for you, or you want to help with a
+specific locale, please open an issue:
+https://github.com/limehq/munkel/issues. Describe the surface (website, macOS
+app, or CLI) and the language you need. See [CONTRIBUTING.md](../CONTRIBUTING.md)
+for how to propose changes.
+
+You can also reach the maintainers directly:
+
+- Jurij Koch — jurij@uq.dev
+- Sebil Satici — hallo@sebil.dev


### PR DESCRIPTION
## Summary

Adds the governance, documentation, and contribution-process artifacts needed to
meet the **OpenSSF Best Practices silver/gold** criteria (project
[13278](https://www.bestpractices.dev/projects/13278)). Documentation only — no
code behavior changes.

Each document was drafted and then **adversarially fact-checked against the
actual repo**, which caught and corrected several overclaims (e.g.
"capture-proof" → best-effort with the macOS 15.4+ ScreenCaptureKit caveat,
"no Durable Object storage" → "persists no message data", a wrong
`make-bundle.sh` invocation, a broken `README#deploy` anchor, CLI "key-id" →
"memberId").

## Criteria covered

**Project oversight**
- `dco` — `CONTRIBUTING.md` DCO section + `.github/workflows/dco.yml` (CI sign-off check)
- `governance` — `GOVERNANCE.md`
- `code_of_conduct` — `CODE_OF_CONDUCT.md` (added scope, enforcement, private contact)
- `roles_responsibilities` — `GOVERNANCE.md` + `MAINTAINERS.md`
- `access_continuity` — `GOVERNANCE.md` (shared admin/key access, offline backups, limehq backstop)
- `bus_factor` — `GOVERNANCE.md` (two maintainers, each with full access)

**Documentation**
- `documentation_roadmap` — `ROADMAP.md` (next ~12 months + non-goals)
- `documentation_architecture` — `docs/ARCHITECTURE.md`
- `documentation_security` — `SECURITY.md` (security requirements + threat model)
- `documentation_quick_start` — `README.md#quick-start`
- `documentation_current` — `CONTRIBUTING.md` keep-docs-current policy
- `documentation_achievements` — badge row + doc links in `README.md`

**Accessibility / i18n / other**
- `accessibility_best_practices` — `docs/ACCESSIBILITY.md`
- `internationalization` — `docs/INTERNATIONALIZATION.md`
- `sites_password_security` — N/A, documented in `SECURITY.md#credential--password-storage`

## Governance / people facts asserted (please confirm they match reality)

- Lead Maintainer: **Jurij Koch**; Maintainer: **Sebil Satici** — both hold admin
  on the GitHub org/repo, the Cloudflare account (relay, landing, `munkel.app`
  DNS), and the Sparkle signing key. This is what makes `bus_factor` and
  `access_continuity` honestly *Met*.
- `@limehq/munkel-maintainers` is the CODEOWNERS team of record — ensure its
  membership matches `MAINTAINERS.md`.
- limehq (legal entity *Unique (Deutschland) GmbH*, per `LICENSE`) is the
  org/legal backstop.

## Notes

- **The badge form is manual.** After merge, enter each criterion's status + URL
  + justification at bestpractices.dev/projects/13278; the repo docs alone do not
  update the badge. URLs point at `main`, so submit after merge.
- **`internationalization` is the softest claim** — marked *Met* for the SHOULD
  ("make an effort"): the app uses localizable SwiftUI primitives and locale-safe
  formatting, but no non-English locale ships yet and there is no String Catalog /
  i18n library. Implementation is on the roadmap.
- **DCO enforcement starts on the next PR.** Future commits need `git commit -s`;
  bot authors are skipped and the existing unsigned history is untouched (the
  check only inspects a PR's own commit range).

## Test plan

- [x] All relative cross-links resolve to existing files (scripted check).
- [x] `.github/workflows/dco.yml` is valid YAML; checkout is SHA-pinned to match
      the repo convention; the bot-skip + Signed-off-by trailer logic verified.
- [x] No source/code changes — nothing to build or test beyond docs.
- [ ] Reviewer: confirm the maintainer/access claims above are accurate.