### PR TITLE
refactor(macos): rename notch display picker to "Preferred Display"

### DIFF
--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -165,7 +165,7 @@ struct MenuView: View {
                     Text(option.name).tag(option.id)
                 }
             } label: {
-                Label("Notch display", systemImage: "display")
+                Label("Preferred Display", systemImage: "display")
             }
             #if DEBUG
             Divider()


### PR DESCRIPTION
## What

Renames the Settings menu picker that chooses which screen the notch renders on:

> **Notch display** → **Preferred Display**

Label text only — the `display` SF Symbol, the picker options (`Automatic` + connected displays), and all behaviour are unchanged.

## Why

"Notch display" named *the thing being chosen* (a display), which read awkwardly next to the display icon on its left and the display names already listed below it. "Preferred Display" names *the choice* instead, drops the redundancy, and lines up with the underlying `preferredDisplayID` UserDefaults key.

## Test plan

- [ ] `bun run dev` in `apps/macos`, open the gear menu in the notch
- [ ] Picker now reads **Preferred Display**, with `Automatic` + each connected screen
- [ ] Selecting a display still pins the notch there; `Automatic` follows the active screen