### PR TITLE
feat(macos): full-screen centered image hover preview (current + history)

### DIFF
--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -199,6 +199,37 @@ final class AppModel: ObservableObject {
         #endif
     }
 
+    #if DEBUG
+    /// Dev aid: seed the notch with a synthetic backlog of text + image messages
+    /// and show a current message on top, so the expanded-history image hover
+    /// preview can be exercised without sending real messages back and forth.
+    /// Triggered from the menu's DEBUG section; the rows live the usual 60 s
+    /// history window, then expire — re-run the item to refresh them. The heavy
+    /// lifting (render + AVIF transcode) is in `DemoHistory`.
+    func debugShowDemoHistory() {
+        let code = groupCodes.first ?? "demo"
+        let index = max(0, groupCodes.firstIndex(of: code) ?? 0)
+        // `build` owns the SwiftUI `Color` (computed from the index) and hands it
+        // back in the bundle, so this model never has to name a SwiftUI type.
+        let demo = DemoHistory.build(group: code, colorIndex: index)
+
+        // Inject the backlog straight into the history buffer, then show the
+        // current message above it — the same path a real arrival takes.
+        notch.debugSeedHistory(demo.backlog)
+        notch.show(
+            sender: "Sebil",
+            avatarData: Identity.avatarData,
+            text: demo.currentText,
+            isDirect: false,
+            group: code,
+            groupColor: demo.color,
+            inMultipleGroups: groupCodes.count > 1,
+            images: demo.currentImages,
+            loadFull: { [fulls = demo.fulls] id in fulls[id] }
+        ) { _, _, _ in }
+    }
+    #endif
+
     /// Opens the quick-send command palette (also bound to the global hotkey).
     func openCommandPalette() {
         palette?.show()

--- a/apps/macos/Sources/MunkelApp/DebugDemoHistory.swift
+++ b/apps/macos/Sources/MunkelApp/DebugDemoHistory.swift
@@ -1,0 +1,157 @@
+#if DEBUG
+import AppKit
+import MunkelKit
+import SwiftUI
+
+/// Builds the demo backlog on the main actor: renders a few labelled gradient
+/// PNGs, transcodes them through the real `ImageCodec` path (so the cells decode
+/// exactly like received images), and assembles history rows + a current message.
+/// Driven by `AppModel.debugShowDemoHistory` (defined in AppModel.swift so it can
+/// reach the private `notch`).
+@MainActor
+enum DemoHistory {
+    struct Built {
+        var backlog: [HistoryEntry]
+        var currentText: String
+        var currentImages: [IncomingImage]
+        /// The circle's color, computed here so callers (AppModel) needn't name a
+        /// SwiftUI type — passed straight through to `notch.show`.
+        var color: Color
+        /// Full-resolution AVIF per r2Key — the per-image loader returns these,
+        /// so there's no R2 round trip for demo pictures.
+        var fulls: [String: Data]
+    }
+
+    static func build(group: String, colorIndex: Int) -> Built {
+        let color = Color.groupColor(index: colorIndex)
+        var fulls: [String: Data] = [:]
+
+        // Render → transcode one demo picture, registering its full bytes.
+        func make(_ id: String, _ label: String, _ width: Int, _ height: Int,
+                  _ from: NSColor, _ to: NSColor, budget: Int) -> IncomingImage? {
+            let png = render(label, width, height, from, to)
+            guard let full = ImageCodec.prepareFull(from: png) else { return nil }
+            // Mirror sendImages: reuse the full AVIF as the inline thumb when it
+            // fits the per-image budget, else a small AVIF.
+            let thumb = full.data.count <= budget
+                ? full.data
+                : (ImageCodec.makeThumbnail(from: png, maxBytes: budget) ?? full.data)
+            fulls[id] = full.data
+            return IncomingImage(id: id, thumb: thumb, width: full.width, height: full.height)
+        }
+
+        let single = AppPayload.perThumbBudget(imageCount: 1)
+
+        // A matrix of aspect ratios (16:9, 4:3, 1:1, 9:16) at different sizes —
+        // including one tiny image — so the centered preview's fit (fill up to the
+        // screen, never upscale past native, aspect preserved) is easy to judge
+        // across shapes and scales. The label baked into each picture names its
+        // ratio + pixel size, so it's legible right in the preview. Each becomes
+        // its own single-image history row.
+        let singleSpecs: [(caption: String, w: Int, h: Int, from: NSColor, to: NSColor)] = [
+            ("16:9 · 1920×1080", 1920, 1080, .systemIndigo, .systemPurple),
+            ("16:9 · 640×360", 640, 360, .systemBlue, .systemTeal),
+            ("4:3 · 1600×1200", 1600, 1200, .systemGreen, .systemMint),
+            ("1:1 · 1280×1280", 1280, 1280, .systemPink, .systemRed),
+            ("9:16 · 1080×1920", 1080, 1920, .systemOrange, .systemYellow),
+            ("1:1 · 160×160", 160, 160, .systemCyan, .systemBlue),
+        ]
+        let singles: [(caption: String, image: IncomingImage)] = singleSpecs.enumerated().compactMap { offset, spec in
+            guard let image = make("demo-single-\(offset)", spec.caption, spec.w, spec.h, spec.from, spec.to, budget: single)
+            else { return nil }
+            return (spec.caption, image)
+        }
+
+        // A mixed-aspect album so the in-grid hover preview can be checked too.
+        let albumSpecs: [(caption: String, w: Int, h: Int, from: NSColor, to: NSColor)] = [
+            ("4:3 · 800×600", 800, 600, .systemRed, .systemOrange),
+            ("16:9 · 960×540", 960, 540, .systemPurple, .systemBlue),
+            ("1:1 · 600×600", 600, 600, .systemTeal, .systemGreen),
+        ]
+        let albumBudget = AppPayload.perThumbBudget(imageCount: albumSpecs.count)
+        let album = albumSpecs.enumerated().compactMap { offset, spec in
+            make("demo-album-\(offset)", spec.caption, spec.w, spec.h, spec.from, spec.to, budget: albumBudget)
+        }
+
+        // Immutable snapshot for the @Sendable per-row loaders (they must not
+        // capture the mutable `fulls`).
+        let resolved = fulls
+        func entry(_ text: String, images: [IncomingImage] = [], caption: String = "") -> HistoryEntry {
+            let label: String
+            if images.isEmpty {
+                label = text
+            } else if !caption.isEmpty {
+                label = "📷 \(caption)"
+            } else {
+                label = images.count == 1 ? "📷 Image" : "📷 \(images.count) images"
+            }
+            return HistoryEntry(
+                sender: "Sebil", text: label, isDirect: false, group: group, groupColor: color,
+                receivedAt: Date(), images: images, caption: caption,
+                loadFull: { id in resolved[id] }
+            )
+        }
+
+        // Oldest first — visibleHistory keeps chronological order, so the newest
+        // row sits directly above the current message.
+        var backlog: [HistoryEntry] = [entry("hey, schau dir die Formate mal an 👇")]
+        for item in singles {
+            backlog.append(entry("", images: [item.image], caption: item.caption))
+        }
+        if !album.isEmpty { backlog.append(entry("", images: album, caption: "Album · gemischte Formate")) }
+
+        return Built(
+            backlog: backlog,
+            currentText: "nein, ich schicke keine Nachricht 🙂",
+            currentImages: [],
+            color: color,
+            fulls: resolved
+        )
+    }
+
+    /// A labelled diagonal-gradient PNG with a grid + border, so size and
+    /// sharpness are easy to judge in the preview.
+    static func render(_ label: String, _ width: Int, _ height: Int, _ from: NSColor, _ to: NSColor) -> Data {
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height, bitsPerSample: 8,
+            samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+        ) else { return Data() }
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return Data() }
+
+        let space = CGColorSpaceCreateDeviceRGB()
+        if let gradient = CGGradient(colorsSpace: space, colors: [from.cgColor, to.cgColor] as CFArray, locations: [0, 1]) {
+            ctx.drawLinearGradient(gradient, start: .zero, end: CGPoint(x: width, y: height), options: [])
+        }
+        ctx.setStrokeColor(NSColor(white: 1, alpha: 0.16).cgColor)
+        ctx.setLineWidth(2)
+        for x in stride(from: 0, through: width, by: 80) {
+            ctx.move(to: CGPoint(x: x, y: 0)); ctx.addLine(to: CGPoint(x: x, y: height))
+        }
+        for y in stride(from: 0, through: height, by: 80) {
+            ctx.move(to: CGPoint(x: 0, y: y)); ctx.addLine(to: CGPoint(x: width, y: y))
+        }
+        ctx.strokePath()
+        ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.85).cgColor)
+        ctx.setLineWidth(10)
+        ctx.stroke(CGRect(x: 5, y: 5, width: width - 10, height: height - 10))
+
+        let style = NSMutableParagraphStyle()
+        style.alignment = .center
+        let side = CGFloat(min(width, height))
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.boldSystemFont(ofSize: side / 11),
+            .foregroundColor: NSColor.white,
+            .paragraphStyle: style,
+        ]
+        NSString(string: label).draw(
+            in: CGRect(x: 0, y: CGFloat(height) / 2 - side / 14, width: CGFloat(width), height: side / 6),
+            withAttributes: attributes
+        )
+        return rep.representation(using: .png, properties: [:]) ?? Data()
+    }
+}
+#endif

--- a/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
+++ b/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
@@ -110,14 +110,21 @@ private struct PreviewCard: View {
         decoded = img
     }
 
-    /// The image's aspect scaled into the space actually available below the
-    /// notch (the panel is half the screen wide); small images are upscaled
-    /// modestly (≤3×) for a usable peek without turning to mush.
+    /// The image's aspect scaled to fill nearly all the room available below the
+    /// notch. For image messages the panel spans the full screen width (see
+    /// ``NotchScreenMetrics/panelFrame(for:wide:)``), so `available` is roughly the
+    /// whole screen and the preview lands near-fullscreen — only a small gutter
+    /// keeps it off the edges. A big screenshot is downscaled to fit; a small
+    /// image is still upscaled at most 3× so it stays sharp instead of blowing up
+    /// to a blurry wall. The full image is itself capped at
+    /// `ImageCodec.maxFullPixels` on the wire, which bounds the crispest result.
     private func fittedSize(in available: CGSize) -> CGSize {
         let w = CGFloat(max(image.width, 1))
         let h = CGFloat(max(image.height, 1))
-        let maxW = max(80, min(available.width - 32, 620))
-        let maxH = max(80, available.height - 24)
+        let horizontalGutter: CGFloat = 48
+        let bottomGutter: CGFloat = 40
+        let maxW = max(80, available.width - 2 * horizontalGutter)
+        let maxH = max(80, available.height - bottomGutter)
         let scale = min(min(maxW / w, maxH / h), 3)
         return CGSize(width: max(1, w * scale), height: max(1, h * scale))
     }

--- a/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
+++ b/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
@@ -4,19 +4,28 @@ import SwiftUI
 
 struct ImagePreviewOverlay: View {
     @ObservedObject var model: MessageDisplayModel
+    /// The current message's images. Past-message pictures are resolved live from
+    /// the model's history (see `resolvedImages`), so hovering either one previews.
     let images: [IncomingImage]
+
+    /// Current-message images plus every picture still in the live history, so a
+    /// hover on a past image previews exactly like the current message's. Lookup
+    /// is by r2Key (unique per image), so the two sets never collide.
+    private var resolvedImages: [IncomingImage] {
+        images + model.history.flatMap(\.images)
+    }
 
     var body: some View {
         GeometryReader { proxy in
             ZStack {
                 if let id = model.previewImageID,
-                   let image = images.first(where: { $0.id == id }) {
+                   let image = resolvedImages.first(where: { $0.id == id }) {
                     PreviewCard(model: model, image: image, available: proxy.size)
                         .id(id)
-                        .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .top)))
+                        .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .center)))
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         }
         .colorScheme(.dark)
         .excludedFromScreenCapture()
@@ -86,14 +95,22 @@ private struct PreviewCard: View {
         decoded = img
     }
 
+    /// The picture's aspect, scaled to fill the screen as far as it goes WITHOUT
+    /// growing past its own native pixel size: a large screenshot spans nearly
+    /// the whole display, a small image shows crisp at 1:1 instead of blowing up
+    /// blurry. Both axes are bounded by the (centered) screen minus a slim gutter,
+    /// so the result is "as wide as the image, up to 100% of the screen, aspect
+    /// preserved". The full image is itself capped at `ImageCodec.maxFullPixels`
+    /// on the wire, which bounds the crispest result.
     private func fittedSize(in available: CGSize) -> CGSize {
         let w = CGFloat(max(image.width, 1))
         let h = CGFloat(max(image.height, 1))
-        let horizontalGutter: CGFloat = 48
-        let bottomGutter: CGFloat = 40
-        let maxW = max(80, available.width - 2 * horizontalGutter)
-        let maxH = max(80, available.height - bottomGutter)
-        let scale = min(min(maxW / w, maxH / h), 3)
+        let gutter: CGFloat = 24
+        let maxW = max(80, available.width - 2 * gutter)
+        let maxH = max(80, available.height - 2 * gutter)
+        // Cap at 1: grow to fill the screen but never upscale beyond the image's
+        // native size ("only as wide as the image actually is").
+        let scale = min(maxW / w, maxH / h, 1)
         return CGSize(width: max(1, w * scale), height: max(1, h * scale))
     }
 }

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -164,6 +164,13 @@ struct MenuView: View {
             Divider()
             Toggle("Echo my broadcasts to me", isOn: $devEchoBroadcasts)
             Toggle("Allow in screenshots", isOn: $allowInScreenshots)
+            // Seed a demo backlog (text + image messages) into the notch so the
+            // expanded-history hover preview can be tested without real traffic.
+            Button {
+                model.debugShowDemoHistory()
+            } label: {
+                Label("Demo image history", systemImage: "photo.stack")
+            }
             #endif
             Divider()
             Button {

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -857,15 +857,23 @@ private struct HistoryAlbumGrid: View {
         } else {
             let columnCount = min(4, images.count)
             let side = (maxWidth - CGFloat(columnCount - 1) * spacing) / CGFloat(columnCount)
-            let columns = Array(
-                repeating: GridItem(.fixed(side), spacing: spacing),
-                count: columnCount
-            )
-            LazyVGrid(columns: columns, alignment: .leading, spacing: spacing) {
-                ForEach(images) { img in
-                    HistoryAlbumCell(model: model, image: img, loadFull: entry.loadFull, fill: true)
-                        .frame(width: side, height: side)
-                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            // Non-lazy rows (not LazyVGrid): an album is ≤8 cells so laziness
+            // buys nothing, and LazyVGrid's per-cell `.onHover` only fires
+            // reliably for the first cell — which would break the hover preview on
+            // every other history picture (same reason the current message's grid
+            // is non-lazy, see MessageNotchView.imageContent).
+            let rows = stride(from: 0, to: images.count, by: columnCount).map { start in
+                Array(images[start..<min(start + columnCount, images.count)])
+            }
+            VStack(alignment: .leading, spacing: spacing) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                    HStack(spacing: spacing) {
+                        ForEach(row) { img in
+                            HistoryAlbumCell(model: model, image: img, loadFull: entry.loadFull, fill: true)
+                                .frame(width: side, height: side)
+                                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                        }
+                    }
                 }
             }
             .frame(width: maxWidth, alignment: .leading)
@@ -886,9 +894,10 @@ private struct HistoryAlbumGrid: View {
 /// One history image cell: paints its inline thumbnail at once, then upgrades to
 /// full resolution via the entry's loader, caching the bytes on the shared model
 /// (keyed by the unique r2Key) so a collapse→expand toggle re-decodes from cache
-/// instead of re-fetching from R2. A self-contained sibling of `AlbumCell`
-/// WITHOUT the per-image copy glyph or hover preview — those belong to the
-/// current message; the history echo is a read-only thumbnail.
+/// instead of re-fetching from R2. A self-contained sibling of `AlbumCell`: it
+/// has no per-image copy glyph (the history echo stays read-only), but a hover
+/// pops the SAME large free-floating Quick-Look preview as the current message —
+/// the preview resolves past images from the model's history (ImagePreviewOverlay).
 ///
 /// Cells mount — and so fetch — only when the history is actually expanded, and
 /// only the FIRST expand fetches (later ones hit the cache). The resulting burst
@@ -926,6 +935,18 @@ private struct HistoryAlbumCell: View {
             }
         }
         .clipped()
+        // Hover any past picture to pop the same large Quick-Look preview the
+        // current message's cells show — the preview (ImagePreviewOverlay)
+        // resolves the image from the model's history. contentShape so a `.fill`
+        // cell's overflow can't steal the hover from a neighbour (mirrors AlbumCell).
+        .contentShape(Rectangle())
+        .onHover { inside in
+            if inside {
+                model.requestPreview(image.id)
+            } else {
+                model.endPreview(forCell: image.id)
+            }
+        }
         .task { await load() }
     }
 

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -851,9 +851,8 @@ private struct HistoryAlbumGrid: View {
         let images = entry.images
         if images.count == 1, let only = images.first {
             let size = fittedSize(width: only.width, height: only.height)
-            HistoryAlbumCell(model: model, image: only, loadFull: entry.loadFull, fill: false)
-                .frame(width: size.width, height: size.height)
-                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            HistoryAlbumCell(model: model, image: only, loadFull: entry.loadFull,
+                             displaySize: size, cornerRadius: 7, fill: false)
         } else {
             let columnCount = min(4, images.count)
             let side = (maxWidth - CGFloat(columnCount - 1) * spacing) / CGFloat(columnCount)
@@ -869,9 +868,9 @@ private struct HistoryAlbumGrid: View {
                 ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                     HStack(spacing: spacing) {
                         ForEach(row) { img in
-                            HistoryAlbumCell(model: model, image: img, loadFull: entry.loadFull, fill: true)
-                                .frame(width: side, height: side)
-                                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                            HistoryAlbumCell(model: model, image: img, loadFull: entry.loadFull,
+                                             displaySize: CGSize(width: side, height: side),
+                                             cornerRadius: 6, fill: true)
                         }
                     }
                 }
@@ -894,10 +893,11 @@ private struct HistoryAlbumGrid: View {
 /// One history image cell: paints its inline thumbnail at once, then upgrades to
 /// full resolution via the entry's loader, caching the bytes on the shared model
 /// (keyed by the unique r2Key) so a collapse→expand toggle re-decodes from cache
-/// instead of re-fetching from R2. A self-contained sibling of `AlbumCell`: it
-/// has no per-image copy glyph (the history echo stays read-only), but a hover
-/// pops the SAME large free-floating Quick-Look preview as the current message —
-/// the preview resolves past images from the model's history (ImagePreviewOverlay).
+/// instead of re-fetching from R2. A self-contained sibling of `AlbumCell` with
+/// the same affordances: a hover pops the large free-floating Quick-Look preview
+/// (resolved from the model's history, see ImagePreviewOverlay) AND reveals a
+/// per-image copy glyph — click it, or press "C" while hovering, to copy the
+/// picture, through the exact same hit-target path as the current message.
 ///
 /// Cells mount — and so fetch — only when the history is actually expanded, and
 /// only the FIRST expand fetches (later ones hit the cache). The resulting burst
@@ -908,13 +908,21 @@ private struct HistoryAlbumCell: View {
     @ObservedObject var model: MessageDisplayModel
     let image: IncomingImage
     let loadFull: (@Sendable (String) async -> Data?)?
+    /// Final on-screen size of the picture. Sized + clipped HERE (not by the
+    /// caller) so the copy glyph can sit OUTSIDE the rounded clip — mirrors AlbumCell.
+    let displaySize: CGSize
+    let cornerRadius: CGFloat
     /// Grid cells fill+crop to a square; a lone image fits its aspect.
     let fill: Bool
 
     @State private var decoded: CGImage?
+    @State private var hovering = false
 
     private var isLoaded: Bool { model.fullImages[image.id] != nil }
     private var didFail: Bool { model.failedImages.contains(image.id) }
+
+    /// Smaller than the current message's 20pt glyph — history cells are compact.
+    private let glyphDiameter: CGFloat = 18
 
     var body: some View {
         ZStack {
@@ -934,13 +942,18 @@ private struct HistoryAlbumCell: View {
                     .foregroundStyle(.white.opacity(0.5))
             }
         }
-        .clipped()
-        // Hover any past picture to pop the same large Quick-Look preview the
-        // current message's cells show — the preview (ImagePreviewOverlay)
-        // resolves the image from the model's history. contentShape so a `.fill`
-        // cell's overflow can't steal the hover from a neighbour (mirrors AlbumCell).
+        // Size + clip HERE (before the glyph overlay) so a `.fill` cell's overflow
+        // can't spill onto neighbours, and the glyph — added next — sits outside
+        // the rounded clip. Mirrors AlbumCell.
+        .frame(width: displaySize.width, height: displaySize.height)
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .overlay(alignment: .topTrailing) { copyGlyph }
+        // Hover pops the large preview (resolved from history) and, via `hovering`,
+        // the copy glyph. contentShape so a `.fill` cell's overflow can't steal the
+        // hover from a neighbour (mirrors AlbumCell).
         .contentShape(Rectangle())
         .onHover { inside in
+            hovering = inside
             if inside {
                 model.requestPreview(image.id)
             } else {
@@ -948,6 +961,30 @@ private struct HistoryAlbumCell: View {
             }
         }
         .task { await load() }
+    }
+
+    /// Per-image copy, mirroring AlbumCell: hidden until hover (or while its
+    /// checkmark lingers). The hit target exists only while hovered — NotchPresenter
+    /// copies the image whose target a click lands in, and the bare-"C" hotkey
+    /// copies the hovered one via the same target; the bytes resolve full-vs-thumb
+    /// at copy time.
+    private var copyGlyph: some View {
+        let isCopied = model.copiedImageID == image.id
+        let show = hovering || isCopied
+        return CopyGlyph(copied: isCopied, diameter: glyphDiameter)
+            .opacity(show ? 1 : 0)
+            .background {
+                if hovering {
+                    ImageCopyHitTarget(
+                        id: image.id,
+                        resolve: { [weak model] in model?.fullImages[image.id] ?? image.thumb }
+                    ) { [weak model] id, resolve, view in
+                        model?.registerImageCopy(id: id, resolve: resolve, view: view)
+                    }
+                }
+            }
+            .padding(3)
+            .animation(.easeInOut(duration: 0.12), value: show)
     }
 
     private func load() async {

--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -253,8 +253,9 @@ struct AlbumCell: View {
 /// Invisible NSView laid out under an album image's copy glyph. Like AreaMarker
 /// but carries the image id and a `resolve` closure (full bytes if loaded, else
 /// the thumbnail), registered into the model so the click monitor can copy the
-/// matching image (NSHostingView's hitTest can't surface it).
-private struct ImageCopyHitTarget: NSViewRepresentable {
+/// matching image (NSHostingView's hitTest can't surface it). Used by both the
+/// current message's `AlbumCell` and the history's `HistoryAlbumCell`.
+struct ImageCopyHitTarget: NSViewRepresentable {
     let id: String
     let resolve: () -> Data
     let register: (String, @escaping () -> Data, NSView) -> Void

--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchHostingContent.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchHostingContent.swift
@@ -13,16 +13,11 @@ import SwiftUI
 struct NotchHostingContent<Content: View>: View {
     @ObservedObject var owner: NotchPanel<Content>
     @State private var floatingHeight: CGFloat = 0
-    /// Measured height of the notch/floating chrome, so the free-floating
-    /// overlay (Quick-Look preview) can sit just below it without overlap.
-    @State private var notchContentHeight: CGFloat = 0
 
     private let safeAreaInset: CGFloat = 15
     private let expandedTopCornerRadius: CGFloat = 15
     private let expandedBottomCornerRadius: CGFloat = 20
     private let floatingCornerRadius: CGFloat = 20
-    /// Gap between the bottom of the notch chrome and the floating overlay.
-    private let floatingOverlayGap: CGFloat = 14
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -33,16 +28,14 @@ struct NotchHostingContent<Content: View>: View {
                 floatingBody
             }
             // The app's free-floating overlay (Quick-Look image preview): a
-            // sibling of the masked notch, so it escapes the NotchShape clip
-            // yet stays inside this capture-excluded panel window. Positioned
-            // just below the measured chrome; never intercepts clicks.
+            // sibling of the masked notch, so it escapes the NotchShape clip yet
+            // stays inside this capture-excluded panel window. Fills the whole
+            // panel and centers the picture itself (see ImagePreviewOverlay), so a
+            // hovered image — current message OR history — blows up to a preview
+            // centered on the screen. Never intercepts clicks.
             if let overlay = owner.floatingOverlay, owner.state == .expanded {
-                // Padding is outermost so the overlay is proposed only the room
-                // BELOW the chrome — its GeometryReader then bounds the card to
-                // what fits (no off-screen overflow). Never intercepts clicks.
                 overlay
                     .allowsHitTesting(false)
-                    .padding(.top, overlayTopClearance + floatingOverlayGap)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -50,11 +43,6 @@ struct NotchHostingContent<Content: View>: View {
             color: .black.opacity(owner.state == .expanded ? 0.5 : 0),
             radius: owner.state == .hidden ? 0 : 10
         )
-    }
-
-    /// How far down the overlay must start to clear the notch (or floating pill).
-    private var overlayTopClearance: CGFloat {
-        owner.hasNotch ? notchContentHeight : floatingHeight + owner.notchSize.height
     }
 
     private var minWidth: CGFloat { owner.notchSize.width + expandedTopCornerRadius * 2 }
@@ -105,14 +93,6 @@ struct NotchHostingContent<Content: View>: View {
         .fixedSize()
         .frame(minWidth: minWidth, minHeight: owner.notchSize.height)
         .onHover(perform: owner.updateHoverState)
-        .background(
-            GeometryReader { proxy in
-                Color.clear
-                    .onChange(of: proxy.size.height, initial: true) { _, height in
-                        notchContentHeight = height
-                    }
-            }
-        )
     }
 
     private var floatingBody: some View {

--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchPanel.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchPanel.swift
@@ -182,7 +182,7 @@ final class NotchPanel<Content: View>: ObservableObject {
     private func buildPanel(on screen: NSScreen) {
         let window = NotchPanelWindow()
         window.contentView = NSHostingView(rootView: NotchHostingContent(owner: self))
-        window.setFrame(NotchScreenMetrics.panelFrame(for: screen), display: false)
+        window.setFrame(panelFrame(on: screen), display: false)
         window.layoutIfNeeded()
         window.applyCaptureExclusion()
         panelWindow = window
@@ -190,11 +190,19 @@ final class NotchPanel<Content: View>: ObservableObject {
 
     private func reposition(on screen: NSScreen) {
         guard let window = panelWindow else { return }
-        window.setFrame(NotchScreenMetrics.panelFrame(for: screen), display: true)
+        window.setFrame(panelFrame(on: screen), display: true)
         // Re-assert the panel properties that a window reconfigure can drop.
         window.applyCaptureExclusion()
         window.level = .screenSaver
         window.collectionBehavior = [.canJoinAllSpaces, .stationary]
+    }
+
+    /// Panels carrying a `floatingOverlay` (the image Quick-Look preview) get the
+    /// full-width canvas so the preview can grow to near-fullscreen; every other
+    /// panel keeps the slimmer half-width frame. Either way the visible shape is
+    /// mask-sized and the empty canvas stays click-through (see ``NotchScreenMetrics``).
+    private func panelFrame(on screen: NSScreen) -> NSRect {
+        NotchScreenMetrics.panelFrame(for: screen, wide: floatingOverlay != nil)
     }
 
     private func showWindow() {

--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchScreenMetrics.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchScreenMetrics.swift
@@ -34,18 +34,25 @@ enum NotchScreenMetrics {
         return (cutout, true, menubarHeight)
     }
 
-    /// Top-centre panel frame: a half-width canvas spanning the *full* screen
-    /// height, pinned so its top edge is the screen top. Full height (not the
-    /// old half-screen) gives the top-anchored content unlimited room to grow
-    /// downward — expanded history could otherwise outgrow a half-screen
-    /// window and get clipped at the window's bottom edge, cutting off the
-    /// notch's bottom corners and breaking the layout. The visible shape is
-    /// unaffected: the NotchShape mask sizes to the content, not the window,
-    /// and the empty canvas stays click-through. Notched and notchless screens
-    /// share this frame; only the content chrome inside differs.
+    /// Top-centre panel frame spanning the *full* screen height, pinned so its top
+    /// edge is the screen top. Full height (not the old half-screen) gives the
+    /// top-anchored content unlimited room to grow downward — expanded history
+    /// could otherwise outgrow a half-screen window and get clipped at the
+    /// window's bottom edge, cutting off the notch's bottom corners and breaking
+    /// the layout. The visible shape is unaffected: the NotchShape mask sizes to
+    /// the content, not the window, and the empty canvas stays click-through.
+    /// Notched and notchless screens share this frame; only the content chrome
+    /// inside differs.
+    ///
+    /// Width is normally half the screen — plenty for the notch chrome. Image
+    /// messages pass `wide: true` to get the full screen width, so the
+    /// free-floating Quick-Look preview (``ImagePreviewOverlay``) can grow to
+    /// near-fullscreen; a child view can't paint wider than its host window. The
+    /// wider canvas is still click-through and the mask still sizes to the chrome,
+    /// so the only visible difference is how large the preview is allowed to get.
     @MainActor
-    static func panelFrame(for screen: NSScreen) -> NSRect {
-        let width = screen.frame.width / 2
+    static func panelFrame(for screen: NSScreen, wide: Bool = false) -> NSRect {
+        let width = wide ? screen.frame.width : screen.frame.width / 2
         let origin = NSPoint(x: screen.frame.midX - width / 2, y: screen.frame.minY)
         return NSRect(x: origin.x, y: origin.y, width: width, height: screen.frame.height)
     }

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -227,14 +227,18 @@ final class NotchPresenter {
             openingAnimation: .spring(response: 0.6, dampingFraction: 0.7),
             skipIntermediateHides: true
         )
-        // Image messages get a free-floating Quick-Look preview that pops below
-        // the notch on cell hover (see ImagePreviewOverlay / AlbumCell). It
-        // renders inside this same capture-excluded panel window.
-        if message.isImage {
-            notch.floatingOverlay = AnyView(
-                ImagePreviewOverlay(model: model, images: message.images)
-            )
-        }
+        // Every message notch carries the free-floating Quick-Look preview: it
+        // pops below the notch when an image cell is hovered — the current
+        // message's grid (AlbumCell) OR a past picture in the expanded history
+        // (HistoryAlbumCell), resolved live from the model. Attached
+        // unconditionally, not just for image messages, because a text message
+        // can carry image history and a live image can drop into history while a
+        // text message is showing. It's inert and click-through until a cell is
+        // hovered, so attaching it always only widens the capture-excluded,
+        // mask-sized canvas — nothing visible changes for a text-only notch.
+        notch.floatingOverlay = AnyView(
+            ImagePreviewOverlay(model: model, images: message.images)
+        )
         currentNotch = notch
 
         hoverObservation = notch.$isHovering
@@ -598,4 +602,16 @@ final class NotchPresenter {
             self.authCodeNotch = nil
         }
     }
+
+    #if DEBUG
+    /// Dev aid: inject synthetic rows straight into the history buffer (no
+    /// arrival animation), so the very next `show` renders them as the expanded
+    /// history backlog. Lets the expanded-history image hover preview be
+    /// exercised without sending real messages back and forth. They live the
+    /// usual 60 s window, then prune. See `AppModel.debugShowDemoHistory`.
+    func debugSeedHistory(_ entries: [HistoryEntry]) {
+        pruneHistory()
+        history.append(contentsOf: entries)
+    }
+    #endif
 }

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -171,9 +171,9 @@ final class NotchPresenter {
             currentEntryID = entryID
             withAnimation(.spring(response: 0.42, dampingFraction: 0.82)) {
                 configure(model, for: message, notchSize: model.notchSize, entryID: entryID, loadFull: loadFull, onReply: onReply)
-                notch.floatingOverlay = message.isImage
-                    ? AnyView(ImagePreviewOverlay(model: model, images: message.images))
-                    : nil
+                notch.floatingOverlay = AnyView(
+                    ImagePreviewOverlay(model: model, images: message.images)
+                )
                 model.mode = .message
                 model.fullyExpanded = false
                 notch.suppressBottomInset = false


### PR DESCRIPTION
## Summary

Hovering an image in the notch popped a Quick-Look preview that was both too small and inconsistent. This PR reworks it into a **full-screen, centered** preview that also covers **past images in the expanded history**, not just the current message — and brings the per-image copy affordance to history too (#99).

## What changed

**Preview size & position**
- Now **centered on the whole screen** (vertically + horizontally) instead of docked below the notch.
- Grows to fill the display **up to the image's native size** — aspect ratio preserved, never upscaled past 1:1. A large screenshot fills the screen; a small picture stays crisp at 1:1 instead of blowing up blurry.
- `NotchScreenMetrics.panelFrame(for:wide:)` selects a full-width canvas for image-bearing notches; the empty overlay is click-through and the `NotchShape` mask still sizes to the content, so the visible notch and click handling are unchanged.

**History gets the same affordances**
- The preview overlay is attached to **every** message notch (not just image messages), so a text message carrying image history previews too.
- `ImagePreviewOverlay` resolves the hovered image from the current message **and** the live history.
- `HistoryAlbumCell` gains the same hover trigger as `AlbumCell`; the history album grid drops `LazyVGrid` so per-cell hover fires for every picture, not just the first.
- **Per-image copy** comes along: a hover-revealed glyph (click to copy) and the bare-"C" hotkey copy a history picture, through the same hit-target path as the current message (`ImageCopyHitTarget` promoted private → internal so both cells share it).

**DEBUG demo tool**
- A `#if DEBUG` menu item **"Demo image history"** seeds the notch with a synthetic backlog (16:9 / 4:3 / 1:1 / 9:16 at several sizes incl. a tiny 160×160, plus a mixed album), each labelled with its ratio + pixel size, so the hover preview can be exercised without sending real messages back and forth.

## Test plan

- [ ] Hover an image in the current message → centered, near-full-screen preview.
- [ ] Expand the history, hover a past image → same centered preview.
- [ ] Small image shows 1:1 (not upscaled); large fills the screen; portrait is height-bounded.
- [ ] Album (current + history): hovering each cell cross-fades the preview.
- [ ] History per-image copy: hover a past picture → glyph appears; click it (or press "C") copies the image; full-res when loaded, thumbnail otherwise.
- [ ] Click-through still works while a preview is up; clicking outside dismisses an open reply.
- [ ] **Capture safety:** start a screen share / screenshot while a preview is up → preview + notch stay excluded.
- [ ] Non-image notches unchanged: text message, unread indicator, GitHub auth code.

Closes #99
