### PR TITLE
docs: extract issue workflow into a github-issue-workflow skill

### DIFF
--- a/.claude/skills/github-issue-workflow/SKILL.md
+++ b/.claude/skills/github-issue-workflow/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: github-issue-workflow
+description: How to start work on a GitHub issue in the munkel repo — check for an existing draft PR and the issue's assignee first to avoid duplicating work someone already owns, claim the issue by assigning it, then open a draft PR linked with "Closes #N" so ownership and in-flight work are visible to everyone. Use whenever asked to work on, start, pick up, take, or implement a GitHub issue (e.g. "arbeite an Issue #N", "work on issue 42", "pick up #99").
+---
+
+# Starting work on a GitHub issue
+
+One issue → one owner → one draft PR, linked both ways. The point is that
+ownership and in-flight work are visible to everyone from the moment work
+starts, so two people never unknowingly build the same thing.
+
+## 1. Before starting: is it already taken?
+
+Never open a second branch or PR for an issue someone already owns. Check first:
+
+```sh
+gh issue view N                                              # assignee + linked PRs
+gh pr list --state open --search "N in:body" \
+  --json number,title,isDraft,url,headRefName
+```
+
+If the issue is already assigned, or an open PR (draft or not) already
+references it, it is taken. **Stop** — report what you found and coordinate with
+the owner, or pick a different issue. Do not start parallel work.
+
+## 2. Claim the issue
+
+Assignment is the ownership signal:
+
+```sh
+gh issue edit N --add-assignee @me      # or the relevant GitHub login
+```
+
+## 3. Open a draft PR immediately
+
+Open the PR *before* the work is finished, so the issue↔PR link exists from the
+start. GitHub needs at least one commit on the branch to open a PR:
+
+```sh
+git checkout -b <type>/<short-slug> origin/main   # feat/ fix/ docs/ chore/ refactor/
+git commit --allow-empty -m "chore: start #N"     # or your first real commit
+git push -u origin <type>/<short-slug>
+gh pr create --draft --base main \
+  --title "<type>: <summary>" \
+  --body "Closes #N"
+```
+
+`Closes #N` (also `Fixes`/`Resolves`) links the PR under the issue's
+**Development** section and auto-closes the issue when the PR merges.
+
+## 4. Work, then mark ready
+
+Push commits as usual while in draft. Flip the PR out of draft only once it is
+genuinely reviewable:
+
+```sh
+gh pr ready <PR>
+```
+
+## Notes
+
+- Branch from `main`. This repo **squash-merges**, so intermediate commits on the
+  branch never reach `main` history — the PR title becomes the squash commit.
+- Use Conventional Commit types for both the branch prefix and the PR title
+  (`feat`, `fix`, `docs`, `chore`, `refactor`); Release Please reads them.
+- No co-author/attribution trailers in commits (house style).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,32 @@ bunx turbo deploy --filter=@munkel/landing    # munkel.app
 One-time before the first relay deploy that includes the R2 binding (the deploy
 fails otherwise): `cd apps/server && bunx wrangler r2 bucket create munkel-blobs`.
 
+## Working on an issue
+
+When asked to work on an issue (e.g. "arbeite an Issue #N"):
+
+1. **Check for an existing draft PR first.** Someone may already own it — never
+   open a duplicate. Look for an open PR that references the issue, and check the
+   issue's assignee:
+   ```sh
+   gh pr list --state open --search "N in:body" --json number,title,isDraft,url,headRefName
+   gh issue view N            # assignee + linked PRs signal who already holds it
+   ```
+   If an open (draft) PR already references the issue, it is taken — coordinate or
+   pick another instead of starting a parallel branch.
+2. **Assign the issue** to whoever is doing the work — this is the ownership
+   signal: `gh issue edit N --add-assignee @me` (or the relevant login).
+3. **Open a draft PR immediately**, before the work is finished, so the issue↔PR
+   link exists from the start and others can see who is on what:
+   - Branch from `main` (`<type>/<short-slug>`), make the first commit — the
+     initial change, or `git commit --allow-empty -m "chore: start #N"` if nothing
+     is ready yet — and `git push -u origin <branch>`.
+   - `gh pr create --draft --base main --title "<type>: <summary>" --body "Closes #N"`.
+     The `Closes #N` keyword links the PR under the issue's Development section and
+     auto-closes the issue on merge.
+   - Take it out of draft with `gh pr ready <PR>` only once it is genuinely
+     reviewable.
+
 ## Conventions
 
 - **No comments in source code (Swift/TS).** Zero — code must be fully

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,14 +115,9 @@ fails otherwise): `cd apps/server && bunx wrangler r2 bucket create munkel-blobs
 
 ## Working on an issue
 
-Starting work on a GitHub issue follows a fixed workflow — **check for an
-existing draft PR and the issue's assignee first** (never duplicate work someone
-already owns), then **claim the issue** by assigning it and open a **draft PR
-immediately**, linked with `Closes #N`, so ownership and in-flight work are
-visible from the start. The full procedure with the exact `gh` commands lives in
-the `github-issue-workflow` skill
-(`.claude/skills/github-issue-workflow/SKILL.md`) — follow it whenever you are
-asked to work on, start, or pick up an issue.
+Follow the **`github-issue-workflow`** skill: check the issue isn't already taken
+(open/draft PR or an assignee) before starting, then claim it and open a draft PR
+linked with `Closes #N`.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,29 +115,14 @@ fails otherwise): `cd apps/server && bunx wrangler r2 bucket create munkel-blobs
 
 ## Working on an issue
 
-When asked to work on an issue (e.g. "arbeite an Issue #N"):
-
-1. **Check for an existing draft PR first.** Someone may already own it — never
-   open a duplicate. Look for an open PR that references the issue, and check the
-   issue's assignee:
-   ```sh
-   gh pr list --state open --search "N in:body" --json number,title,isDraft,url,headRefName
-   gh issue view N            # assignee + linked PRs signal who already holds it
-   ```
-   If an open (draft) PR already references the issue, it is taken — coordinate or
-   pick another instead of starting a parallel branch.
-2. **Assign the issue** to whoever is doing the work — this is the ownership
-   signal: `gh issue edit N --add-assignee @me` (or the relevant login).
-3. **Open a draft PR immediately**, before the work is finished, so the issue↔PR
-   link exists from the start and others can see who is on what:
-   - Branch from `main` (`<type>/<short-slug>`), make the first commit — the
-     initial change, or `git commit --allow-empty -m "chore: start #N"` if nothing
-     is ready yet — and `git push -u origin <branch>`.
-   - `gh pr create --draft --base main --title "<type>: <summary>" --body "Closes #N"`.
-     The `Closes #N` keyword links the PR under the issue's Development section and
-     auto-closes the issue on merge.
-   - Take it out of draft with `gh pr ready <PR>` only once it is genuinely
-     reviewable.
+Starting work on a GitHub issue follows a fixed workflow — **check for an
+existing draft PR and the issue's assignee first** (never duplicate work someone
+already owns), then **claim the issue** by assigning it and open a **draft PR
+immediately**, linked with `Closes #N`, so ownership and in-flight work are
+visible from the start. The full procedure with the exact `gh` commands lives in
+the `github-issue-workflow` skill
+(`.claude/skills/github-issue-workflow/SKILL.md`) — follow it whenever you are
+asked to work on, start, or pick up an issue.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Follow-up to #104. The GitHub issue procedure is reusable, action-triggered process — a better fit as a **skill** than an always-loaded CLAUDE.md section. This:

- Adds a **project Claude Code skill** at `.claude/skills/github-issue-workflow/SKILL.md` with the full procedure (the exact `gh` commands). It loads only when starting issue work, keeping `CLAUDE.md` lean. (It lives in `.claude/skills/`, the internal contributor-tooling location — **not** the repo's `skills/` dir, which publishes *product* capabilities to end users via skills.sh.)
- Leaves a short **pointer** in `CLAUDE.md` that keeps the core rule visible inline: *check for an existing draft PR and the issue's assignee first*, then claim + open a draft PR linked with `Closes #N`.

### The workflow it codifies

1. **Before starting** — `gh issue view N` + `gh pr list --search "N in:body"` to see if it's already assigned / has an open (draft) PR. If taken, coordinate instead of duplicating.
2. **Claim** — `gh issue edit N --add-assignee @me` as the ownership signal.
3. **Open a draft PR immediately** — branch, first commit (or empty `chore: start #N`), push, `gh pr create --draft --body "Closes #N"`. `Closes #N` links it under the issue's Development section and auto-closes on merge.
4. **Mark ready** — `gh pr ready <PR>` once genuinely reviewable.

## Test plan

- [ ] Docs/skill-only change; no code paths touched, CI unaffected.
- [ ] Skill frontmatter (`name`/`description`) matches the repo's SKILL.md convention; the `gh` commands are accurate.
