### PR TITLE
fix(landing): wrap footer links on mobile to prevent overflow

### DIFF
--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -1087,6 +1087,10 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0; }
   .mb-notch { transform: translateX(-50%) scale(0.58); }
   .mb-menubar { height: 16px; font-size: 9px; }
   .mb-apple { font-size: 11px; }
+  /* Phone: wrap the footer link cluster instead of clipping it off-screen;
+     each link stays whole and gets a roomier hit area. */
+  .footer-links { flex-wrap: wrap; row-gap: 0.25rem; column-gap: 1.25rem; }
+  .footer-links a { padding: 0.4rem 0; font-size: var(--text-sm); white-space: nowrap; }
 }
 @media (prefers-reduced-motion: reduce) {
   .pulse, .cursor { animation: none; }


### PR DESCRIPTION
## Problem

On phones (≤600px) the landing-page footer's 7-link row sat in a single non-wrapping flex row and overflowed the viewport: **"Protocol v1" broke mid-phrase** and **"MIT License" was clipped** off the right edge.

Root cause: `.footer-links` was `display: flex` with no `flex-wrap`, and there was no footer-specific mobile rule.

## Fix

Four lines added inside the **existing** `@media (max-width: 600px)` block in `apps/landing/src/styles.css`:

```css
.footer-links { flex-wrap: wrap; row-gap: 0.25rem; column-gap: 1.25rem; }
.footer-links a { padding: 0.4rem 0; font-size: var(--text-sm); white-space: nowrap; }
```

- `flex-wrap: wrap` — root-cause fix; links flow onto multiple rows instead of overflowing.
- `white-space: nowrap` per link — multi-word labels ("Protocol v1", "munkel CLI", "MIT License") stay whole.
- `row-gap` + vertical `padding` — breathing room between wrapped rows and a roomier tap area.
- `--text-sm` (14px) — better thumb legibility than the 12px desktop size.

Scoped entirely inside the existing 600px breakpoint, so the **desktop layout (≥601px) is byte-for-byte unchanged**. No JSX change.

## Test plan

Verified headlessly by measuring real render width (`scrollWidth` vs `clientWidth`) and screenshotting the footer:

- [x] **320px** — footer fully within bounds, links wrap to 3 rows, nothing clipped
- [x] **390px** — clean 2 rows, every label whole
- [x] **768px (desktop)** — unchanged single non-wrapping row, 12px links, `scrollWidth == clientWidth`
- [x] No footer element overflows the right edge at any tested width

Note: a pre-existing ~30px document overflow at 320px traces to `.badge-marquee-row` (an intentionally 3367px-wide marquee animation), **not** the footer — out of scope for this PR.