### PR TITLE
feat(macos): member presence modes — Online / Do Not Disturb / Away

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -34,7 +34,7 @@ Each member broadcasts a presence status — Online, Do Not Disturb, or Away —
 the other members of their circles inside the end-to-end-encrypted profile
 payload. The relay never sees it in plaintext; only connected peers do. Away is
 also set automatically after five minutes without keyboard or mouse input (and
-on screen sleep, system sleep, or fast user switch), so being in a circle
+on screen lock, screen sleep, system sleep, or fast user switch), so being in a circle
 reveals coarse at-the-keyboard activity to the other members. Do Not Disturb and
 Away only suppress the notch preview on the recipient's own machine; they never
 block or delay delivery.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -22,11 +22,18 @@ The token is requested with empty scope, used to fetch the profile once, and not
 stored by Munkel. GitHub still records the OAuth authorization in the user's
 GitHub account settings.
 
+Avatars are shared with circle members as the GitHub avatar URL, not as image
+bytes through the relay: each member's app fetches the avatar directly from
+GitHub's avatar CDN. GitHub's CDN therefore sees, for each viewer, their IP
+address and which account's avatar is being loaded, and circle members can see
+each other's GitHub user id (it is embedded in the URL). The relay never carries
+avatar image bytes. Avatar URLs are only fetched from `*.githubusercontent.com`.
+
 ## Local data
 
 The app stores local settings in the `dev.uq.munkel` defaults domain, including
 joined circle codes, relay URL, member ID, display name, GitHub login, the
-downscaled avatar image, and the chosen presence status.
+downscaled avatar image, the GitHub avatar URL, and the chosen presence status.
 
 ## Presence
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -25,8 +25,19 @@ GitHub account settings.
 ## Local data
 
 The app stores local settings in the `dev.uq.munkel` defaults domain, including
-joined circle codes, relay URL, member ID, display name, GitHub login, and the
-downscaled avatar image.
+joined circle codes, relay URL, member ID, display name, GitHub login, the
+downscaled avatar image, and the chosen presence status.
+
+## Presence
+
+Each member broadcasts a presence status — Online, Do Not Disturb, or Away — to
+the other members of their circles inside the end-to-end-encrypted profile
+payload. The relay never sees it in plaintext; only connected peers do. Away is
+also set automatically after five minutes without keyboard or mouse input (and
+on screen sleep, system sleep, or fast user switch), so being in a circle
+reveals coarse at-the-keyboard activity to the other members. Do Not Disturb and
+Away only suppress the notch preview on the recipient's own machine; they never
+block or delay delivery.
 
 ## Limits
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,7 +86,8 @@ with anything sensitive.
 - **No cryptographic proof of identity from GitHub login.** "Sign in with
   GitHub" imports a display name and avatar only. It does not prove to peers
   that a member controls a given GitHub account; profiles are self-asserted,
-  the same as a typed name.
+  the same as a typed name. Presence status (Online / Do Not Disturb / Away) is
+  likewise self-asserted — a member can broadcast any value.
 - **No hiding metadata from the relay.** The relay necessarily observes
   connection metadata: derived group IDs, member IDs, connection timing,
   message sizes, and routing targets. It cannot read content, but it is not a
@@ -108,7 +109,7 @@ followed by adversaries that are explicitly out of scope.
 | **Passive network or relay observer** (anyone watching the wire or running the relay) | Payloads are end-to-end encrypted with AES-256-GCM on-device; the relay only sees the derived `groupId`, member IDs, sizes, and timing — never plaintext or the circle code. Image blobs in R2 are opaque ciphertext with a short TTL. |
 | **Screen capture / screen sharing** (Zoom, Teams, screenshots, recorders) | Notch panel, menu popover, and command palette set `NSWindow.sharingType = .none` via `CaptureExclusion`, so message content and circle codes are hidden from captured frames while staying visible on the physical display. This is reliable on the legacy capture path and on ScreenCaptureKit through macOS 15.3; full-display SCK capture on macOS 15.4+ can bypass it. |
 | **A malicious or curious circle member** | Limited by design: the message key is shared, so a member can read circle traffic. The relay enforces targeted delivery for direct messages, and there is no message history for a member to exfiltrate after the fact. To exclude someone, rotate to a new circle code. |
-| **A lost or unlocked device** | No message history is stored and no GitHub token is persisted (the token is RAM-only and discarded after one profile fetch). What remains locally is settings in the `dev.uq.munkel` defaults domain — joined circle codes, member ID, display name, GitHub login, and a downscaled avatar; ephemerality limits what can be recovered from the device. |
+| **A lost or unlocked device** | No message history is stored and no GitHub token is persisted (the token is RAM-only and discarded after one profile fetch). What remains locally is settings in the `dev.uq.munkel` defaults domain — joined circle codes, member ID, display name, GitHub login, a downscaled avatar, and the chosen presence status; ephemerality limits what can be recovered from the device. |
 
 ### Out of scope
 

--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -1,5 +1,8 @@
 import AppKit
+import Combine
+import CoreGraphics
 import Foundation
+import IOKit.pwr_mgt
 import MunkelKit
 
 enum GitHubLoginState: Equatable {
@@ -41,6 +44,19 @@ final class AppModel: ObservableObject {
     /// Bumped whenever any session's presence changes, so views refresh.
     @Published private(set) var presenceVersion = 0
 
+    @Published var localStatus: PresenceStatus = Identity.presenceStatus {
+        didSet {
+            guard localStatus != oldValue else { return }
+            Identity.presenceStatus = localStatus
+            if localStatus != .online { isAutoAway = false }
+            applyPresence()
+        }
+    }
+    @Published private(set) var isAutoAway = false
+    var effectiveStatus: PresenceStatus {
+        localStatus == .online && isAutoAway ? .away : localStatus
+    }
+
     /// Sparkle bridge, injected by `AppDelegate` at launch (release build only;
     /// nil in the dev build, which doesn't auto-update).
     var updater: UpdaterController?
@@ -76,6 +92,10 @@ final class AppModel: ObservableObject {
     private var githubLoginTask: Task<Void, Never>?
     private var githubLoginGeneration = 0
     private var profileBroadcastTask: Task<Void, Never>?
+    private var idleTimer: Timer?
+    private var presenceObservers: Set<AnyCancellable> = []
+    private let awayThreshold: TimeInterval = 5 * 60
+    private let idlePollInterval: TimeInterval = 30
 
     init() {
         self.displayName = Identity.displayName
@@ -94,6 +114,7 @@ final class AppModel: ObservableObject {
         // Registers the global hotkey (default ⌃⌘M) and owns the palette
         // window — long-lived like the notch, so it survives popover churn.
         self.palette = CommandPalettePresenter(model: self)
+        startPresenceMonitoring()
     }
 
     func session(for code: String) -> GroupSession? {
@@ -330,6 +351,76 @@ final class AppModel: ObservableObject {
         }
     }
 
+    private func applyPresence() {
+        let status = effectiveStatus
+        for session in sessions.values {
+            session.localStatus = status
+        }
+        broadcastProfile()
+    }
+
+    private func startPresenceMonitoring() {
+        let timer = Timer(timeInterval: idlePollInterval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.pollIdle() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        idleTimer = timer
+
+        let center = NSWorkspace.shared.notificationCenter
+        let goneNames: [Notification.Name] = [
+            NSWorkspace.screensDidSleepNotification,
+            NSWorkspace.willSleepNotification,
+            NSWorkspace.sessionDidResignActiveNotification,
+        ]
+        let backNames: [Notification.Name] = [
+            NSWorkspace.screensDidWakeNotification,
+            NSWorkspace.didWakeNotification,
+            NSWorkspace.sessionDidBecomeActiveNotification,
+        ]
+        for name in goneNames {
+            center.publisher(for: name)
+                .sink { [weak self] _ in self?.enterAutoAway() }
+                .store(in: &presenceObservers)
+        }
+        for name in backNames {
+            center.publisher(for: name)
+                .sink { [weak self] _ in self?.pollIdle() }
+                .store(in: &presenceObservers)
+        }
+    }
+
+    private func pollIdle() {
+        guard localStatus == .online else { return }
+        if Self.secondsSinceUserInput() >= awayThreshold {
+            if !Self.displayIsKeptAwake() { setAutoAway(true) }
+        } else {
+            setAutoAway(false)
+        }
+    }
+
+    private func enterAutoAway() {
+        guard localStatus == .online else { return }
+        setAutoAway(true)
+    }
+
+    private func setAutoAway(_ value: Bool) {
+        guard isAutoAway != value else { return }
+        isAutoAway = value
+        applyPresence()
+    }
+
+    private static func secondsSinceUserInput() -> TimeInterval {
+        CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: CGEventType(rawValue: ~0)!)
+    }
+
+    private static func displayIsKeptAwake() -> Bool {
+        var assertions: Unmanaged<CFDictionary>?
+        guard IOPMCopyAssertionsStatus(&assertions) == kIOReturnSuccess,
+              let counts = assertions?.takeRetainedValue() as? [String: Int]
+        else { return false }
+        return (counts[kIOPMAssertionTypePreventUserIdleDisplaySleep as String] ?? 0) > 0
+    }
+
     /// The display name is always the GitHub first name — not editable.
     /// Accounts without a public name fall back to the login.
     private static func firstName(of user: GitHubUser) -> String {
@@ -497,7 +588,8 @@ final class AppModel: ObservableObject {
                 isDirect: isDirect,
                 group: code,
                 groupColor: .groupColor(index: self.groupCodes.firstIndex(of: code) ?? 0),
-                inMultipleGroups: self.groupCodes.count > 1
+                inMultipleGroups: self.groupCodes.count > 1,
+                silent: self.effectiveStatus.suppressesNotchPreview
             ) { [weak self] reply, images, privately in
                 // Default mirrors how the message arrived; the toggle
                 // in the reply field can override per message.
@@ -523,6 +615,7 @@ final class AppModel: ObservableObject {
                 groupColor: .groupColor(index: self.groupCodes.firstIndex(of: code) ?? 0),
                 inMultipleGroups: self.groupCodes.count > 1,
                 images: images,
+                silent: self.effectiveStatus.suppressesNotchPreview,
                 loadFull: loadFull
             ) { [weak self] reply, images, privately in
                 let to = privately ? sender.id : nil
@@ -533,6 +626,7 @@ final class AppModel: ObservableObject {
                 }
             }
         }
+        session.localStatus = effectiveStatus
         sessions[code] = session
         session.start()
     }

--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -57,6 +57,16 @@ final class AppModel: ObservableObject {
         localStatus == .online && isAutoAway ? .away : localStatus
     }
 
+    func chooseStatus(_ status: PresenceStatus) {
+        let clearedAutoAway = isAutoAway
+        isAutoAway = false
+        if localStatus != status {
+            localStatus = status
+        } else if clearedAutoAway {
+            applyPresence()
+        }
+    }
+
     /// Sparkle bridge, injected by `AppDelegate` at launch (release build only;
     /// nil in the dev build, which doesn't auto-update).
     var updater: UpdaterController?
@@ -351,12 +361,18 @@ final class AppModel: ObservableObject {
         }
     }
 
+    private func broadcastPresence() {
+        for session in sessions.values {
+            Task { await session.sendPresence() }
+        }
+    }
+
     private func applyPresence() {
         let status = effectiveStatus
         for session in sessions.values {
             session.localStatus = status
         }
-        broadcastProfile()
+        broadcastPresence()
     }
 
     private func startPresenceMonitoring() {
@@ -387,12 +403,20 @@ final class AppModel: ObservableObject {
                 .sink { [weak self] _ in self?.pollIdle() }
                 .store(in: &presenceObservers)
         }
+
+        let distributed = DistributedNotificationCenter.default()
+        distributed.publisher(for: Notification.Name("com.apple.screenIsLocked"))
+            .sink { [weak self] _ in self?.enterAutoAway() }
+            .store(in: &presenceObservers)
+        distributed.publisher(for: Notification.Name("com.apple.screenIsUnlocked"))
+            .sink { [weak self] _ in self?.pollIdle() }
+            .store(in: &presenceObservers)
     }
 
     private func pollIdle() {
         guard localStatus == .online else { return }
-        if Self.secondsSinceUserInput() >= awayThreshold {
-            if !Self.displayIsKeptAwake() { setAutoAway(true) }
+        if Self.secondsSinceUserInput() >= awayThreshold, !Self.displayIsKeptAwake() {
+            setAutoAway(true)
         } else {
             setAutoAway(false)
         }
@@ -413,12 +437,53 @@ final class AppModel: ObservableObject {
         CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: CGEventType(rawValue: ~0)!)
     }
 
+    private static let remoteControlHolders = [
+        "rustdesk",
+        "screensharingd",
+        "screensharingag",
+        "ardagent",
+        "teamviewer",
+        "anydesk",
+        "remoting_host",
+        "chrome-remote-desktop",
+        "parsec",
+        "vncserver",
+    ]
+
+    private static func isRemoteControlHolder(_ name: String) -> Bool {
+        guard !name.isEmpty else { return false }
+        let lower = name.lowercased()
+        return remoteControlHolders.contains { lower.hasPrefix($0) || $0.hasPrefix(lower) }
+    }
+
     private static func displayIsKeptAwake() -> Bool {
-        var assertions: Unmanaged<CFDictionary>?
-        guard IOPMCopyAssertionsStatus(&assertions) == kIOReturnSuccess,
-              let counts = assertions?.takeRetainedValue() as? [String: Int]
-        else { return false }
-        return (counts[kIOPMAssertionTypePreventUserIdleDisplaySleep as String] ?? 0) > 0
+        displaySleepHolderNames().contains { !isRemoteControlHolder($0) }
+    }
+
+    private static func displaySleepHolderNames() -> [String] {
+        var raw: Unmanaged<CFDictionary>?
+        guard IOPMCopyAssertionsByProcess(&raw) == kIOReturnSuccess,
+              let byProcess = raw?.takeRetainedValue() as? [Int: [[String: Any]]]
+        else { return [] }
+
+        let canonical = kIOPMAssertionTypePreventUserIdleDisplaySleep as String
+        let legacy = kIOPMAssertionTypeNoDisplaySleep as String
+        let typeKey = kIOPMAssertionTypeKey as String
+        let levelKey = kIOPMAssertionLevelKey as String
+
+        var names: [String] = []
+        for assertions in byProcess.values {
+            for assertion in assertions {
+                let type = assertion[typeKey] as? String ?? ""
+                let trueType = assertion["AssertionTrueType"] as? String ?? ""
+                let level = assertion[levelKey] as? Int ?? 0
+                let holdsDisplay = type == canonical || type == legacy
+                    || trueType == canonical || trueType == legacy
+                guard holdsDisplay, level != 0 else { continue }
+                names.append(assertion["Process Name"] as? String ?? "")
+            }
+        }
+        return names
     }
 
     /// The display name is always the GitHub first name — not editable.

--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -269,6 +269,7 @@ final class AppModel: ObservableObject {
     /// stop (the group codes stay persisted and reconnect after re-login).
     func logoutGitHub() {
         Identity.avatarData = nil
+        Identity.avatarURL = nil
         Identity.githubLogin = nil
         githubUserLogin = nil
         for session in sessions.values {
@@ -317,7 +318,7 @@ final class AppModel: ObservableObject {
             }
 
             guard generation == githubLoginGeneration else { return }
-            applyProfile(name: Self.firstName(of: user), avatar: avatar, githubLogin: user.login)
+            applyProfile(name: Self.firstName(of: user), avatar: avatar, avatarURL: user.avatarURL?.absoluteString, githubLogin: user.login)
             githubLoginState = .idle
             // Login gates everything: the persisted groups connect only now.
             for code in groupCodes where sessions[code] == nil {
@@ -337,8 +338,9 @@ final class AppModel: ObservableObject {
 
     /// Writes both identity halves before the single broadcast — a didSet
     /// broadcast would race the avatar write and send a stale profile.
-    private func applyProfile(name: String, avatar: Data?, githubLogin login: String?) {
+    private func applyProfile(name: String, avatar: Data?, avatarURL: String?, githubLogin login: String?) {
         Identity.avatarData = avatar
+        Identity.avatarURL = avatarURL
         Identity.githubLogin = login
         githubUserLogin = login
         displayName = name

--- a/apps/macos/Sources/MunkelApp/AvatarStore.swift
+++ b/apps/macos/Sources/MunkelApp/AvatarStore.swift
@@ -1,0 +1,40 @@
+import Foundation
+import MunkelKit
+
+actor AvatarStore {
+    static let shared = AvatarStore()
+
+    private var cache: [String: Data] = [:]
+    private var inflight: [String: Task<Data?, Never>] = [:]
+
+    func image(for urlString: String) async -> Data? {
+        if let cached = cache[urlString] { return cached }
+        if let existing = inflight[urlString] { return await existing.value }
+        let task = Task<Data?, Never> { await Self.download(urlString) }
+        inflight[urlString] = task
+        let result = await task.value
+        inflight[urlString] = nil
+        if let result { cache[urlString] = result }
+        return result
+    }
+
+    private static let maxDownloadBytes = 4 * 1024 * 1024
+
+    private static func download(_ urlString: String) async -> Data? {
+        guard let url = URL(string: urlString), isAllowedHost(url) else { return nil }
+        var request = URLRequest(url: url)
+        request.setValue("munkel", forHTTPHeaderField: "User-Agent")
+        guard
+            let (data, response) = try? await URLSession.shared.data(for: request),
+            let http = response as? HTTPURLResponse,
+            http.statusCode == 200,
+            data.count <= maxDownloadBytes
+        else { return nil }
+        return AvatarCodec.makeAvatar(from: data)
+    }
+
+    private static func isAllowedHost(_ url: URL) -> Bool {
+        guard url.scheme == "https", let host = url.host?.lowercased() else { return false }
+        return host == "avatars.githubusercontent.com" || host.hasSuffix(".githubusercontent.com")
+    }
+}

--- a/apps/macos/Sources/MunkelApp/AvatarView.swift
+++ b/apps/macos/Sources/MunkelApp/AvatarView.swift
@@ -9,6 +9,8 @@ struct AvatarView: View {
     let name: String
     var imageData: Data?
     var size: CGFloat = 34
+    var status: PresenceStatus? = nil
+    var statusRingColor: Color = Color(nsColor: .windowBackgroundColor)
 
     private static let palettes: [[Color]] = [
         [Color(red: 0.96, green: 0.42, blue: 0.42), Color(red: 0.85, green: 0.19, blue: 0.41)],
@@ -43,6 +45,15 @@ struct AvatarView: View {
         }
         .frame(width: size, height: size)
         .clipShape(Circle())
+        .overlay(alignment: .bottomTrailing) {
+            if let status {
+                let dot = max(7, size * 0.34)
+                Circle()
+                    .fill(status.dotColor)
+                    .frame(width: dot, height: dot)
+                    .overlay(Circle().strokeBorder(statusRingColor, lineWidth: dot * 0.2))
+            }
+        }
     }
 
     private var initials: String {

--- a/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
@@ -11,6 +11,7 @@ struct Recipient: Identifiable, Equatable {
     let memberId: String?    // nil = broadcast to the whole circle
     let label: String        // display name, or "Everyone"
     let avatar: Data?
+    let status: PresenceStatus?
 
     var isEveryone: Bool { memberId == nil }
 }
@@ -65,7 +66,8 @@ final class CommandPaletteState: ObservableObject {
                 circle: code,
                 memberId: nil,
                 label: "Everyone",
-                avatar: nil
+                avatar: nil,
+                status: nil
             )
             let people = members.map { member in
                 Recipient(
@@ -73,7 +75,8 @@ final class CommandPaletteState: ObservableObject {
                     circle: code,
                     memberId: member.id,
                     label: member.label,
-                    avatar: member.avatar
+                    avatar: member.avatar,
+                    status: member.status
                 )
             }
             return [everyone] + people

--- a/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
@@ -128,7 +128,7 @@ struct CommandPaletteView: View {
                         .font(.system(size: 12))
                         .frame(width: 18, height: 18)
                 } else {
-                    AvatarView(name: recipient.label, imageData: recipient.avatar, size: 18)
+                    AvatarView(name: recipient.label, imageData: recipient.avatar, size: 18, status: recipient.status)
                 }
                 Text(recipient.isEveryone ? "Everyone" : recipient.label)
                     .font(.system(size: 12, weight: .medium))

--- a/apps/macos/Sources/MunkelApp/GroupSession.swift
+++ b/apps/macos/Sources/MunkelApp/GroupSession.swift
@@ -9,6 +9,7 @@ final class GroupSession {
         let id: String
         var displayName: String? = nil
         var avatar: Data? = nil
+        var avatarURL: String? = nil
         var status: PresenceStatus = .online
 
         var label: String {
@@ -83,7 +84,8 @@ final class GroupSession {
     func sendProfile(to memberId: String? = nil) async -> Bool {
         let payload = AppPayload.profile(
             displayName: Identity.displayName,
-            avatar: Identity.avatarData,
+            avatar: nil,
+            avatarURL: Identity.avatarURL,
             status: localStatus
         )
         return await send(payload, to: memberId)
@@ -182,6 +184,15 @@ final class GroupSession {
         }
     }
 
+    private func fetchMemberAvatar(_ memberId: String, from urlString: String) async {
+        guard let bytes = await AvatarStore.shared.image(for: urlString) else { return }
+        guard let index = members.firstIndex(where: { $0.id == memberId }),
+              members[index].avatarURL == urlString
+        else { return }
+        members[index].avatar = bytes
+        onStateChange?()
+    }
+
     private func handle(_ event: RelayClient.Event) async {
         switch event {
         case .disconnected:
@@ -246,21 +257,30 @@ final class GroupSession {
         }
 
         switch decoded {
-        case let .profile(displayName, avatar, status):
-            // nil clears the avatar (peer logged out of GitHub).
+        case let .profile(displayName, avatar, avatarURL, status):
             let sanitizedAvatar = avatar.flatMap {
                 $0.count <= Self.maxIncomingAvatarBytes ? $0 : nil
             }
             if let index = members.firstIndex(where: { $0.id == memberId }) {
                 members[index].displayName = displayName
-                members[index].avatar = sanitizedAvatar
                 members[index].status = status
+                members[index].avatarURL = avatarURL
+                if avatarURL == nil { members[index].avatar = sanitizedAvatar }
             } else {
                 members.append(
-                    Member(id: memberId, displayName: displayName, avatar: sanitizedAvatar, status: status)
+                    Member(
+                        id: memberId,
+                        displayName: displayName,
+                        avatar: avatarURL == nil ? sanitizedAvatar : nil,
+                        avatarURL: avatarURL,
+                        status: status
+                    )
                 )
             }
             onStateChange?()
+            if let avatarURL {
+                Task { await self.fetchMemberAvatar(memberId, from: avatarURL) }
+            }
 
         case let .presence(status):
             if let index = members.firstIndex(where: { $0.id == memberId }) {

--- a/apps/macos/Sources/MunkelApp/GroupSession.swift
+++ b/apps/macos/Sources/MunkelApp/GroupSession.swift
@@ -9,6 +9,7 @@ final class GroupSession {
         let id: String
         var displayName: String? = nil
         var avatar: Data? = nil
+        var status: PresenceStatus = .online
 
         var label: String {
             displayName ?? String(id.prefix(8))
@@ -28,6 +29,7 @@ final class GroupSession {
     let code: String
     private(set) var members: [Member] = []
     private(set) var isConnected = false
+    var localStatus: PresenceStatus = .online
 
     private let key: GroupKey
     private let client: RelayClient
@@ -81,7 +83,8 @@ final class GroupSession {
     func sendProfile(to memberId: String? = nil) async -> Bool {
         let payload = AppPayload.profile(
             displayName: Identity.displayName,
-            avatar: Identity.avatarData
+            avatar: Identity.avatarData,
+            status: localStatus
         )
         return await send(payload, to: memberId)
     }
@@ -238,7 +241,7 @@ final class GroupSession {
         }
 
         switch decoded {
-        case let .profile(displayName, avatar):
+        case let .profile(displayName, avatar, status):
             // nil clears the avatar (peer logged out of GitHub).
             let sanitizedAvatar = avatar.flatMap {
                 $0.count <= Self.maxIncomingAvatarBytes ? $0 : nil
@@ -246,9 +249,10 @@ final class GroupSession {
             if let index = members.firstIndex(where: { $0.id == memberId }) {
                 members[index].displayName = displayName
                 members[index].avatar = sanitizedAvatar
+                members[index].status = status
             } else {
                 members.append(
-                    Member(id: memberId, displayName: displayName, avatar: sanitizedAvatar)
+                    Member(id: memberId, displayName: displayName, avatar: sanitizedAvatar, status: status)
                 )
             }
             onStateChange?()

--- a/apps/macos/Sources/MunkelApp/GroupSession.swift
+++ b/apps/macos/Sources/MunkelApp/GroupSession.swift
@@ -89,6 +89,11 @@ final class GroupSession {
         return await send(payload, to: memberId)
     }
 
+    @discardableResult
+    func sendPresence(to memberId: String? = nil) async -> Bool {
+        await send(.presence(status: localStatus), to: memberId)
+    }
+
     /// Transcodes each image to AVIF, ALWAYS uploads the sealed ciphertext to R2
     /// (in parallel), then relays ONE pointer listing all of them with their
     /// inline AVIF thumbnails. Encoding + crypto run off the main actor. The
@@ -256,6 +261,12 @@ final class GroupSession {
                 )
             }
             onStateChange?()
+
+        case let .presence(status):
+            if let index = members.firstIndex(where: { $0.id == memberId }) {
+                members[index].status = status
+                onStateChange?()
+            }
 
         case let .chat(text, _):
             let sender = members.first { $0.id == memberId }

--- a/apps/macos/Sources/MunkelApp/Identity.swift
+++ b/apps/macos/Sources/MunkelApp/Identity.swift
@@ -8,6 +8,7 @@ enum Identity {
     private static let memberIdKey = "memberId"
     private static let displayNameKey = "displayName"
     private static let avatarDataKey = "avatarData"
+    private static let avatarURLKey = "avatarURL"
     private static let githubLoginKey = "githubLogin"
     private static let presenceStatusKey = "presenceStatus"
 
@@ -26,11 +27,18 @@ enum Identity {
         set { UserDefaults.standard.set(newValue, forKey: displayNameKey) }
     }
 
-    /// Downscaled JPEG from GitHub, ≤ AvatarCodec.maxEncodedBytes — travels
-    /// only inside encrypted profile payloads.
+    /// Downscaled JPEG of the local user's GitHub avatar, kept for local
+    /// display only — peers receive `avatarURL`, never these bytes.
     static var avatarData: Data? {
         get { UserDefaults.standard.data(forKey: avatarDataKey) }
         set { UserDefaults.standard.set(newValue, forKey: avatarDataKey) }
+    }
+
+    /// The GitHub avatar URL, broadcast to peers in profile payloads in place
+    /// of inline bytes; peers fetch it directly from GitHub. nil after logout.
+    static var avatarURL: String? {
+        get { UserDefaults.standard.string(forKey: avatarURLKey) }
+        set { UserDefaults.standard.set(newValue, forKey: avatarURLKey) }
     }
 
     /// GitHub login while signed in; nil after logout. Purely informational —

--- a/apps/macos/Sources/MunkelApp/Identity.swift
+++ b/apps/macos/Sources/MunkelApp/Identity.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MunkelKit
 
 /// Local identity: a stable per-installation member UUID plus the display
 /// name (the GitHub first name — login is mandatory, the name not editable).
@@ -8,6 +9,7 @@ enum Identity {
     private static let displayNameKey = "displayName"
     private static let avatarDataKey = "avatarData"
     private static let githubLoginKey = "githubLogin"
+    private static let presenceStatusKey = "presenceStatus"
 
     static var memberId: String {
         let defaults = UserDefaults.standard
@@ -36,5 +38,13 @@ enum Identity {
     static var githubLogin: String? {
         get { UserDefaults.standard.string(forKey: githubLoginKey) }
         set { UserDefaults.standard.set(newValue, forKey: githubLoginKey) }
+    }
+
+    static var presenceStatus: PresenceStatus {
+        get {
+            UserDefaults.standard.string(forKey: presenceStatusKey)
+                .flatMap(PresenceStatus.init(rawValue:)) ?? .online
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: presenceStatusKey) }
     }
 }

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -190,29 +190,23 @@ struct MenuView: View {
     }
 
     private var statusPicker: some View {
-        Menu {
+        Picker(selection: $model.localStatus) {
             ForEach(PresenceStatus.allCases, id: \.self) { status in
-                Button {
-                    model.localStatus = status
-                } label: {
-                    if model.localStatus == status {
-                        Label(status.menuLabel, systemImage: "checkmark")
-                    } else {
-                        Text(status.menuLabel)
-                    }
+                Label {
+                    Text(status.menuLabel)
+                } icon: {
+                    Image(systemName: status.symbolName)
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(status.dotColor)
                 }
+                .tag(status)
             }
         } label: {
-            HStack(spacing: 4) {
-                Circle()
-                    .fill(model.localStatus.dotColor)
-                    .frame(width: 8, height: 8)
-                Text(model.localStatus.menuLabel)
-                    .font(.caption)
-            }
+            Text("Presence")
         }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
+        .pickerStyle(.menu)
+        .labelsHidden()
+        .buttonStyle(.borderless)
         .controlSize(.small)
         .help("Set your presence")
     }

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -8,6 +8,7 @@ struct MenuView: View {
     @State private var joinCode = ""
     @State private var userCodeCopied = false
     @State private var groupListHeight: CGFloat = 0
+    @State private var statusHovering = false
     @StateObject private var displayList = DisplayList()
     /// "Launch at Login" state that reflects intent immediately and reconciles
     /// with the real SMAppService status on foreground.
@@ -198,6 +199,7 @@ struct MenuView: View {
                     Image(systemName: status.symbolName)
                         .symbolRenderingMode(.palette)
                         .foregroundStyle(status.dotColor)
+                        .imageScale(status == .online ? .small : .medium)
                 }
                 .tag(status)
             }
@@ -208,6 +210,14 @@ struct MenuView: View {
         .labelsHidden()
         .buttonStyle(.borderless)
         .controlSize(.small)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.primary.opacity(statusHovering ? 0.1 : 0))
+        )
+        .onHover { statusHovering = $0 }
+        .animation(.easeOut(duration: 0.12), value: statusHovering)
         .help("Set your presence")
     }
 

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -166,6 +166,13 @@ struct MenuView: View {
             Toggle("Allow in screenshots", isOn: $allowInScreenshots)
             #endif
             Divider()
+            if model.githubUserLogin != nil {
+                Button {
+                    model.logoutGitHub()
+                } label: {
+                    Label("Sign out", systemImage: "rectangle.portrait.and.arrow.right")
+                }
+            }
             Button {
                 NSApp.terminate(nil)
             } label: {
@@ -180,6 +187,34 @@ struct MenuView: View {
         .menuIndicator(.hidden)
         .fixedSize()
         .help("Settings")
+    }
+
+    private var statusPicker: some View {
+        Menu {
+            ForEach(PresenceStatus.allCases, id: \.self) { status in
+                Button {
+                    model.localStatus = status
+                } label: {
+                    if model.localStatus == status {
+                        Label(status.menuLabel, systemImage: "checkmark")
+                    } else {
+                        Text(status.menuLabel)
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(model.localStatus.dotColor)
+                    .frame(width: 8, height: 8)
+                Text(model.localStatus.menuLabel)
+                    .font(.caption)
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .controlSize(.small)
+        .help("Set your presence")
     }
 
     private func showAbout() {
@@ -228,15 +263,14 @@ struct MenuView: View {
     private var githubArea: some View {
         switch model.githubLoginState {
         case .idle:
-            if let login = model.githubUserLogin {
+            if model.githubUserLogin != nil {
                 HStack(spacing: 8) {
-                    AvatarView(name: model.displayName, imageData: Identity.avatarData, size: 20)
-                    Text("Signed in as \(model.displayName) (@\(login))")
+                    AvatarView(name: model.displayName, imageData: Identity.avatarData, size: 20, status: model.effectiveStatus)
+                    Text(model.displayName)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Spacer()
-                    Button("Sign out") { model.logoutGitHub() }
-                        .controlSize(.small)
+                    statusPicker
                 }
             } else {
                 Button {
@@ -619,7 +653,7 @@ struct GroupSectionView: View {
                         recipient = member.id
                         fieldFocused = true
                     } label: {
-                        AvatarView(name: member.label, imageData: member.avatar, size: targetSize)
+                        AvatarView(name: member.label, imageData: member.avatar, size: targetSize, status: member.status)
                     }
                 }
 

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -191,7 +191,7 @@ struct MenuView: View {
     }
 
     private var statusPicker: some View {
-        Picker(selection: $model.localStatus) {
+        Picker(selection: Binding(get: { model.localStatus }, set: { model.chooseStatus($0) })) {
             ForEach(PresenceStatus.allCases, id: \.self) { status in
                 Label {
                     Text(status.menuLabel)

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -30,6 +30,7 @@ final class NotchPresenter {
     private var hoverCopyObservation: AnyCancellable?
     /// Observes hover on the unread indicator to dismiss it.
     private var indicatorHoverObservation: AnyCancellable?
+    private var onIndicatorHover: (() -> Void)?
     private var clickMonitor: Any?
     private var outsideClickMonitor: Any?
     /// While a modal file picker (NSOpenPanel) is up, its in-process clicks
@@ -85,6 +86,7 @@ final class NotchPresenter {
         groupColor: Color,
         inMultipleGroups: Bool,
         images: [IncomingImage] = [],
+        silent: Bool = false,
         loadFull: (@Sendable (String) async -> Data?)? = nil,
         onReply: @escaping (_ text: String, _ images: [Data], _ privately: Bool) -> Void
     ) {
@@ -135,17 +137,32 @@ final class NotchPresenter {
             return
         }
 
-        // Strictly serialized, collapsing display chain: messages display one
-        // after another, and a newer one supersedes an older still-pending one
-        // (it survives only as a history row). This keeps two near-simultaneous
-        // messages from racing on the single current panel.
+        if silent {
+            if !notchVisible {
+                onIndicatorHover = { [weak self] in
+                    self?.scheduleDisplay(message, entryID: entry.id, loadFull: loadFull, onReply: onReply)
+                }
+                showIndicator()
+            }
+            return
+        }
+
+        scheduleDisplay(message, entryID: entry.id, loadFull: loadFull, onReply: onReply)
+    }
+
+    private func scheduleDisplay(
+        _ message: IncomingMessage,
+        entryID: UUID,
+        loadFull: (@Sendable (String) async -> Data?)?,
+        onReply: @escaping (_ text: String, _ images: [Data], _ privately: Bool) -> Void
+    ) {
         showGeneration += 1
         let generation = showGeneration
         let previous = pendingShow
         pendingShow = Task { [weak self] in
             await previous?.value
             guard let self, generation == self.showGeneration else { return }
-            await self.display(message, entryID: entry.id, generation: generation, loadFull: loadFull, onReply: onReply)
+            await self.display(message, entryID: entryID, generation: generation, loadFull: loadFull, onReply: onReply)
         }
     }
 
@@ -167,6 +184,7 @@ final class NotchPresenter {
         hoverObservation = nil
         removeClickMonitors()
         turnOffHoverCopy()
+        onIndicatorHover = nil
         hideIndicator()
         if let previous = currentNotch {
             // hide() collapses immediately; afterwards a newer message may
@@ -530,10 +548,13 @@ final class NotchPresenter {
             .filter { $0 }
             .sink { [weak self, weak indicator] _ in
                 Task { @MainActor in
-                    guard let indicator else { return }
+                    guard let self, let indicator else { return }
                     await indicator.hide()
-                    self?.indicatorNotch = nil
-                    self?.indicatorHoverObservation = nil
+                    self.indicatorNotch = nil
+                    self.indicatorHoverObservation = nil
+                    let reveal = self.onIndicatorHover
+                    self.onIndicatorHover = nil
+                    reveal?()
                 }
             }
 

--- a/apps/macos/Sources/MunkelApp/PresenceStatus+UI.swift
+++ b/apps/macos/Sources/MunkelApp/PresenceStatus+UI.swift
@@ -1,0 +1,20 @@
+import MunkelKit
+import SwiftUI
+
+extension PresenceStatus {
+    var dotColor: Color {
+        switch self {
+        case .online: .green
+        case .doNotDisturb: .orange
+        case .away: .red
+        }
+    }
+
+    var menuLabel: String {
+        switch self {
+        case .online: "Online"
+        case .doNotDisturb: "Do Not Disturb"
+        case .away: "Away"
+        }
+    }
+}

--- a/apps/macos/Sources/MunkelApp/PresenceStatus+UI.swift
+++ b/apps/macos/Sources/MunkelApp/PresenceStatus+UI.swift
@@ -17,4 +17,12 @@ extension PresenceStatus {
         case .away: "Away"
         }
     }
+
+    var symbolName: String {
+        switch self {
+        case .online: "circle.fill"
+        case .doNotDisturb: "moon.fill"
+        case .away: "clock.fill"
+        }
+    }
 }

--- a/apps/macos/Sources/MunkelKit/AppPayload.swift
+++ b/apps/macos/Sources/MunkelKit/AppPayload.swift
@@ -27,7 +27,7 @@ public struct ImageItem: Codable, Sendable, Equatable {
 /// What lives inside the encrypted blob — the relay never sees these.
 public enum AppPayload: Sendable, Equatable {
     case chat(text: String, sentAt: Date)
-    case profile(displayName: String, avatar: Data?, status: PresenceStatus)
+    case profile(displayName: String, avatar: Data?, avatarURL: String?, status: PresenceStatus)
     case presence(status: PresenceStatus)
     /// One or more images (an album) sent together, with an optional shared
     /// `caption` ("" if none). Each `ImageItem` is a pointer to an R2 blob plus
@@ -50,7 +50,7 @@ public enum AppPayload: Sendable, Equatable {
 
 extension AppPayload: Codable {
     private enum CodingKeys: String, CodingKey {
-        case kind, text, sentAt, displayName, avatar, status
+        case kind, text, sentAt, displayName, avatar, avatarURL, status
         case items, caption
     }
 
@@ -73,6 +73,7 @@ extension AppPayload: Codable {
             self = try .profile(
                 displayName: container.decode(String.self, forKey: .displayName),
                 avatar: container.decodeIfPresent(Data.self, forKey: .avatar),
+                avatarURL: container.decodeIfPresent(String.self, forKey: .avatarURL),
                 status: statusRaw.flatMap(PresenceStatus.init(rawValue:)) ?? .online
             )
         case "presence":
@@ -123,10 +124,11 @@ extension AppPayload: Codable {
             try container.encode("chat", forKey: .kind)
             try container.encode(text, forKey: .text)
             try container.encode(ISO8601DateFormatter().string(from: sentAt), forKey: .sentAt)
-        case let .profile(displayName, avatar, status):
+        case let .profile(displayName, avatar, avatarURL, status):
             try container.encode("profile", forKey: .kind)
             try container.encode(displayName, forKey: .displayName)
             try container.encodeIfPresent(avatar, forKey: .avatar)
+            try container.encodeIfPresent(avatarURL, forKey: .avatarURL)
             try container.encode(status.rawValue, forKey: .status)
         case let .presence(status):
             try container.encode("presence", forKey: .kind)

--- a/apps/macos/Sources/MunkelKit/AppPayload.swift
+++ b/apps/macos/Sources/MunkelKit/AppPayload.swift
@@ -28,6 +28,7 @@ public struct ImageItem: Codable, Sendable, Equatable {
 public enum AppPayload: Sendable, Equatable {
     case chat(text: String, sentAt: Date)
     case profile(displayName: String, avatar: Data?, status: PresenceStatus)
+    case presence(status: PresenceStatus)
     /// One or more images (an album) sent together, with an optional shared
     /// `caption` ("" if none). Each `ImageItem` is a pointer to an R2 blob plus
     /// a tiny inline preview thumbnail.
@@ -74,6 +75,9 @@ extension AppPayload: Codable {
                 avatar: container.decodeIfPresent(Data.self, forKey: .avatar),
                 status: statusRaw.flatMap(PresenceStatus.init(rawValue:)) ?? .online
             )
+        case "presence":
+            let statusRaw = try container.decodeIfPresent(String.self, forKey: .status)
+            self = .presence(status: statusRaw.flatMap(PresenceStatus.init(rawValue:)) ?? .online)
         case "image":
             let sentAtRaw = try container.decode(String.self, forKey: .sentAt)
             guard let sentAt = Self.parseISO8601(sentAtRaw) else {
@@ -123,6 +127,9 @@ extension AppPayload: Codable {
             try container.encode("profile", forKey: .kind)
             try container.encode(displayName, forKey: .displayName)
             try container.encodeIfPresent(avatar, forKey: .avatar)
+            try container.encode(status.rawValue, forKey: .status)
+        case let .presence(status):
+            try container.encode("presence", forKey: .kind)
             try container.encode(status.rawValue, forKey: .status)
         case let .image(items, caption, sentAt):
             try container.encode("image", forKey: .kind)

--- a/apps/macos/Sources/MunkelKit/AppPayload.swift
+++ b/apps/macos/Sources/MunkelKit/AppPayload.swift
@@ -27,7 +27,7 @@ public struct ImageItem: Codable, Sendable, Equatable {
 /// What lives inside the encrypted blob — the relay never sees these.
 public enum AppPayload: Sendable, Equatable {
     case chat(text: String, sentAt: Date)
-    case profile(displayName: String, avatar: Data?)
+    case profile(displayName: String, avatar: Data?, status: PresenceStatus)
     /// One or more images (an album) sent together, with an optional shared
     /// `caption` ("" if none). Each `ImageItem` is a pointer to an R2 blob plus
     /// a tiny inline preview thumbnail.
@@ -49,7 +49,7 @@ public enum AppPayload: Sendable, Equatable {
 
 extension AppPayload: Codable {
     private enum CodingKeys: String, CodingKey {
-        case kind, text, sentAt, displayName, avatar
+        case kind, text, sentAt, displayName, avatar, status
         case items, caption
     }
 
@@ -68,9 +68,11 @@ extension AppPayload: Codable {
             }
             self = try .chat(text: container.decode(String.self, forKey: .text), sentAt: sentAt)
         case "profile":
+            let statusRaw = try container.decodeIfPresent(String.self, forKey: .status)
             self = try .profile(
                 displayName: container.decode(String.self, forKey: .displayName),
-                avatar: container.decodeIfPresent(Data.self, forKey: .avatar)
+                avatar: container.decodeIfPresent(Data.self, forKey: .avatar),
+                status: statusRaw.flatMap(PresenceStatus.init(rawValue:)) ?? .online
             )
         case "image":
             let sentAtRaw = try container.decode(String.self, forKey: .sentAt)
@@ -117,10 +119,11 @@ extension AppPayload: Codable {
             try container.encode("chat", forKey: .kind)
             try container.encode(text, forKey: .text)
             try container.encode(ISO8601DateFormatter().string(from: sentAt), forKey: .sentAt)
-        case let .profile(displayName, avatar):
+        case let .profile(displayName, avatar, status):
             try container.encode("profile", forKey: .kind)
             try container.encode(displayName, forKey: .displayName)
             try container.encodeIfPresent(avatar, forKey: .avatar)
+            try container.encode(status.rawValue, forKey: .status)
         case let .image(items, caption, sentAt):
             try container.encode("image", forKey: .kind)
             try container.encode(items, forKey: .items)

--- a/apps/macos/Sources/MunkelKit/PresenceStatus.swift
+++ b/apps/macos/Sources/MunkelKit/PresenceStatus.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public enum PresenceStatus: String, Codable, Sendable, CaseIterable {
+    case online
+    case doNotDisturb = "dnd"
+    case away
+
+    public var suppressesNotchPreview: Bool {
+        self != .online
+    }
+}

--- a/apps/macos/Tests/MunkelKitTests/WireMessageTests.swift
+++ b/apps/macos/Tests/MunkelKitTests/WireMessageTests.swift
@@ -85,7 +85,7 @@ struct AppPayloadTests {
     }
 
     @Test func profileRoundtrip() throws {
-        let payload = AppPayload.profile(displayName: "Alex", avatar: Data([1, 2, 3]), status: .doNotDisturb)
+        let payload = AppPayload.profile(displayName: "Alex", avatar: Data([1, 2, 3]), avatarURL: nil, status: .doNotDisturb)
         let decoded = try AppPayload.decoded(from: payload.encoded())
         #expect(decoded == payload)
     }
@@ -109,7 +109,7 @@ struct AppPayloadTests {
     }
 
     @Test func profileWithoutAvatarOmitsKey() throws {
-        let data = try AppPayload.profile(displayName: "Alex", avatar: nil, status: .online).encoded()
+        let data = try AppPayload.profile(displayName: "Alex", avatar: nil, avatarURL: nil, status: .online).encoded()
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         #expect(json["avatar"] == nil)
     }
@@ -118,19 +118,19 @@ struct AppPayloadTests {
         let decoded = try AppPayload.decoded(
             from: Data(#"{"kind":"profile","displayName":"Alex"}"#.utf8)
         )
-        #expect(decoded == .profile(displayName: "Alex", avatar: nil, status: .online))
+        #expect(decoded == .profile(displayName: "Alex", avatar: nil, avatarURL: nil, status: .online))
     }
 
     @Test func profileAvatarEncodesAsBase64String() throws {
         let bytes = Data([0xFF, 0xD8, 0xFF, 0xE0])
-        let data = try AppPayload.profile(displayName: "Alex", avatar: bytes, status: .online).encoded()
+        let data = try AppPayload.profile(displayName: "Alex", avatar: bytes, avatarURL: nil, status: .online).encoded()
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         let base64 = try #require(json["avatar"] as? String)
         #expect(Data(base64Encoded: base64) == bytes)
     }
 
     @Test func profileStatusEncodesAsString() throws {
-        let data = try AppPayload.profile(displayName: "Alex", avatar: nil, status: .doNotDisturb).encoded()
+        let data = try AppPayload.profile(displayName: "Alex", avatar: nil, avatarURL: nil, status: .doNotDisturb).encoded()
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         #expect(json["status"] as? String == "dnd")
     }
@@ -158,20 +158,35 @@ struct AppPayloadTests {
         let decoded = try AppPayload.decoded(
             from: Data(#"{"kind":"profile","displayName":"Alex"}"#.utf8)
         )
-        #expect(decoded == .profile(displayName: "Alex", avatar: nil, status: .online))
+        #expect(decoded == .profile(displayName: "Alex", avatar: nil, avatarURL: nil, status: .online))
     }
 
     @Test func profileDecodesUnknownStatusAsOnline() throws {
         let decoded = try AppPayload.decoded(
             from: Data(#"{"kind":"profile","displayName":"Alex","status":"vacation"}"#.utf8)
         )
-        #expect(decoded == .profile(displayName: "Alex", avatar: nil, status: .online))
+        #expect(decoded == .profile(displayName: "Alex", avatar: nil, avatarURL: nil, status: .online))
     }
 
     @Test func profileDecodesAwayStatus() throws {
         let decoded = try AppPayload.decoded(
             from: Data(#"{"kind":"profile","displayName":"Alex","status":"away"}"#.utf8)
         )
-        #expect(decoded == .profile(displayName: "Alex", avatar: nil, status: .away))
+        #expect(decoded == .profile(displayName: "Alex", avatar: nil, avatarURL: nil, status: .away))
+    }
+
+    @Test func profileEncodesAvatarURLNotBytes() throws {
+        let url = "https://avatars.githubusercontent.com/u/1?v=4"
+        let data = try AppPayload.profile(displayName: "Alex", avatar: nil, avatarURL: url, status: .online).encoded()
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        #expect(json["avatarURL"] as? String == url)
+        #expect(json["avatar"] == nil)
+    }
+
+    @Test func profileDecodesAvatarURL() throws {
+        let decoded = try AppPayload.decoded(
+            from: Data(#"{"kind":"profile","displayName":"Alex","avatarURL":"https://x.githubusercontent.com/a"}"#.utf8)
+        )
+        #expect(decoded == .profile(displayName: "Alex", avatar: nil, avatarURL: "https://x.githubusercontent.com/a", status: .online))
     }
 }

--- a/apps/macos/Tests/MunkelKitTests/WireMessageTests.swift
+++ b/apps/macos/Tests/MunkelKitTests/WireMessageTests.swift
@@ -135,6 +135,25 @@ struct AppPayloadTests {
         #expect(json["status"] as? String == "dnd")
     }
 
+    @Test func presenceRoundtrip() throws {
+        let payload = AppPayload.presence(status: .away)
+        #expect(try AppPayload.decoded(from: payload.encoded()) == payload)
+    }
+
+    @Test func presenceEncodesKindAndStatusOnly() throws {
+        let data = try AppPayload.presence(status: .doNotDisturb).encoded()
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        #expect(json["kind"] as? String == "presence")
+        #expect(json["status"] as? String == "dnd")
+        #expect(json["displayName"] == nil)
+        #expect(json["avatar"] == nil)
+    }
+
+    @Test func presenceDecodesMissingStatusAsOnline() throws {
+        let decoded = try AppPayload.decoded(from: Data(#"{"kind":"presence"}"#.utf8))
+        #expect(decoded == .presence(status: .online))
+    }
+
     @Test func profileDecodesMissingStatusAsOnline() throws {
         let decoded = try AppPayload.decoded(
             from: Data(#"{"kind":"profile","displayName":"Alex"}"#.utf8)

--- a/apps/macos/Tests/MunkelKitTests/WireMessageTests.swift
+++ b/apps/macos/Tests/MunkelKitTests/WireMessageTests.swift
@@ -85,7 +85,7 @@ struct AppPayloadTests {
     }
 
     @Test func profileRoundtrip() throws {
-        let payload = AppPayload.profile(displayName: "Alex", avatar: Data([1, 2, 3]))
+        let payload = AppPayload.profile(displayName: "Alex", avatar: Data([1, 2, 3]), status: .doNotDisturb)
         let decoded = try AppPayload.decoded(from: payload.encoded())
         #expect(decoded == payload)
     }
@@ -109,7 +109,7 @@ struct AppPayloadTests {
     }
 
     @Test func profileWithoutAvatarOmitsKey() throws {
-        let data = try AppPayload.profile(displayName: "Alex", avatar: nil).encoded()
+        let data = try AppPayload.profile(displayName: "Alex", avatar: nil, status: .online).encoded()
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         #expect(json["avatar"] == nil)
     }
@@ -118,14 +118,41 @@ struct AppPayloadTests {
         let decoded = try AppPayload.decoded(
             from: Data(#"{"kind":"profile","displayName":"Alex"}"#.utf8)
         )
-        #expect(decoded == .profile(displayName: "Alex", avatar: nil))
+        #expect(decoded == .profile(displayName: "Alex", avatar: nil, status: .online))
     }
 
     @Test func profileAvatarEncodesAsBase64String() throws {
         let bytes = Data([0xFF, 0xD8, 0xFF, 0xE0])
-        let data = try AppPayload.profile(displayName: "Alex", avatar: bytes).encoded()
+        let data = try AppPayload.profile(displayName: "Alex", avatar: bytes, status: .online).encoded()
         let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         let base64 = try #require(json["avatar"] as? String)
         #expect(Data(base64Encoded: base64) == bytes)
+    }
+
+    @Test func profileStatusEncodesAsString() throws {
+        let data = try AppPayload.profile(displayName: "Alex", avatar: nil, status: .doNotDisturb).encoded()
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        #expect(json["status"] as? String == "dnd")
+    }
+
+    @Test func profileDecodesMissingStatusAsOnline() throws {
+        let decoded = try AppPayload.decoded(
+            from: Data(#"{"kind":"profile","displayName":"Alex"}"#.utf8)
+        )
+        #expect(decoded == .profile(displayName: "Alex", avatar: nil, status: .online))
+    }
+
+    @Test func profileDecodesUnknownStatusAsOnline() throws {
+        let decoded = try AppPayload.decoded(
+            from: Data(#"{"kind":"profile","displayName":"Alex","status":"vacation"}"#.utf8)
+        )
+        #expect(decoded == .profile(displayName: "Alex", avatar: nil, status: .online))
+    }
+
+    @Test func profileDecodesAwayStatus() throws {
+        let decoded = try AppPayload.decoded(
+            from: Data(#"{"kind":"profile","displayName":"Alex","status":"away"}"#.utf8)
+        )
+        #expect(decoded == .profile(displayName: "Alex", avatar: nil, status: .away))
     }
 }

--- a/apps/server/scripts/dev-image.ts
+++ b/apps/server/scripts/dev-image.ts
@@ -166,13 +166,13 @@ if (listenMode) {
     }
   };
   ws.onopen = async () => {
-    ws.send(JSON.stringify({ type: 'send', payload: await sealJSON({ kind: 'profile', displayName: name }) }));
+    ws.send(JSON.stringify({ type: 'send', payload: await sealJSON({ kind: 'profile', displayName: name, status: 'online' }) }));
     process.stdout.write(`listening as "${name}" (${memberId})… send an image to me from the app or another client\n`);
     setInterval(() => ws.send(JSON.stringify({ type: 'ping' })), 30_000);
   };
 } else {
   ws.onopen = async () => {
-    ws.send(JSON.stringify({ type: 'send', payload: await sealJSON({ kind: 'profile', displayName: name }) }));
+    ws.send(JSON.stringify({ type: 'send', payload: await sealJSON({ kind: 'profile', displayName: name, status: 'online' }) }));
 
     const selected = paths.slice(0, MAX_IMAGES);
     const perThumb = Math.max(1_200, Math.floor(ALBUM_THUMB_BUDGET / selected.length));

--- a/apps/server/scripts/dev-send.ts
+++ b/apps/server/scripts/dev-send.ts
@@ -107,7 +107,7 @@ ws.onmessage = async (event) => {
 };
 
 ws.onopen = async () => {
-  ws.send(JSON.stringify({ type: 'send', payload: await seal({ kind: 'profile', displayName: sender }) }));
+  ws.send(JSON.stringify({ type: 'send', payload: await seal({ kind: 'profile', displayName: sender, status: 'online' }) }));
   if (listenMode) {
     process.stdout.write(`listening as "${sender}" (${memberId})…\n`);
     setInterval(() => ws.send(JSON.stringify({ type: 'ping' })), 30_000);

--- a/apps/server/scripts/dev-send.ts
+++ b/apps/server/scripts/dev-send.ts
@@ -11,6 +11,7 @@
 // instead of broadcasting to the whole group; unset means broadcast.
 // Set PRESENCE=<online|dnd|away> to send a presence-only status delta
 // (the `presence` payload kind) in place of the chat, then exit.
+// Set AVATAR_URL=<url> to include a GitHub avatar URL in the profile.
 
 const listenMode = process.argv[2] === '--listen';
 const positional = process.argv.slice(listenMode ? 3 : 2);
@@ -109,7 +110,7 @@ ws.onmessage = async (event) => {
 };
 
 ws.onopen = async () => {
-  ws.send(JSON.stringify({ type: 'send', payload: await seal({ kind: 'profile', displayName: sender, status: process.env.STATUS ?? 'online' }) }));
+  ws.send(JSON.stringify({ type: 'send', payload: await seal({ kind: 'profile', displayName: sender, ...(process.env.AVATAR_URL ? { avatarURL: process.env.AVATAR_URL } : {}), status: process.env.STATUS ?? 'online' }) }));
   if (listenMode) {
     process.stdout.write(`listening as "${sender}" (${memberId})…\n`);
     setInterval(() => ws.send(JSON.stringify({ type: 'ping' })), 30_000);

--- a/apps/server/scripts/dev-send.ts
+++ b/apps/server/scripts/dev-send.ts
@@ -9,6 +9,8 @@
 //
 // Set TO=<memberId> to direct the chat at a single member (a "whisper")
 // instead of broadcasting to the whole group; unset means broadcast.
+// Set PRESENCE=<online|dnd|away> to send a presence-only status delta
+// (the `presence` payload kind) in place of the chat, then exit.
 
 const listenMode = process.argv[2] === '--listen';
 const positional = process.argv.slice(listenMode ? 3 : 2);
@@ -113,13 +115,19 @@ ws.onopen = async () => {
     setInterval(() => ws.send(JSON.stringify({ type: 'ping' })), 30_000);
     return;
   }
-  const to = process.env.TO;
-  ws.send(JSON.stringify({
-    type: 'send',
-    ...(to ? { to } : {}),
-    payload: await seal({ kind: 'chat', text, sentAt: new Date().toISOString() }),
-  }));
-  process.stdout.write(`sent profile + chat as "${sender}"${to ? ` → ${to}` : ''}\n`);
+  const presence = process.env.PRESENCE;
+  if (presence) {
+    ws.send(JSON.stringify({ type: 'send', payload: await seal({ kind: 'presence', status: presence }) }));
+    process.stdout.write(`sent presence status=${presence} as "${sender}"\n`);
+  } else {
+    const to = process.env.TO;
+    ws.send(JSON.stringify({
+      type: 'send',
+      ...(to ? { to } : {}),
+      payload: await seal({ kind: 'chat', text, sentAt: new Date().toISOString() }),
+    }));
+    process.stdout.write(`sent profile + chat as "${sender}"${to ? ` → ${to}` : ''}\n`);
+  }
   setTimeout(() => {
     ws.close();
     process.exit(0);

--- a/apps/server/scripts/dev-send.ts
+++ b/apps/server/scripts/dev-send.ts
@@ -107,7 +107,7 @@ ws.onmessage = async (event) => {
 };
 
 ws.onopen = async () => {
-  ws.send(JSON.stringify({ type: 'send', payload: await seal({ kind: 'profile', displayName: sender, status: 'online' }) }));
+  ws.send(JSON.stringify({ type: 'send', payload: await seal({ kind: 'profile', displayName: sender, status: process.env.STATUS ?? 'online' }) }));
   if (listenMode) {
     process.stdout.write(`listening as "${sender}" (${memberId})…\n`);
     setInterval(() => ws.send(JSON.stringify({ type: 'ping' })), 30_000);

--- a/apps/server/src/protocol.ts
+++ b/apps/server/src/protocol.ts
@@ -62,6 +62,10 @@ import { z } from 'zod';
  *   — broadcast after joining and whenever a `peer-joined` arrives, so
  *   newcomers learn who everyone is. Sending `profile` without `avatar` clears
  *   it. Byte budgets live with the codec: AvatarCodec.swift (MunkelKit).
+ * - `presence`: `status` (`online` | `dnd` | `away`) only — a lightweight
+ *   delta broadcast when a member's status changes, so a status flip needn't
+ *   re-send the avatar bytes. The initial status still rides on `profile` for
+ *   the join snapshot; clients without presence support ignore this kind.
  * - `image`:   `items` (1–8), shared `caption`, `sentAt`. Each item is
  *   `{r2Key, mime, width, height, byteLen, thumb (inline AVIF, base64)}`.
  *   The full-resolution image is AVIF, always sealed and PUT to R2 (blob.ts);

--- a/apps/server/src/protocol.ts
+++ b/apps/server/src/protocol.ts
@@ -57,11 +57,13 @@ import { z } from 'zod';
  * discriminator:
  *
  * - `chat`:    `text`, `sentAt` (ISO-8601) — the actual message.
- * - `profile`: `displayName`, `avatar?` (base64 JPEG/PNG), `status?`
- *   (`online` | `dnd` | `away`; an absent or unknown value reads as `online`)
- *   — broadcast after joining and whenever a `peer-joined` arrives, so
- *   newcomers learn who everyone is. Sending `profile` without `avatar` clears
- *   it. Byte budgets live with the codec: AvatarCodec.swift (MunkelKit).
+ * - `profile`: `displayName`, `avatarURL?` (the sender's GitHub avatar URL),
+ *   `avatar?` (legacy inline base64 JPEG/PNG — no longer sent, still decoded
+ *   for older peers), `status?` (`online` | `dnd` | `away`; an absent or
+ *   unknown value reads as `online`) — broadcast after joining and whenever a
+ *   `peer-joined` arrives, so newcomers learn who everyone is. Clients fetch
+ *   the avatar directly from `avatarURL` (GitHub's CDN), so avatar bytes never
+ *   transit the relay.
  * - `presence`: `status` (`online` | `dnd` | `away`) only — a lightweight
  *   delta broadcast when a member's status changes, so a status flip needn't
  *   re-send the avatar bytes. The initial status still rides on `profile` for

--- a/apps/server/src/protocol.ts
+++ b/apps/server/src/protocol.ts
@@ -57,10 +57,11 @@ import { z } from 'zod';
  * discriminator:
  *
  * - `chat`:    `text`, `sentAt` (ISO-8601) — the actual message.
- * - `profile`: `displayName`, `avatar?` (base64 JPEG/PNG) — broadcast after
- *   joining and whenever a `peer-joined` arrives, so newcomers learn who
- *   everyone is. Sending `profile` without `avatar` clears it. Byte budgets
- *   live with the codec: AvatarCodec.swift (MunkelKit).
+ * - `profile`: `displayName`, `avatar?` (base64 JPEG/PNG), `status?`
+ *   (`online` | `dnd` | `away`; an absent or unknown value reads as `online`)
+ *   — broadcast after joining and whenever a `peer-joined` arrives, so
+ *   newcomers learn who everyone is. Sending `profile` without `avatar` clears
+ *   it. Byte budgets live with the codec: AvatarCodec.swift (MunkelKit).
  * - `image`:   `items` (1–8), shared `caption`, `sentAt`. Each item is
  *   `{r2Key, mime, width, height, byteLen, thumb (inline AVIF, base64)}`.
  *   The full-resolution image is AVIF, always sealed and PUT to R2 (blob.ts);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -216,7 +216,9 @@ and [`blob.ts`](../apps/server/src/blob.ts)).
    payload that fails to decrypt or decode is dropped, not surfaced.
 3. The decoded `AppPayload` is dispatched: `chat` text and `image` albums are
    shown in the notch via `NotchPanel` / `NotchPresenter`; `profile` payloads
-   update the sender's display name, avatar, and presence status locally. When
+   update the sender's display name and presence status locally, and the avatar
+   is fetched from the sender's GitHub avatar URL directly (not via the relay).
+   When
    the local user's own status is Do Not Disturb or Away, the proactive notch
    preview is suppressed and the message lands silently in the 60 s history.
    Full-resolution images are fetched and decrypted from R2 lazily, on demand,
@@ -255,7 +257,8 @@ TypeScript reference sender is
   closes connections idle for more than 120 s.
 - **Application payloads** (inside the encrypted blob, invisible to the relay):
   a `kind`-discriminated JSON object — `chat` (`text`, `sentAt`), `profile`
-  (`displayName`, optional base64 `avatar`, optional `status` of
+  (`displayName`, optional `avatarURL` that peers fetch from GitHub directly —
+  not via the relay, optional `status` of
   `online` | `dnd` | `away`), `presence` (`status` only — a lightweight delta
   sent when a member's status changes, so a flip needn't re-send the avatar),
   or `image` (1–8 `items`, shared `caption`, `sentAt`; each item is an `r2Key`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,13 @@ and relay connections; the CLI and the UI are clients of it. Source layout under
   app state, and the CLI control socket.
   - [`AppModel.swift`](../apps/macos/Sources/MunkelApp/AppModel.swift) — central
     state: joined circles, identity, and the `handleControl` entry point that
-    resolves circle/recipient names for the CLI.
+    resolves circle/recipient names for the CLI. It also computes the local
+    presence status, overlaying **Away** on an Online base after five minutes
+    without keyboard or mouse input (or on screen lock, screen sleep, system
+    sleep, or fast user switch). The idle guard ignores `PreventUserIdleDisplaySleep`
+    assertions held *solely* by remote-desktop daemons (RustDesk, Screen Sharing,
+    ARD, …) so a remote session no longer pins you Online, while genuine
+    fullscreen video still suppresses auto-Away.
   - [`GroupSession.swift`](../apps/macos/Sources/MunkelApp/GroupSession.swift) —
     one joined circle: holds its `RelayClient`, seals/opens payloads, tracks
     presence and each member's status, and exchanges `profile` payloads. This is
@@ -250,8 +256,10 @@ TypeScript reference sender is
 - **Application payloads** (inside the encrypted blob, invisible to the relay):
   a `kind`-discriminated JSON object — `chat` (`text`, `sentAt`), `profile`
   (`displayName`, optional base64 `avatar`, optional `status` of
-  `online` | `dnd` | `away`), or `image` (1–8 `items`, shared `caption`,
-  `sentAt`; each item is an `r2Key` pointer plus an inline AVIF `thumb`). See
+  `online` | `dnd` | `away`), `presence` (`status` only — a lightweight delta
+  sent when a member's status changes, so a flip needn't re-send the avatar),
+  or `image` (1–8 `items`, shared `caption`, `sentAt`; each item is an `r2Key`
+  pointer plus an inline AVIF `thumb`). See
   [`AppPayload.swift`](../apps/macos/Sources/MunkelKit/AppPayload.swift).
 
 ### Image blobs (R2)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,8 +65,8 @@ and relay connections; the CLI and the UI are clients of it. Source layout under
     resolves circle/recipient names for the CLI.
   - [`GroupSession.swift`](../apps/macos/Sources/MunkelApp/GroupSession.swift) —
     one joined circle: holds its `RelayClient`, seals/opens payloads, tracks
-    presence, and exchanges `profile` payloads. This is where send and receive
-    are wired end-to-end.
+    presence and each member's status, and exchanges `profile` payloads. This is
+    where send and receive are wired end-to-end.
   - [`NotchPanel/`](../apps/macos/Sources/MunkelApp/NotchPanel) +
     [`NotchPresenter.swift`](../apps/macos/Sources/MunkelApp/NotchPresenter.swift)
     — the notch display: a borderless `NotchPanelWindow` shaped to the physical
@@ -210,8 +210,11 @@ and [`blob.ts`](../apps/server/src/blob.ts)).
    payload that fails to decrypt or decode is dropped, not surfaced.
 3. The decoded `AppPayload` is dispatched: `chat` text and `image` albums are
    shown in the notch via `NotchPanel` / `NotchPresenter`; `profile` payloads
-   update the sender's display name and avatar locally. Full-resolution images
-   are fetched and decrypted from R2 lazily, on demand, keyed by `r2Key`.
+   update the sender's display name, avatar, and presence status locally. When
+   the local user's own status is Do Not Disturb or Away, the proactive notch
+   preview is suppressed and the message lands silently in the 60 s history.
+   Full-resolution images are fetched and decrypted from R2 lazily, on demand,
+   keyed by `r2Key`.
 4. Messages live only in memory and only for the notch-survival window
    (~60 s); there is no history and nothing is written to disk. See
    [`GroupSession.handleIncoming`](../apps/macos/Sources/MunkelApp/GroupSession.swift).
@@ -246,9 +249,9 @@ TypeScript reference sender is
   closes connections idle for more than 120 s.
 - **Application payloads** (inside the encrypted blob, invisible to the relay):
   a `kind`-discriminated JSON object — `chat` (`text`, `sentAt`), `profile`
-  (`displayName`, optional base64 `avatar`), or `image` (1–8 `items`, shared
-  `caption`, `sentAt`; each item is an `r2Key` pointer plus an inline AVIF
-  `thumb`). See
+  (`displayName`, optional base64 `avatar`, optional `status` of
+  `online` | `dnd` | `away`), or `image` (1–8 `items`, shared `caption`,
+  `sentAt`; each item is an `r2Key` pointer plus an inline AVIF `thumb`). See
   [`AppPayload.swift`](../apps/macos/Sources/MunkelKit/AppPayload.swift).
 
 ### Image blobs (R2)


### PR DESCRIPTION
Closes #103

Adds member presence modes (Online / Do Not Disturb / Away) to the macOS app: a colored status dot on every avatar plus three modes that change recipient-side presentation without touching delivery or ephemerality.

## What changed

**Data / wire (MunkelKit)**
- New `PresenceStatus` enum (`online` / `dnd` / `away`).
- `AppPayload.profile` carries an optional `status`; absent or unknown decodes to `.online`, so it is backward- and forward-compatible. Mirrored in `dev-send.ts`, `dev-image.ts`, and the `protocol.ts` spec. `WireMessage.swift` is unchanged (opaque payload).

**Session**
- `GroupSession.Member.status` (set from the incoming profile); `GroupSession.localStatus` is sent by `sendProfile()`.

**Presence engine (AppModel)**
- `localStatus` (manual base, persisted) + `isAutoAway` → computed `effectiveStatus`. Auto-Away overlays **only** an Online base; manual DND/Away is sticky.
- Idle detection: 30 s `CGEventSourceSecondsSinceLastEventType` poll (5 min threshold), `NSWorkspace` sleep/wake/switch acceleration, and an `IOPMCopyAssertionsStatus` guard so watching a video does not flip you Away. No Accessibility / Input-Monitoring prompt (it is a timestamp read, and the app is unsandboxed).
- Status broadcasts only on change.

**Recipient-side suppression (NotchPresenter)**
- When the local user is DND/Away, incoming messages skip the proactive notch teaser and land in the 60 s RAM history; hovering the unread indicator reveals them (full message + history, reply intact). Delivery and ephemerality are unchanged — nothing is buffered or persisted.

**UI**
- `AvatarView` gains an optional status-dot overlay (green/orange/red).
- Menu footer: the label is just the display name; a status combo (reusing the dot colors) sits on the right where Sign out was; the self-avatar shows the effective status.
- Sign out moved into the gear menu, directly above Quit.
- Status dots on the menu roster (`recipientRow`) and the quick-send palette chips.

**Docs**: PRIVACY (presence reveals coarse at-the-keyboard activity to peers; persisted status), ARCHITECTURE (profile payload + receive dispatch), SECURITY (self-asserted status + local-data inventory).

## How it was built

Mapped the affected subsystems with a parallel multi-agent pass, implemented against the verified line map, then ran an adversarial multi-agent review (6 dimensions, each finding independently refuted or confirmed). Four findings were confirmed and fixed: a double profile-broadcast on one manual transition, an Online→Away flap after wake-from-sleep, and — the important one — DND/Away messages were suppressed but not revealable on hover (now wired through the unread indicator). The three fixes were re-verified by independent agents.

## Test plan

Automated (green):
- [x] `swift build` + `swift test` — 64 tests, incl. new `AppPayload` status round-trip, missing-status-defaults-online, unknown-status-defaults-online, and the Swift↔TS crypto interop vector
- [x] CLI `bun test` (21), server `vitest run` incl. e2e (31), server `tsc` typecheck

Manual (needs a GUI run — TODO before marking ready):
- [ ] Status combo switches Online / DND / Away; self dot and peers' dots update live
- [ ] DND/Away: an incoming message does **not** pop the teaser; the unread indicator appears; hovering it reveals the message + history; a reply still sends
- [ ] Idle ≥ 5 min flips to Away and reverts on return; video playback does not trigger Away; manual DND stays DND while idle
- [ ] Sign out lives in the gear menu above Quit; the footer shows just the name
- [ ] Capture check: status dots stay hidden from screen recordings (no tooltips in notch content)
