### PR TITLE
Morph the notch between message and unread anchor

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -5,8 +5,33 @@ import SwiftUI
 /// Drives the in-place morph between the one-line teaser, the full message
 /// view and the inline reply field inside a single expanded notch, plus the
 /// shared copied-feedback state.
+/// Whether the notch is showing the message (teaser/expanded) or has morphed
+/// down to the small unread anchor dot. Same panel, same instance — only the
+/// mode flips, so the shape animates between the two sizes seamlessly.
+enum NotchDisplayMode { case message, indicator }
+
 @MainActor
 final class MessageDisplayModel: ObservableObject {
+    @Published var mode: NotchDisplayMode = .message
+    /// The message this notch is presenting. Model-driven so a new message can
+    /// morph the SAME panel (update + animate) instead of tearing it down.
+    @Published var message: IncomingMessage
+    /// Identity of the current message (its history-entry id). Changing it gives
+    /// the message subtree a new identity so SwiftUI slides the new message in
+    /// and the old one out, instead of silently swapping the content in place.
+    @Published var messageToken = UUID()
+    /// Hardware notch cutout size for the panel's screen; .zero on no-notch Macs.
+    @Published var notchSize: CGSize = .zero
+    /// Per-message callbacks, owned here so the persistent container always
+    /// reaches the current message's handlers after a morph (set by NotchPresenter).
+    var onReply: (_ text: String, _ images: [Data], _ privately: Bool) -> Void = { _, _, _ in }
+    var onCancelReply: () -> Void = {}
+    var onPickFile: () -> Void = {}
+    var onTeaserFinished: () -> Void = {}
+    /// Anchor-dot countdown ring: 1 when the newest message just arrived, 0 when
+    /// it is about to age out (and the whole history vanishes). Driven once a
+    /// second by NotchPresenter's prune loop; only visible in `.indicator` mode.
+    @Published var anchorProgress: Double = 1
     @Published var fullyExpanded = false
     @Published var copied = false
     /// Decrypted full-resolution bytes per album image (keyed by r2Key),
@@ -91,6 +116,33 @@ final class MessageDisplayModel: ObservableObject {
     weak var historyMarker: NSView?
     weak var replyMarker: NSView?
     weak var teaserMarker: NSView?
+
+    init(message: IncomingMessage) {
+        self.message = message
+    }
+
+    /// Clear per-message transient state when the SAME model is reused for a new
+    /// message (the morph path). Animated fields (mode / fullyExpanded / the
+    /// panel's bottom inset) are flipped by NotchPresenter inside the morph
+    /// animation, not here, so the shape grows smoothly instead of snapping. The
+    /// click markers are left alone: they follow the message subtree's lifecycle
+    /// (gone in dot mode, re-registered when it reappears).
+    func resetTransient() {
+        clearPreview()
+        copied = false
+        replying = false
+        replySent = false
+        fullImages = [:]
+        failedImages = []
+        attachedImages = []
+        historyExpanded = false
+        copiedHistoryID = nil
+        copiedImageID = nil
+        hoveredHistoryID = nil
+        hoveredImageID = nil
+        historyCopyTargets = []
+        imageCopyTargets = []
+    }
 
     func copy(_ text: String) {
         writePasteboard(text)
@@ -285,20 +337,23 @@ final class ImageCopyTarget {
 /// the notch. Hovering swells everything into the full message view.
 struct MessageNotchContainer: View {
     @ObservedObject var model: MessageDisplayModel
-    let message: IncomingMessage
+
+    // Everything below reads from the model so a new message can morph this same
+    // view in place (no rebuild). NotchPresenter sets them on display / morph.
+    private var message: IncomingMessage { model.message }
     /// Hardware notch cutout size, measured from NSScreen; .zero on Macs
     /// without a notch (the panel then uses its floating style).
-    let notchSize: CGSize
+    private var notchSize: CGSize { model.notchSize }
     /// Called with the trimmed reply text, any staged images, and whether it
     /// goes privately to the sender (true) or to the whole circle; the
     /// images-vs-text routing happens in AppModel.
-    var onReply: (_ text: String, _ images: [Data], _ privately: Bool) -> Void
-    var onCancelReply: () -> Void
+    private var onReply: (_ text: String, _ images: [Data], _ privately: Bool) -> Void { model.onReply }
+    private var onCancelReply: () -> Void { model.onCancelReply }
     /// Opens the file picker (NSOpenPanel) to attach image files from disk —
     /// driven by NotchPresenter so it can suspend the outside-click dismiss
     /// while the modal is up. ⌘V paste is handled in-view (see pasteMonitor).
-    var onPickFile: () -> Void
-    var onTeaserFinished: () -> Void
+    private var onPickFile: () -> Void { model.onPickFile }
+    private var onTeaserFinished: () -> Void { model.onTeaserFinished }
 
     @State private var draft = ""
     /// Local ⌘V monitor, armed only while the reply field is focused (MenuView
@@ -318,54 +373,33 @@ struct MessageNotchContainer: View {
 
     var body: some View {
         Group {
-            if model.fullyExpanded {
-                // Same width as the teaser: hovering only grows downward.
-                VStack(alignment: .leading, spacing: 6) {
-                    MessageNotchView(message: message, model: model)
-                        // Reply opens only from a click on the current
-                        // message itself, not anywhere on the shape.
-                        .background(AreaMarker { [weak model] in model?.replyMarker = $0 })
-                        // Expanded, the copy button travels down to sit on
-                        // the message it copies. It copies the text/caption;
-                        // pictures are copied per-image via the cell glyphs, so
-                        // a captionless image message hides it (see
-                        // showsMessageCopyButton).
-                        .overlay(alignment: .topTrailing) {
-                            if showsMessageCopyButton {
-                                CopyMessageButton(copied: model.copied, diameter: avatarSize) {
-                                    copyCurrent()
-                                }
-                                .padding(.top, 2)
-                                .padding(.trailing, 4)
-                            }
-                        }
-                    if model.replySent {
-                        sentConfirmation
-                    } else if model.replying {
-                        if !model.attachedImages.isEmpty {
-                            attachmentStrip
-                        }
-                        replyField
-                    }
-                    if !model.history.isEmpty {
-                        historyRows
-                    }
-                }
-                .frame(width: tickerWindow, alignment: .leading)
-            } else if notchSize.height > 0 {
-                notchedTeaser
+            if model.mode == .indicator {
+                // Morphed down to the unread anchor ring (same panel, same
+                // instance) — the shape animates from the message to this.
+                UnreadIndicatorView(notchSize: notchSize, progress: model.anchorProgress)
             } else {
-                fallbackTeaser
+                messageContent
+                    // A new message gets a new identity (messageToken), so it
+                    // slides in from the top while the previous one fades out —
+                    // a deliberate "new message" motion, not a silent swap. The
+                    // removal stays a plain fade so collapsing to the dot keeps
+                    // its smooth shrink.
+                    .id(model.messageToken)
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .top).combined(with: .opacity),
+                        removal: .opacity
+                    ))
             }
         }
-        // Never narrower than the expanded state: otherwise short
-        // content can shrink the shape until it hides behind the
-        // hardware notch.
-        .frame(minWidth: tickerWindow, alignment: .leading)
+        // Pin the width constant across every state (teaser, expanded, dot) so
+        // the message<->dot morph is a pure vertical grow/shrink: with a mere
+        // minWidth the content swap briefly re-measures down to the floor and
+        // the shape flickers narrow before the new message sets its width.
+        .frame(width: tickerWindow, alignment: .leading)
         // In the teaser the copy button sits in the strip right of the
         // cutout; expanded it moves onto the message itself (see above).
         .overlay(alignment: .topTrailing) {
-            if !model.fullyExpanded, showsMessageCopyButton {
+            if model.mode == .message, !model.fullyExpanded, showsMessageCopyButton {
                 CopyMessageButton(copied: model.copied, diameter: avatarSize) {
                     copyCurrent()
                 }
@@ -375,6 +409,7 @@ struct MessageNotchContainer: View {
         // Click-anywhere-to-reply is handled by an AppKit event monitor in
         // NotchPresenter — a SwiftUI tap gesture here would lose the first
         // click to window activation.
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: model.mode)
         .animation(.spring(response: 0.35, dampingFraction: 0.75), value: model.fullyExpanded)
         .animation(.spring(response: 0.35, dampingFraction: 0.75), value: model.replying)
         .animation(.spring(response: 0.35, dampingFraction: 0.75), value: model.replySent)
@@ -394,6 +429,51 @@ struct MessageNotchContainer: View {
         // their own window, which cannot inherit the exclusion and would
         // surface in a share while the notch itself is invisible.
         .excludedFromScreenCapture()
+    }
+
+    /// The message states (teaser / expanded / no-notch fallback). Extracted so
+    /// it can carry a per-message identity + slide transition, so a new message
+    /// animates in instead of swapping its content in place.
+    @ViewBuilder private var messageContent: some View {
+        if model.fullyExpanded {
+            // Same width as the teaser: hovering only grows downward.
+            VStack(alignment: .leading, spacing: 6) {
+                MessageNotchView(message: message, model: model)
+                    // Reply opens only from a click on the current
+                    // message itself, not anywhere on the shape.
+                    .background(AreaMarker { [weak model] in model?.replyMarker = $0 })
+                    // Expanded, the copy button travels down to sit on
+                    // the message it copies. It copies the text/caption;
+                    // pictures are copied per-image via the cell glyphs, so
+                    // a captionless image message hides it (see
+                    // showsMessageCopyButton).
+                    .overlay(alignment: .topTrailing) {
+                        if showsMessageCopyButton {
+                            CopyMessageButton(copied: model.copied, diameter: avatarSize) {
+                                copyCurrent()
+                            }
+                            .padding(.top, 2)
+                            .padding(.trailing, 4)
+                        }
+                    }
+                if model.replySent {
+                    sentConfirmation
+                } else if model.replying {
+                    if !model.attachedImages.isEmpty {
+                        attachmentStrip
+                    }
+                    replyField
+                }
+                if !model.history.isEmpty {
+                    historyRows
+                }
+            }
+            .frame(width: tickerWindow, alignment: .leading)
+        } else if notchSize.height > 0 {
+            notchedTeaser
+        } else {
+            fallbackTeaser
+        }
     }
 
     /// What else arrived in the last minute, dimmed and compact below the

--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchHostingContent.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchHostingContent.swift
@@ -97,7 +97,7 @@ struct NotchHostingContent<Content: View>: View {
             }
         }
         .safeAreaInset(edge: .top, spacing: 0) { Color.clear.frame(height: owner.notchSize.height) }
-        .safeAreaInset(edge: .bottom, spacing: 0) { Color.clear.frame(height: safeAreaInset) }
+        .safeAreaInset(edge: .bottom, spacing: 0) { Color.clear.frame(height: owner.suppressBottomInset ? 0 : safeAreaInset) }
         .safeAreaInset(edge: .leading, spacing: 0) { Color.clear.frame(width: safeAreaInset) }
         .safeAreaInset(edge: .trailing, spacing: 0) { Color.clear.frame(width: safeAreaInset) }
         .frame(minWidth: owner.notchSize.width)

--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchPanel.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchPanel.swift
@@ -50,7 +50,14 @@ final class NotchPanel<Content: View>: ObservableObject {
     var transitionConfiguration = TransitionConfiguration()
     let content: Content
 
-    var floatingOverlay: AnyView?
+    /// @Published so swapping it on a morph (a new image message reusing the
+    /// same panel) re-renders the Quick-Look preview for the new album.
+    @Published var floatingOverlay: AnyView?
+
+    /// Drop the chrome's bottom inset so the shape stays at menu-bar height in
+    /// indicator mode. @Published so flipping it (inside withAnimation) animates
+    /// the bottom strip in lockstep with the message<->dot morph.
+    @Published var suppressBottomInset = false
 
     private let hoverBehavior: HoverBehavior
     private let targetScreen: @MainActor () -> NSScreen?

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -13,12 +13,10 @@ import UniformTypeIdentifiers
 @MainActor
 final class NotchPresenter {
     private typealias MessageNotch = NotchPanel<MessageNotchContainer>
-    private typealias IndicatorNotch = NotchPanel<UnreadIndicatorView>
     private typealias AuthCodeNotch = NotchPanel<AuthCodeNotchView>
 
     private var currentNotch: MessageNotch?
     private var currentModel: MessageDisplayModel?
-    private var indicatorNotch: IndicatorNotch?
     private var authCodeNotch: AuthCodeNotch?
     /// Serializes auth-code show/hide so a hide fully tears its panel down
     /// before the next show builds one — a quick cancel→re-login would
@@ -28,8 +26,6 @@ final class NotchPresenter {
     private var pruneTask: Task<Void, Never>?
     private var hoverObservation: AnyCancellable?
     private var hoverCopyObservation: AnyCancellable?
-    /// Observes hover on the unread indicator to dismiss it.
-    private var indicatorHoverObservation: AnyCancellable?
     private var clickMonitor: Any?
     private var outsideClickMonitor: Any?
     /// While a modal file picker (NSOpenPanel) is up, its in-process clicks
@@ -37,7 +33,6 @@ final class NotchPresenter {
     /// collapse the open reply. Set during pickImageFile to suppress the
     /// dismiss, mirroring CommandPalettePresenter.suppressResignHide.
     private var suppressReplyDismiss = false
-    private var userInteractedWithMessage = false
 
     /// RAM-only message history shown in the expanded notch: everything
     /// younger than this window, deleted afterwards (also live on screen).
@@ -51,7 +46,6 @@ final class NotchPresenter {
     private var currentEntryID: UUID?
     private var notchVisible = false
 
-    private let afterTeaserDelay: Duration = .seconds(2)
     private let afterReadDelay: Duration = .seconds(1)
 
     init() {
@@ -67,13 +61,15 @@ final class NotchPresenter {
         KeyboardShortcuts.disable(.copyHoveredHistory)
     }
 
-    /// Upper bound in case the teaser never reports completion — sized to
-    /// the text so long messages aren't cut off mid-scroll. Rough estimate:
-    /// ~7pt per character at the ticker's font, scrolling at 24pt/s through
-    /// a 250pt window, plus generous start/finish buffers.
-    private func safetyDuration(for text: String) -> Duration {
-        let scrollSeconds = max(0, (Double(text.count) * 7 - 250) / 24)
-        return .seconds(min(90, 10 + scrollSeconds))
+    /// How long a freshly shown message stays before collapsing to the anchor.
+    /// One formula for every path (first message OR a morphed-in new one) so the
+    /// on-screen time is consistent instead of riding on the teaser's scroll
+    /// completion. Lightly scaled by length, tightly bounded; the full text is
+    /// always reachable by hovering (which cancels the hide).
+    private func displayDuration(for message: IncomingMessage) -> Duration {
+        if message.isImage { return .seconds(6) }
+        let seconds = min(8, max(4, 3 + Double(message.text.count) * 0.04))
+        return .seconds(seconds)
     }
 
     func show(
@@ -163,65 +159,41 @@ final class NotchPresenter {
             guard generation == showGeneration else { return }
         }
 
-        hideTask?.cancel()
-        hoverObservation = nil
-        removeClickMonitors()
-        turnOffHoverCopy()
-        hideIndicator()
-        if let previous = currentNotch {
-            // hide() collapses immediately; afterwards a newer message may
-            // already have taken over.
-            await previous.hide()
-            guard generation == showGeneration else { return }
-        }
-        userInteractedWithMessage = false
-
-        let model = MessageDisplayModel()
-        // Replies default to the channel the message came in on.
-        model.replyPrivately = message.isDirect
-        // Per-image loaders the grid cells call on appear (lazy full fetch).
-        if let loadFull {
-            var loaders: [String: @Sendable () async -> Data?] = [:]
-            for image in message.images {
-                let id = image.id
-                loaders[id] = { await loadFull(id) }
-            }
-            model.imageLoaders = loaders
-        }
-        // The expanded state shows what else arrived in the last minute
-        // before this message.
         pruneHistory()
-        model.history = visibleHistory(excluding: entryID)
-        currentEntryID = entryID
-        currentModel = model
-        // The hover-"C" shortcut copies this when the pointer isn't over a
-        // history row (see MessageDisplayModel.copyHovered).
-        model.currentText = message.text
 
-        // The display chosen in Settings (or the active screen when set to
-        // automatic / the chosen one is unplugged). One measurement drives both
-        // panel placement and content layout.
+        // A panel is already up (a message or the anchor dot): morph it to the
+        // new message in place — no teardown, no respawn. The new message slides
+        // in from the top while the old one pushes out the bottom (the content
+        // transition keyed by `messageToken` in MessageNotchContainer), so it
+        // reads as a deliberate new message rather than a silent swap.
+        if let notch = currentNotch, let model = currentModel {
+            hideTask?.cancel()
+            currentEntryID = entryID
+            withAnimation(.spring(response: 0.42, dampingFraction: 0.82)) {
+                configure(model, for: message, notchSize: model.notchSize, entryID: entryID, loadFull: loadFull, onReply: onReply)
+                notch.floatingOverlay = message.isImage
+                    ? AnyView(ImagePreviewOverlay(model: model, images: message.images))
+                    : nil
+                model.mode = .message
+                model.fullyExpanded = false
+                notch.suppressBottomInset = false
+            }
+            scheduleHide(of: notch, after: displayDuration(for: message))
+            return
+        }
+
+        // No panel yet: build a fresh one. The display chosen in Settings (or
+        // the active screen when automatic / the chosen one is unplugged); one
+        // measurement drives both panel placement and content layout.
         let targetScreen: @MainActor () -> NSScreen? = { DisplayPreference.resolvedScreen() }
         let notchSize = NotchScreenMetrics.metrics(for: targetScreen()).notchSize
+        let model = MessageDisplayModel(message: message)
+        configure(model, for: message, notchSize: notchSize, entryID: entryID, loadFull: loadFull, onReply: onReply)
+        currentEntryID = entryID
+        currentModel = model
+
         let notch = NotchPanel(hoverBehavior: .all, targetScreen: targetScreen) {
-            MessageNotchContainer(
-                model: model,
-                message: message,
-                notchSize: notchSize,
-                onReply: { [weak self] reply, images, privately in
-                    onReply(reply, images, privately)
-                    self?.replyWasSent()
-                },
-                onCancelReply: { [weak self] in
-                    self?.cancelReply()
-                },
-                onPickFile: { [weak self, weak model] in
-                    guard let self, let model else { return }
-                    self.pickImageFile(model: model)
-                }
-            ) { [weak self] in
-                self?.teaserFinished()
-            }
+            MessageNotchContainer(model: model)
         }
         notch.transitionConfiguration = .init(
             openingAnimation: .spring(response: 0.6, dampingFraction: 0.7),
@@ -244,14 +216,20 @@ final class NotchPresenter {
                 guard let self, let notch else { return }
                 Task { @MainActor in
                     if hovering {
-                        self.userInteractedWithMessage = true
-                        self.hideTask?.cancel()
-                        // Animate the teaser→expanded morph explicitly: the
-                        // implicit `.animation(value:)` inside MessageNotchContainer
-                        // isn't honored through the NSHostingView host, so the
-                        // expand would otherwise snap open without a transition.
-                        withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
-                            self.currentModel?.fullyExpanded = true
+                        // In anchor-dot mode, hover morphs the same panel back up
+                        // to the message + history; otherwise it expands the
+                        // teaser.
+                        if self.currentModel?.mode == .indicator {
+                            self.reopenFromIndicator(notch)
+                        } else {
+                            self.hideTask?.cancel()
+                            // Animate the teaser→expanded morph explicitly: the
+                            // implicit `.animation(value:)` inside MessageNotchContainer
+                            // isn't honored through the NSHostingView host, so the
+                            // expand would otherwise snap open without a transition.
+                            withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                                self.currentModel?.fullyExpanded = true
+                            }
                         }
                     } else {
                         // Leaving the notch entirely dismisses the hover image
@@ -292,24 +270,74 @@ final class NotchPresenter {
         notch.panel?.sharingType = NSWindow.munkelCaptureSharingType
         notchVisible = true
         installClickMonitors(for: notch, model: model)
-        startHistoryPruning(model: model)
+        startHistoryPruning()
 
         // Album images load lazily per grid cell (see AlbumCell) once the
         // notch is expanded — no eager fetch here.
 
-        // The text teaser sizes its safety timeout to the scroll length; an
-        // image teaser has no ticker, so give it a fixed generous window.
-        let safety: Duration = message.isImage ? .seconds(20) : safetyDuration(for: message.text)
-        scheduleHide(of: notch, after: safety)
+        scheduleHide(of: notch, after: displayDuration(for: message))
     }
 
-    /// Expires history entries live while the notch is on screen, so rows
-    /// vanish from the expanded view the moment they turn 60 seconds old.
-    private func startHistoryPruning(model: MessageDisplayModel) {
+    /// Point a (new or reused) model at `message`: its handlers, loaders,
+    /// history rows and reply channel, with all per-message transient state
+    /// reset. Used by both the first build and the in-place morph, so a new
+    /// message reaches the right reply target after the panel is reused.
+    private func configure(
+        _ model: MessageDisplayModel,
+        for message: IncomingMessage,
+        notchSize: CGSize,
+        entryID: UUID,
+        loadFull: (@Sendable (String) async -> Data?)?,
+        onReply: @escaping (_ text: String, _ images: [Data], _ privately: Bool) -> Void
+    ) {
+        model.resetTransient()
+        model.message = message
+        model.messageToken = entryID
+        model.notchSize = notchSize
+        // Replies default to the channel the message came in on.
+        model.replyPrivately = message.isDirect
+        // The hover-"C" shortcut copies this when the pointer isn't over a row.
+        model.currentText = message.text
+        // The expanded state shows what else arrived in the last minute.
+        model.history = visibleHistory(excluding: entryID)
+        // A fresh message refills the countdown ring (it is the newest entry).
+        model.anchorProgress = anchorFraction()
+
+        // Per-image loaders the grid cells call on appear (lazy full fetch).
+        var loaders: [String: @Sendable () async -> Data?] = [:]
+        if let loadFull {
+            for image in message.images {
+                let id = image.id
+                loaders[id] = { await loadFull(id) }
+            }
+        }
+        model.imageLoaders = loaders
+
+        model.onReply = { [weak self] reply, images, privately in
+            onReply(reply, images, privately)
+            self?.replyWasSent()
+        }
+        model.onCancelReply = { [weak self] in self?.cancelReply() }
+        model.onPickFile = { [weak self, weak model] in
+            guard let self, let model else { return }
+            self.pickImageFile(model: model)
+        }
+    }
+
+    /// One prune loop for the whole panel lifetime (message AND anchor-dot
+    /// modes): expires history entries live, keeps the visible rows fresh, and
+    /// when the buffer finally empties it tears the panel down — so the dot
+    /// disappears the instant there is nothing left to reopen.
+    private func startHistoryPruning() {
         pruneTask?.cancel()
-        pruneTask = Task { [weak self, weak model] in
-            while !Task.isCancelled, let self, let model {
+        pruneTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self, let model = self.currentModel, let notch = self.currentNotch else { return }
                 self.pruneHistory()
+                if self.history.isEmpty {
+                    await self.tearDownNotch(notch)
+                    return
+                }
                 if let id = self.currentEntryID {
                     let visible = self.visibleHistory(excluding: id)
                     if model.history != visible {
@@ -318,9 +346,23 @@ final class NotchPresenter {
                         }
                     }
                 }
+                // Re-target the anchor ring every second; the linear animation
+                // matches the tick, so the arc depletes as one smooth countdown.
+                withAnimation(.linear(duration: 1)) {
+                    model.anchorProgress = self.anchorFraction()
+                }
                 try? await Task.sleep(for: .seconds(1))
             }
         }
+    }
+
+    /// Fraction of the 60s window the NEWEST history entry has left — drives the
+    /// anchor ring. The newest entry is the last to expire, so this is how long
+    /// the whole history stays on screen before it vanishes.
+    private func anchorFraction() -> Double {
+        guard let newest = history.last else { return 0 }
+        let remaining = historyWindow - Date().timeIntervalSince(newest.receivedAt)
+        return max(0, min(1, remaining / historyWindow))
     }
 
     /// Everything in the buffer except the message that's currently
@@ -344,9 +386,14 @@ final class NotchPresenter {
     private func installClickMonitors(for notch: MessageNotch, model: MessageDisplayModel) {
         clickMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseDown) { [weak self, weak notch, weak model] event in
             MainActor.assumeIsolated {
-                guard let self, let model, let panel = notch?.panel else { return }
+                guard let self, let model, let notch, let panel = notch.panel else { return }
                 if event.window === panel {
-                    self.userInteractedWithMessage = true
+                    // Anchor-dot mode: any click on the shape reopens the
+                    // history (morph back up), skipping the marker logic.
+                    if model.mode == .indicator {
+                        self.reopenFromIndicator(notch)
+                        return
+                    }
                     // hitTest is useless here (NSHostingView returns
                     // itself wherever SwiftUI content covers the marker),
                     // so clicks are matched against the marker frames via
@@ -482,8 +529,6 @@ final class NotchPresenter {
 
     private func replyWasSent() {
         guard let notch = currentNotch, let model = currentModel else { return }
-        userInteractedWithMessage = true
-        hideIndicator()
         withAnimation(.spring(duration: 0.3)) {
             model.replying = false
             model.replySent = true
@@ -492,66 +537,68 @@ final class NotchPresenter {
         scheduleHide(of: notch, after: .seconds(1.2))
     }
 
-    private func teaserFinished() {
-        guard let notch = currentNotch, currentModel?.fullyExpanded != true else { return }
-        scheduleHide(of: notch, after: afterTeaserDelay)
-    }
-
     private func scheduleHide(of notch: MessageNotch, after delay: Duration) {
         hideTask?.cancel()
         hideTask = Task { [weak self, weak notch] in
             try? await Task.sleep(for: delay)
-            guard !Task.isCancelled, let notch else { return }
-            await notch.hide()
-            self?.notchVisible = false
-            self?.pruneTask?.cancel()
-            self?.turnOffHoverCopy()
-            if !(self?.userInteractedWithMessage ?? true) {
-                self?.showIndicator()
-            }
+            guard !Task.isCancelled, let self, let notch else { return }
+            await self.collapseOrAnchor(notch)
         }
     }
 
-    /// Show the unread indicator (blue dot) in the notch.
-    private func showIndicator() {
-        guard indicatorNotch == nil else { return }
-
-        let targetScreen: @MainActor () -> NSScreen? = { DisplayPreference.resolvedScreen() }
-        let indicator = IndicatorNotch(hoverBehavior: .all, targetScreen: targetScreen) {
-            UnreadIndicatorView()
+    /// When the notch would hide: if there is still history, morph the SAME
+    /// panel down to the unread anchor dot — no respawn, the shape just shrinks
+    /// to menu-bar height while staying as wide as the message. Otherwise tear
+    /// it down. The window, click/hover monitors and the prune loop all stay
+    /// alive across the morph, so reopening is instant and seamless.
+    private func collapseOrAnchor(_ notch: MessageNotch) async {
+        pruneHistory()
+        guard let model = currentModel, !history.isEmpty else {
+            await tearDownNotch(notch)
+            return
         }
-        indicator.transitionConfiguration = .init(
-            openingAnimation: .spring(response: 0.6, dampingFraction: 0.7),
-            skipIntermediateHides: true
-        )
-        indicatorNotch = indicator
-
-        indicatorHoverObservation = indicator.$isHovering
-            .filter { $0 }
-            .sink { [weak self, weak indicator] _ in
-                Task { @MainActor in
-                    guard let indicator else { return }
-                    await indicator.hide()
-                    self?.indicatorNotch = nil
-                    self?.indicatorHoverObservation = nil
-                }
-            }
-
-        Task {
-            await indicator.expand()
-            if let panel = indicator.panel {
-                panel.sharingType = NSWindow.munkelCaptureSharingType
-            }
+        model.clearPreview()
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+            model.fullyExpanded = false
+            model.replying = false
+            model.replySent = false
+            model.mode = .indicator
+            notch.suppressBottomInset = true
         }
     }
 
-    /// Hide the unread indicator.
-    private func hideIndicator() {
-        Task { [weak self] in
-            if let indicator = self?.indicatorNotch {
-                await indicator.hide()
-                self?.indicatorNotch = nil
+    /// Hover or click on the anchor dot reopens the history in the same panel:
+    /// morph back up to the message, expanded so the history rows show at once.
+    private func reopenFromIndicator(_ notch: MessageNotch) {
+        guard let model = currentModel, model.mode == .indicator else { return }
+        hideTask?.cancel()
+        // Refresh the rows up front: the 1s prune loop could be up to a second
+        // stale, so reopening would otherwise flash an outdated history.
+        pruneHistory()
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+            model.mode = .message
+            notch.suppressBottomInset = false
+            if let id = currentEntryID {
+                model.history = visibleHistory(excluding: id)
             }
+            model.fullyExpanded = true
+        }
+    }
+
+    /// Real teardown: collapse and close the window, stop the monitors and the
+    /// prune loop. Used when the history empties, a new message rebuilds, or the
+    /// auth-code panel preempts.
+    private func tearDownNotch(_ notch: MessageNotch) async {
+        hideTask?.cancel()
+        pruneTask?.cancel()
+        removeClickMonitors()
+        hoverObservation = nil
+        turnOffHoverCopy()
+        await notch.hide()
+        if currentNotch === notch {
+            currentNotch = nil
+            currentModel = nil
+            notchVisible = false
         }
     }
 
@@ -568,10 +615,12 @@ final class NotchPresenter {
             // state (startGitHubLogin sets `.requestingCode`), which runs
             // hideAuthCode and nils this first — so a fresh code always rebuilds.
             guard let self, self.authCodeNotch == nil else { return }
-            // The notch slot holds one panel: clear a stale unread indicator
-            // that could linger into a re-login. No message notch can race here
-            // — sessions are login-gated, so none are live mid-sign-in.
-            self.hideIndicator()
+            // The notch slot holds one panel: tear down a lingering message /
+            // anchor-dot panel so two windows never coexist. No live message can
+            // race here — sessions are login-gated, so none are up mid-sign-in.
+            if let notch = self.currentNotch {
+                await self.tearDownNotch(notch)
+            }
             let targetScreen: @MainActor () -> NSScreen? = { DisplayPreference.resolvedScreen() }
             let notch = AuthCodeNotch(hoverBehavior: .none, targetScreen: targetScreen) {
                 AuthCodeNotchView(code: code)

--- a/apps/macos/Sources/MunkelApp/UnreadIndicatorView.swift
+++ b/apps/macos/Sources/MunkelApp/UnreadIndicatorView.swift
@@ -1,19 +1,66 @@
 import SwiftUI
 
-/// Unread message indicator: a blue dot with black background shown in the
-/// notch when a message arrives but the user hasn't interacted with the app.
-/// Disappears on any interaction (hover, click, send).
+/// History anchor: a small white countdown ring (on a faint track) lifted into
+/// the black menu-bar strip beside the notch cutout, where a sender avatar sits
+/// for an incoming
+/// message. It widens the notch horizontally instead of growing it downward.
+/// Hovering or clicking it reopens the notch on the history (wired in
+/// NotchPresenter). The ring's arc depletes from full to empty as the newest
+/// message ages toward the 60s history window: when it empties, the whole
+/// history vanishes and the anchor tears down — so it reads as "this much time
+/// left before the chat disappears."
 struct UnreadIndicatorView: View {
+    /// Hardware cutout size; drives the horizontal width and the strip lift.
+    var notchSize: CGSize = .zero
+    /// 1 = the newest message just arrived (full ring), 0 = about to age out.
+    /// Driven once a second by NotchPresenter's prune loop.
+    var progress: Double = 1
+
+    private let ringSize: CGFloat = 11
+    private let ringWidth: CGFloat = 2.5
+
     var body: some View {
-        Circle()
-            .fill(Color.blue)
-            .frame(width: 12, height: 12)
-            .background(.black, in: Circle())
+        if notchSize.height > 0 {
+            // A flat 1pt strip. The hosting container imposes the message width
+            // (frame width: tickerWindow), so the dot mode is exactly as wide as
+            // a message and the morph is a pure vertical collapse at constant
+            // width. The panel drops its bottom inset, so no downward growth.
+            // The ring rides in the leading side zone — beside the cutout, where
+            // the sender avatar sits — lifted onto the menu-bar line.
+            Color.clear
+                .frame(width: notchSize.width, height: 1)
+                .overlay(alignment: .topLeading) {
+                    ring.offset(y: -(notchSize.height + ringSize) / 2)
+                }
+        } else {
+            // No-notch screens use the floating pill chrome; just show the ring.
+            ring.padding(2)
+        }
+    }
+
+    private var ring: some View {
+        ZStack {
+            // Faint track so the full circle stays legible the whole time — you
+            // always see it was once a complete ring.
+            Circle()
+                .stroke(Color.white.opacity(0.18), lineWidth: ringWidth)
+            // The depleting arc on top, fully white. Starts at 12 o'clock and
+            // shortens back toward there as it empties.
+            Circle()
+                .trim(from: 0, to: max(0, min(1, progress)))
+                .stroke(Color.white, style: StrokeStyle(lineWidth: ringWidth, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: ringSize, height: ringSize)
     }
 }
 
 #Preview {
-    UnreadIndicatorView()
-        .frame(width: 40, height: 40)
-        .background(Color.gray)
+    VStack(spacing: 20) {
+        UnreadIndicatorView(notchSize: CGSize(width: 200, height: 32), progress: 1)
+        UnreadIndicatorView(notchSize: CGSize(width: 200, height: 32), progress: 0.6)
+        UnreadIndicatorView(notchSize: CGSize(width: 200, height: 32), progress: 0.15)
+    }
+    .frame(width: 320, height: 160)
+    .background(Color.black)
 }


### PR DESCRIPTION
The message notch and the unread indicator used to be two separate windows. A message would fully hide and the dot would respawn, with a flash of the bare notch in between. They are now one persistent panel that morphs in place, so the shape just resizes.

While it sits idle it shows a white countdown ring on a faint track, bound to the newest message, so you can see how long the history stays visible. New messages slide in instead of swapping their content silently. And the on screen time is unified, so every message stays up for a consistent span (before it ranged from about a second to fifteen).

Tested locally with the dev build.