### PR TITLE
fix(macos): bound notch history image cache to the 60s ephemerality window

### DIFF
--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -362,6 +362,7 @@ final class NotchPresenter {
                     await self.tearDownNotch(notch)
                     return
                 }
+                self.pruneImageCache(of: model)
                 if let id = self.currentEntryID {
                     let visible = self.visibleHistory(excluding: id)
                     if model.history != visible {
@@ -398,6 +399,17 @@ final class NotchPresenter {
 
     private func pruneHistory() {
         history.removeAll { Date().timeIntervalSince($0.receivedAt) > historyWindow }
+    }
+
+    private func pruneImageCache(of model: MessageDisplayModel) {
+        let liveIDs = Set(model.imageLoaders.keys)
+            .union(history.flatMap { $0.images.map(\.id) })
+        if model.fullImages.contains(where: { !liveIDs.contains($0.key) }) {
+            model.fullImages = model.fullImages.filter { liveIDs.contains($0.key) }
+        }
+        if model.failedImages.contains(where: { !liveIDs.contains($0) }) {
+            model.failedImages = model.failedImages.intersection(liveIDs)
+        }
     }
 
     /// Click-anywhere-to-reply, at the AppKit level: the panel is not key


### PR DESCRIPTION
Closes #94

## Is it actually a bug?

**Yes — but narrower and lower-severity than the P1 text implies.** The issue was filed against pre-morph code; the notch-morph rewrite (#114) reuses one `MessageDisplayModel` across messages and `resetTransient()` now wipes `fullImages`/`failedImages` on every morph. So the *simple* version the issue describes ("cache survives until a new message rebuilds the model") is already gone on the common path.

What **does** still leak: two `show()` paths reuse the model **without** `resetTransient()` —

- **live-absorb** (`NotchPresenter.swift:127`): a new message arriving while the notch is expanded is appended to history and the call returns before `display()`/`configure()`;
- **silent / anchor-dot** (`:135`): a silent update in indicator mode.

On both, expanded-history albums decrypt full-res bytes into `fullImages`, but `pruneHistory()` only expired the **rows** — never the cache. So an album's decrypted plaintext outlived its 60s row, freed only on the next morph (`resetTransient`) or full teardown (history empties → `tearDownNotch` nils the model). Under a sustained stream that keeps the panel alive, the practical lifetime is "~60s past the *last* message," i.e. arbitrarily far past an individual image's own window.

It is RAM-only (never hits disk), capture-excluded (`sharingType = .none`), and collapses the instant the pointer leaves the notch or a morph occurs. Hence **low severity** — but for a product whose core promise is ephemerality, the history tier shouldn't hold plaintext past its window.

## Fix

`pruneImageCache(of:)`, called each second in the existing prune loop, bounds the byte caches to the same window as the rows that reference them:

```swift
let liveIDs = Set(model.imageLoaders.keys)
    .union(history.flatMap { $0.images.map(\.id) })
```

- **Current message** is keyed off `imageLoaders.keys`, **not** the history array — so the displayed picture is retained even after its own `HistoryEntry` ages out at 60s (the main view still renders `model.message`). Deriving it from history instead would evict the on-screen image → spinner regression.
- **History** images are retained only while their (already-pruned-to-60s) row is live.
- `.contains(where:)` guards avoid reassigning the `@Published` caches every second when nothing changed (no needless re-render).

**Intentional, by design:** an *actively displayed* image's bytes outlive the 60s history window for as long as it is on screen (or reopenable from the anchor dot) — it is the active message, not history. Freed on the next morph or teardown.

The issue's second proposed fix (clear caches in `scheduleHide`) is **dropped as obsolete**: post-#114, `scheduleHide` morphs to the anchor dot and keeps the model alive for reopen; the real teardown (`tearDownNotch`) already nils `currentModel` and frees the cache.

## Verification

- `swift build` (apps/macos) — ✅ clean.
- Adversarial review (7 independent agents): **3× approve, 0 blocking**; confirmed `liveIDs` correctness, the displayed-message edge case, no flicker (a still-visible cell's id is always in `liveIDs`, so never evicted; a previewed row that expires drops out of `resolvedImages` and the card fades rather than showing a spinner), no race (`@MainActor`), no retain cycle.
- No automated coverage: `NotchPresenter`/`MessageDisplayModel` live in the `MunkelApp` bundle target (Swift Bundler), unreachable from `MunkelKitTests` — see issue #94's optional item on extracting a pure helper into MunkelKit.

## Test plan (manual)

- [ ] Send an image album; hover to expand history and load full-res. Keep receiving messages while hovering; after >60s confirm the *expired* album's row is gone and its bytes no longer linger (no leak), while the currently displayed image stays crisp (no spinner/flicker).
- [ ] Collapse to the anchor dot, let history empty (~60s idle) → notch tears down, caches freed.
- [ ] Re-expand a still-live history album → no flicker, full-res still loads.

## Not in scope (issue's optional items)

Thumb-decode-on-cache-hit, `loadFull == nil` defensive glyph, the `HistoryEntry.==` note (would violate the no-comments convention anyway), and extracting a unit-testable `historyLabel(...)` into MunkelKit — left for a follow-up.