### PR TITLE
fix(macos): paste, select all, emoji in inputs

### DIFF
--- a/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteView.swift
@@ -161,6 +161,11 @@ struct CommandPaletteView: View {
                 TextField(placeholder, text: $state.message)
                     .textFieldStyle(.plain)
                     .font(.system(size: 15))
+                    // Single line that scrolls internally, clipped to its slot,
+                    // so a long draft can't push the field editor past the box.
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .clipped()
                     .focused($focused)
                     .onSubmit(send)
                     .onExitCommand(perform: onClose)

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -469,9 +469,16 @@ private struct FrostedField: ViewModifier {
     func body(content: Content) -> some View {
         content
             .textFieldStyle(.plain)
+            // Single line that scrolls internally — without this a long draft
+            // grows the field editor and spills the text past the box.
+            .lineLimit(1)
             .focused($focused)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 8)
             .padding(.vertical, 5)
+            // Clip the (already single-line) field to its box so a long draft
+            // that overruns the field editor can't spill past the rounded edge.
+            .clipShape(RoundedRectangle(cornerRadius: 7))
             // White tint over the material lightens it while keeping the
             // translucency — gently in dark mode, where 35% white would
             // turn the fields into gray slabs.

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -584,9 +584,14 @@ struct MessageNotchContainer: View {
                 .font(.system(size: 13))
                 .foregroundStyle(.white)
                 .tint(.white)
+                // Single line that scrolls internally; clipped to the field so a
+                // long reply can't spill out past the box's rounded edge.
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 5)
                 .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 7))
+                .clipShape(RoundedRectangle(cornerRadius: 7))
                 .focused($replyFocused)
                 .onChange(of: draft) { _, new in
                     if new.count > MessageLimits.maxCharacters {

--- a/apps/macos/Sources/MunkelApp/MunkelApp.swift
+++ b/apps/macos/Sources/MunkelApp/MunkelApp.swift
@@ -21,10 +21,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         // Accessory: no Dock icon — menu bar item and notch are the only UI.
         NSApp.setActivationPolicy(.accessory)
 
-        // An accessory app gets no main menu, so the standard editing shortcuts
-        // (⌘X/⌘C/⌘V/⌘A) are never routed to the focused text field's responder.
-        // A minimal, never-displayed Edit menu wires them back up app-wide.
-        installEditMenu()
+        // An accessory app gets no main menu, so the standard editing actions
+        // (⌘X/⌘C/⌘V/⌘A and the emoji picker) are never routed to the focused
+        // text field's responder. A standard, never-displayed menu wires them
+        // back up app-wide.
+        installMainMenu()
 
         let model = AppModel()
         self.model = model
@@ -70,18 +71,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         statusItem = item
     }
 
-    /// A minimal Edit menu so Cut/Copy/Paste/Select All reach the first
-    /// responder (the focused text field).
-    private func installEditMenu() {
+    /// A standard (never-displayed) main menu so the editing actions reach the
+    /// first responder — the focused field editor. The App and Edit submenus are
+    /// both present: AppKit only routes the Edit-menu key equivalents and the
+    /// emoji picker properly when the menu is shaped the conventional way. The
+    /// "Emoji & Symbols" item (⌃⌘Space) is what makes the picker open at all.
+    private func installMainMenu() {
         let mainMenu = NSMenu()
+
+        let appItem = NSMenuItem()
+        mainMenu.addItem(appItem)
+        let appMenu = NSMenu()
+        appMenu.addItem(withTitle: "Quit Munkel", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appItem.submenu = appMenu
+
         let editItem = NSMenuItem()
         mainMenu.addItem(editItem)
         let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        let redo = editMenu.addItem(withTitle: "Redo", action: Selector(("redo:")), keyEquivalent: "z")
+        redo.keyEquivalentModifierMask = [.command, .shift]
+        editMenu.addItem(.separator())
         editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
         editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
         editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Delete", action: #selector(NSText.delete(_:)), keyEquivalent: "")
         editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        editMenu.addItem(.separator())
+        let emoji = editMenu.addItem(
+            withTitle: "Emoji & Symbols",
+            action: #selector(NSApplication.orderFrontCharacterPalette(_:)),
+            keyEquivalent: " "
+        )
+        emoji.keyEquivalentModifierMask = [.command, .control]
         editItem.submenu = editMenu
+
         NSApp.mainMenu = mainMenu
     }
 


### PR DESCRIPTION
The popover, Quick Send and notch reply fields are broken because an accessory app gets no main menu, so the focused field editor never received the standard editing actions. This swaps the minimal Edit menu for a proper main menu (App + Edit submenus) including an Emoji & Symbols item, so paste, select all, cut/copy and the emoji picker route to the field; the existing image-paste monitors are unaffected. It also clips all three message fields to a single scrolling line so a long draft stays inside its box.

Closes #117