### PR TITLE
feat(macos): keep animated gifs animated

### DIFF
--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -202,7 +202,7 @@ final class AppModel: ObservableObject {
                             : ImageCodec.makeThumbnail(from: data, maxBytes: perThumb)
                         guard let thumb else { continue }
                         let id = "echo-\(index)"
-                        images.append(IncomingImage(id: id, thumb: thumb, width: full.width, height: full.height))
+                        images.append(IncomingImage(id: id, thumb: thumb, width: full.width, height: full.height, mime: full.mime))
                         fulls[id] = full.data
                     }
                     return images.isEmpty ? nil : (images, fulls)
@@ -702,7 +702,7 @@ final class AppModel: ObservableObject {
         session.onImages = { [weak self] sender, items, caption, isDirect, loadFull in
             guard let self else { return }
             let images = items.map {
-                IncomingImage(id: $0.r2Key, thumb: $0.thumb, width: $0.width, height: $0.height)
+                IncomingImage(id: $0.r2Key, thumb: $0.thumb, width: $0.width, height: $0.height, mime: $0.mime)
             }
             self.notch.show(
                 sender: sender.label,

--- a/apps/macos/Sources/MunkelApp/ClipboardImage.swift
+++ b/apps/macos/Sources/MunkelApp/ClipboardImage.swift
@@ -1,13 +1,20 @@
 import AppKit
 
-/// Reads an image off the general pasteboard for ⌘V-to-attach. Prefers raw
-/// PNG/TIFF data, falling back to any NSImage on the pasteboard. Shared by the
-/// command palette and the menu-bar composer — both intercept ⌘V with an
-/// NSEvent monitor because an accessory app's text fields don't route `paste:`
-/// to SwiftUI's onPasteCommand.
+/// Reads an image off the general pasteboard for ⌘V-to-attach. Prefers raw GIF
+/// data (so an animated GIF keeps its frames), then PNG/TIFF, falling back to
+/// any NSImage on the pasteboard. Shared by the command palette and the menu-bar
+/// composer — both intercept ⌘V with an NSEvent monitor because an accessory
+/// app's text fields don't route `paste:` to SwiftUI's onPasteCommand.
 enum ClipboardImage {
+    private static let gifType = NSPasteboard.PasteboardType("com.compuserve.gif")
+
     static func read() -> Data? {
         let pasteboard = NSPasteboard.general
+        // GIF first: a copied animated GIF often also exposes a flattened PNG/
+        // TIFF still, and reading those would drop the animation.
+        if let gif = pasteboard.data(forType: gifType) {
+            return gif
+        }
         if let data = pasteboard.data(forType: .png) ?? pasteboard.data(forType: .tiff) {
             return data
         }

--- a/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
+++ b/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
@@ -41,11 +41,17 @@ private struct PreviewCard: View {
 
     private var didFail: Bool { model.failedImages.contains(image.id) }
     private var fullLoaded: Bool { model.fullImages[image.id] != nil }
+    private var animatedFull: Data? {
+        guard image.isAnimated, let full = model.fullImages[image.id] else { return nil }
+        return full
+    }
 
     var body: some View {
         let size = fittedSize(in: available)
         ZStack {
-            if let decoded {
+            if let animatedFull {
+                AnimatedImageView(data: animatedFull, contentMode: .fit)
+            } else if let decoded {
                 Image(decorative: decoded, scale: 1)
                     .resizable()
                     .interpolation(.high)
@@ -89,7 +95,9 @@ private struct PreviewCard: View {
     }
 
     private func decodeFull() async {
-        guard let full = model.fullImages[image.id] else { return }
+        // Animated images play from raw bytes (AnimatedImageView); a still
+        // full decode would just be replaced.
+        guard !image.isAnimated, let full = model.fullImages[image.id] else { return }
         let img = await Task.detached { ImageCodec.decode(full, maxPixels: ImageCodec.maxFullPixels) }.value
         guard !Task.isCancelled else { return }
         decoded = img

--- a/apps/macos/Sources/MunkelApp/IncomingMessage.swift
+++ b/apps/macos/Sources/MunkelApp/IncomingMessage.swift
@@ -26,6 +26,12 @@ struct IncomingImage: Equatable, Identifiable, Sendable {
     let thumb: Data
     let width: Int
     let height: Int
+    /// MIME of the full image. Animated mimes (`image/gif`) render in a view
+    /// that plays them; everything else is a static decode.
+    var mime: String = "image/avif"
+
+    /// Whether the full image animates and should be shown in a playing view.
+    var isAnimated: Bool { mime == "image/gif" }
 }
 
 /// One entry of the short-lived notch history: messages stay visible in

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -1004,9 +1004,17 @@ private struct HistoryAlbumCell: View {
     /// Smaller than the current message's 20pt glyph — history cells are compact.
     private let glyphDiameter: CGFloat = 18
 
+    /// Animated bytes to play once loaded; nil keeps the still thumbnail.
+    private var animatedFull: Data? {
+        guard image.isAnimated, let full = model.fullImages[image.id] else { return nil }
+        return full
+    }
+
     var body: some View {
         ZStack {
-            if let decoded {
+            if let animatedFull {
+                AnimatedImageView(data: animatedFull, contentMode: fill ? .fill : .fit)
+            } else if let decoded {
                 Image(decorative: decoded, scale: 1)
                     .resizable()
                     .interpolation(.medium)
@@ -1073,12 +1081,14 @@ private struct HistoryAlbumCell: View {
             decoded = await Task.detached { ImageCodec.decode(thumb, maxPixels: 300) }.value
         }
         if let full = model.fullImages[image.id] {
+            if image.isAnimated { return }
             decoded = await Task.detached { ImageCodec.decode(full, maxPixels: 900) }.value
             return
         }
         guard !didFail, let loadFull else { return }
         if let data = await loadFull(image.id) {
             model.fullImages[image.id] = data
+            if image.isAnimated { return }
             decoded = await Task.detached { ImageCodec.decode(data, maxPixels: 900) }.value
         } else {
             model.failedImages.insert(image.id)

--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -146,9 +146,18 @@ struct AlbumCell: View {
 
         private let glyphDiameter: CGFloat = 20
 
+    /// The animated bytes to play, once they've loaded for an animated image;
+    /// nil keeps the still thumbnail showing.
+    private var animatedFull: Data? {
+        guard image.isAnimated, let full = model.fullImages[image.id] else { return nil }
+        return full
+    }
+
     var body: some View {
         ZStack {
-            if let decoded {
+            if let animatedFull {
+                AnimatedImageView(data: animatedFull, contentMode: .fill)
+            } else if let decoded {
                 Image(decorative: decoded, scale: 1)
                     .resizable()
                     .interpolation(.medium)
@@ -236,17 +245,44 @@ struct AlbumCell: View {
             decoded = await Task.detached { ImageCodec.decode(thumb, maxPixels: 400) }.value
         }
         // Full resolution: use the cache, else fetch once via the model's loader.
+        // An animated image plays from its raw bytes (AnimatedImageView), so a
+        // still full-res decode would just be thrown away — skip it.
         if let full = model.fullImages[image.id] {
+            if image.isAnimated { return }
             decoded = await Task.detached { ImageCodec.decode(full, maxPixels: 1400) }.value
             return
         }
         guard !didFail, let loader = model.imageLoaders[image.id] else { return }
         if let data = await loader() {
             model.fullImages[image.id] = data
+            if image.isAnimated { return }
             decoded = await Task.detached { ImageCodec.decode(data, maxPixels: 1400) }.value
         } else {
             model.failedImages.insert(image.id)
         }
+    }
+}
+
+/// Plays animated image bytes (an animated GIF) in an NSImageView, which loops
+/// the frames on its own — SwiftUI's `Image` only ever paints a still CGImage.
+/// Used for the full-resolution view once the animated bytes have loaded; the
+/// inline thumbnail keeps showing as a still frame until then.
+struct AnimatedImageView: NSViewRepresentable {
+    let data: Data
+    let contentMode: ContentMode
+
+    func makeNSView(context: Context) -> NSImageView {
+        let view = NSImageView()
+        view.imageScaling = contentMode == .fill ? .scaleProportionallyUpOrDown : .scaleProportionallyDown
+        view.animates = true
+        view.imageFrameStyle = .none
+        view.image = NSImage(data: data)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSImageView, context: Context) {
+        nsView.imageScaling = contentMode == .fill ? .scaleProportionallyUpOrDown : .scaleProportionallyDown
+        if nsView.image == nil { nsView.image = NSImage(data: data) }
     }
 }
 

--- a/apps/macos/Sources/MunkelKit/ImageCodec.swift
+++ b/apps/macos/Sources/MunkelKit/ImageCodec.swift
@@ -6,9 +6,10 @@ import UniformTypeIdentifiers
 /// Prepares images for sending and decodes incoming ones. Two outputs per send:
 ///
 /// - `prepareFull` — the full-resolution image that gets sealed and uploaded to
-///   R2. The source (JPEG, PNG, anything decodable) is ALWAYS transcoded to
-///   AVIF and hard-capped at 2 MiB — AVIF is smaller at equal quality, which is
-///   the whole point: minimize bytes on the wire.
+///   R2. A still source (JPEG, PNG, anything decodable) is transcoded to AVIF —
+///   smaller at equal quality, which is the whole point: minimize bytes on the
+///   wire. An animated GIF stays a GIF so it keeps playing. Either way it's
+///   hard-capped at 2 MiB.
 /// - `makeThumbnail` — a tiny AVIF that rides inside the relay pointer for an
 ///   instant notch preview (same format as the full image — no second codec).
 ///
@@ -43,17 +44,21 @@ public enum ImageCodec {
         }
     }
 
-    /// Full-resolution image ready to seal + upload. The source — JPEG, PNG or
-    /// anything else decodable — is ALWAYS transcoded to AVIF (smaller at equal
-    /// quality, one format on the wire) and hard-capped at `maxBytes` (2 MiB).
-    /// Steps quality down, then pixel size, until it fits. Returns nil when the
-    /// input is undecodable, AVIF encoding is unavailable, or it can't be
-    /// compressed within budget.
+    /// Full-resolution image ready to seal + upload. A single-frame source —
+    /// JPEG, PNG or anything else decodable — is transcoded to AVIF (smaller at
+    /// equal quality, one format on the wire). An animated source (a multi-frame
+    /// GIF) keeps its animation: it stays a GIF on the wire so the recipient can
+    /// play it. Either way it's hard-capped at `maxBytes` (2 MiB) by stepping
+    /// quality, then pixel size, until it fits. Returns nil when the input is
+    /// undecodable or can't be compressed within budget.
     public static func prepareFull(
         from data: Data,
         maxBytes: Int = maxFullBytes,
         maxPixels: Int = maxFullPixels
     ) -> Prepared? {
+        if isAnimated(data) {
+            return prepareAnimated(from: data, maxBytes: maxBytes, maxPixels: maxPixels)
+        }
         let sizes = [maxPixels, maxPixels * 3 / 4, maxPixels / 2].filter { $0 > 0 }
         for pixels in sizes {
             guard let image = downsample(data, maxPixels: pixels) else { return nil }
@@ -62,6 +67,28 @@ public enum ImageCodec {
                     return Prepared(data: avif, mime: "image/avif", width: image.width, height: image.height)
                 }
             }
+        }
+        return nil
+    }
+
+    /// Animated GIF kept animated. The original already fits when small enough;
+    /// otherwise it's re-encoded at smaller pixel sizes (frame timing preserved)
+    /// until it lands under budget. Returns nil if even the smallest re-encode
+    /// can't fit — the caller falls back to dropping the image.
+    private static func prepareAnimated(
+        from data: Data,
+        maxBytes: Int,
+        maxPixels: Int
+    ) -> Prepared? {
+        if data.count <= maxBytes, let info = properties(of: data) {
+            return Prepared(data: data, mime: "image/gif", width: info.width, height: info.height)
+        }
+        let sizes = [maxPixels, maxPixels * 3 / 4, maxPixels / 2, maxPixels / 3].filter { $0 > 0 }
+        for pixels in sizes {
+            guard let gif = encodeAnimatedGIF(data, maxPixels: pixels), gif.data.count <= maxBytes else {
+                continue
+            }
+            return Prepared(data: gif.data, mime: "image/gif", width: gif.width, height: gif.height)
         }
         return nil
     }
@@ -108,6 +135,72 @@ public enum ImageCodec {
         let mime = (CGImageSourceGetType(source).flatMap { UTType($0 as String) })
             .flatMap { $0.preferredMIMEType } ?? "application/octet-stream"
         return ImageInfo(width: width, height: height, mime: mime)
+    }
+
+    /// True for a multi-frame image (an animated GIF). Single-frame sources —
+    /// even GIFs — take the still AVIF path; only these keep their animation.
+    public static func isAnimated(_ data: Data) -> Bool {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return false }
+        return CGImageSourceGetCount(source) > 1
+    }
+
+    /// Re-encode an animated GIF at a smaller longest side, preserving every
+    /// frame and its delay so it still plays. Frames are downsampled through the
+    /// bomb-safe thumbnailer; loop count is carried over (default infinite). nil
+    /// if the source isn't a readable multi-frame GIF.
+    private static func encodeAnimatedGIF(_ data: Data, maxPixels: Int) -> (data: Data, width: Int, height: Int)? {
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else { return nil }
+        let frameCount = CGImageSourceGetCount(source)
+        guard frameCount > 1 else { return nil }
+
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixels,
+        ] as [CFString: Any] as CFDictionary
+
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output, UTType.gif.identifier as CFString, frameCount, nil
+        ) else {
+            return nil
+        }
+
+        let loopCount = (CGImageSourceCopyProperties(source, nil) as? [CFString: Any])
+            .flatMap { $0[kCGImagePropertyGIFDictionary] as? [CFString: Any] }
+            .flatMap { $0[kCGImagePropertyGIFLoopCount] as? Int } ?? 0
+        CGImageDestinationSetProperties(destination, [
+            kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: loopCount],
+        ] as CFDictionary)
+
+        var width = 0
+        var height = 0
+        for index in 0..<frameCount {
+            guard let frame = CGImageSourceCreateThumbnailAtIndex(source, index, thumbnailOptions) else {
+                return nil
+            }
+            width = max(width, frame.width)
+            height = max(height, frame.height)
+            CGImageDestinationAddImage(destination, frame, [
+                kCGImagePropertyGIFDictionary: [
+                    kCGImagePropertyGIFUnclampedDelayTime: frameDelay(of: source, at: index),
+                ],
+            ] as CFDictionary)
+        }
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return (output as Data, width, height)
+    }
+
+    /// Per-frame delay in seconds, falling back to a sensible default so a GIF
+    /// with missing timing still animates instead of freezing.
+    private static func frameDelay(of source: CGImageSource, at index: Int) -> Double {
+        let gif = (CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any])
+            .flatMap { $0[kCGImagePropertyGIFDictionary] as? [CFString: Any] }
+        let unclamped = gif?[kCGImagePropertyGIFUnclampedDelayTime] as? Double
+        let clamped = gif?[kCGImagePropertyGIFDelayTime] as? Double
+        let delay = unclamped ?? clamped ?? 0.1
+        return delay > 0 ? delay : 0.1
     }
 
     /// Thumbnail-decode with a hard longest-side cap — the bomb-safe path for

--- a/apps/macos/Tests/MunkelKitTests/ImageCodecTests.swift
+++ b/apps/macos/Tests/MunkelKitTests/ImageCodecTests.swift
@@ -35,6 +35,36 @@ private func noisePNG(width: Int, height: Int) -> Data {
     return output as Data
 }
 
+/// A multi-frame (animated) GIF — solid color per frame, so it stays tiny.
+private func animatedGIF(width: Int, height: Int, frames: Int) -> Data {
+    let output = NSMutableData()
+    let destination = CGImageDestinationCreateWithData(
+        output, UTType.gif.identifier as CFString, frames, nil
+    )!
+    CGImageDestinationSetProperties(destination, [
+        kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: 0],
+    ] as CFDictionary)
+    for i in 0..<frames {
+        let context = CGContext(
+            data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpace(name: CGColorSpace.sRGB)!,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        let shade = CGFloat(i) / CGFloat(max(frames - 1, 1))
+        context.setFillColor(CGColor(srgbRed: shade, green: 0.2, blue: 0.8, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        CGImageDestinationAddImage(destination, context.makeImage()!, [
+            kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFUnclampedDelayTime: 0.1],
+        ] as CFDictionary)
+    }
+    CGImageDestinationFinalize(destination)
+    return output as Data
+}
+
+private func frameCount(of data: Data) -> Int {
+    CGImageSourceCreateWithData(data as CFData, nil).map(CGImageSourceGetCount) ?? 0
+}
+
 /// True iff `data` is a real AVIF: an ISOBMFF `ftyp` box whose MAJOR brand is
 /// avif/avis. Deliberately ignores the compatible-brand list — HEIC also lists
 /// mif1/miaf there, so accepting those would let a silent HEIC/JPEG fallback
@@ -121,6 +151,31 @@ struct ImageCodecTests {
         let png = noisePNG(width: 256, height: 256)
         let image = try! #require(ImageCodec.decode(png, maxPixels: 32))
         #expect(max(image.width, image.height) <= 32)
+    }
+
+    @Test func detectsAnimatedSource() {
+        #expect(ImageCodec.isAnimated(animatedGIF(width: 32, height: 32, frames: 4)))
+        #expect(!ImageCodec.isAnimated(noisePNG(width: 32, height: 32)))
+        #expect(!ImageCodec.isAnimated(animatedGIF(width: 32, height: 32, frames: 1)))
+    }
+
+    @Test func prepareFullKeepsSmallGIFAnimated() {
+        let gif = animatedGIF(width: 48, height: 48, frames: 6)
+        let prepared = try! #require(ImageCodec.prepareFull(from: gif))
+        #expect(prepared.mime == "image/gif")
+        // A small GIF already fits, so it rides through untouched and animated.
+        #expect(prepared.data == gif)
+        #expect(frameCount(of: prepared.data) == 6)
+    }
+
+    @Test func prepareFullReencodesOversizedGIFKeepingFrames() {
+        let gif = animatedGIF(width: 600, height: 600, frames: 12)
+        let prepared = try! #require(ImageCodec.prepareFull(from: gif, maxBytes: gif.count - 1, maxPixels: 128))
+        #expect(prepared.mime == "image/gif")
+        #expect(prepared.data.count <= gif.count - 1)
+        #expect(max(prepared.width, prepared.height) <= 128)
+        // Still animated after the downscale — every frame survives.
+        #expect(frameCount(of: prepared.data) == 12)
     }
 
     @Test func rejectsUndecodableInput() {


### PR DESCRIPTION
Animated GIFs no longer arrive as a frozen still frame. `ImageCodec` now detects multi-frame sources and keeps them as GIFs on the wire (re-encoded to a smaller size, with frame timing preserved, when they exceed the 2 MiB cap) instead of flattening them to a single-frame AVIF. The receiver renders animated mimes in an NSImageView-backed view that plays them, and the clipboard read prefers raw GIF data so the frames survive a paste.

Closes #105