### PR TITLE
fix(server): drive dev-send profile status from PRESENCE, not STATUS

### DIFF
--- a/apps/server/scripts/dev-send.ts
+++ b/apps/server/scripts/dev-send.ts
@@ -110,7 +110,7 @@ ws.onmessage = async (event) => {
 };
 
 ws.onopen = async () => {
-  ws.send(JSON.stringify({ type: 'send', payload: await seal({ kind: 'profile', displayName: sender, ...(process.env.AVATAR_URL ? { avatarURL: process.env.AVATAR_URL } : {}), status: process.env.STATUS ?? 'online' }) }));
+  ws.send(JSON.stringify({ type: 'send', payload: await seal({ kind: 'profile', displayName: sender, ...(process.env.AVATAR_URL ? { avatarURL: process.env.AVATAR_URL } : {}), status: process.env.PRESENCE ?? 'online' }) }));
   if (listenMode) {
     process.stdout.write(`listening as "${sender}" (${memberId})…\n`);
     setInterval(() => ws.send(JSON.stringify({ type: 'ping' })), 30_000);


### PR DESCRIPTION
## Summary

`apps/server/scripts/dev-send.ts` is one of the three pinned mirrors of the wire protocol. Its profile payload read the initial `status` from an undocumented `STATUS` env var (used nowhere else, never documented), while the header docstring and the presence-delta branch use `PRESENCE`.

Running the documented `PRESENCE=dnd bun scripts/dev-send.ts <code> <name>` therefore emitted a `presence` delta of `dnd` but a join-snapshot `profile` with `status: 'online'` — an internally inconsistent pair from the reference sender. A peer that reads the profile join snapshot (or misses the separate `presence` frame, which `protocol.ts` documents as a valid case) renders the sender as Online.

Read the profile status from `PRESENCE` as well, so one value drives both the join snapshot and the delta. Unset still defaults to `'online'`, so back-compat with senders that omit presence is unchanged.

Found during post-merge verification of #111 / #102.

## Test plan

- [x] `tsc --noEmit` (server) passes
- [ ] `PRESENCE=dnd bun apps/server/scripts/dev-send.ts <code> <name>` → Munkel app shows the member as DND from the join snapshot
- [ ] no env var → member shows as Online (unchanged)