### PR TITLE
fix(macos): stop caching fetched image-url bytes to disk

### DIFF
--- a/apps/macos/Sources/MunkelApp/GroupSession.swift
+++ b/apps/macos/Sources/MunkelApp/GroupSession.swift
@@ -27,6 +27,13 @@ final class GroupSession {
     /// the server's per-blob cap (apps/server/src/blob.ts) plus envelope.
     private static let maxIncomingImageBytes = 3 * 1024 * 1024 + 4_096
 
+    private static let imageURLSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 10
+        config.timeoutIntervalForResource = 30
+        return URLSession(configuration: config)
+    }()
+
     let code: String
     private(set) var members: [Member] = []
     private(set) var isConnected = false
@@ -107,7 +114,7 @@ final class GroupSession {
     private static func fetchImage(from url: URL) async -> Data? {
         var request = URLRequest(url: url)
         request.setValue("image/*", forHTTPHeaderField: "Accept")
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
+        guard let (data, response) = try? await imageURLSession.data(for: request),
               let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
               data.count <= maxIncomingImageBytes
         else {


### PR DESCRIPTION
## What

`sendChat`'s image-url path (#120) fetched image URLs through `URLSession.shared`, whose default `URLCache` is disk-backed. Cacheable image responses were written to `~/Library/Caches/dev.uq.munkel/…` and outlived the message — a forensic copy of every URL-image a sender shares sat on their disk until URLSession evicted it. That regresses the **"no message storage"** invariant the product is built on (CLAUDE.md: *"Ephemerality is structural, not policy"*).

## Fix

Switch to a dedicated **ephemeral** `URLSession` (RAM-only, no disk cache), mirroring `GitHubDeviceAuth.swift`, which already uses `.ephemeral` to keep the OAuth exchange out of disk cache. Also bound `timeoutIntervalForRequest = 10s` / `timeoutIntervalForResource = 30s` so a slow/hung image host can't stall the `sendChat` path for the 60s default — a DoS on the same sensitive code path.

```diff
+    private static let imageURLSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 10
+        config.timeoutIntervalForResource = 30
+        return URLSession(configuration: config)
+    }()
…
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
+        guard let (data, response) = try? await imageURLSession.data(for: request),
```

## Verification

- `swift build` in `apps/macos` → `Build complete!` (GroupSession.swift compiles clean).
- Diff: 1 file, +8 / −1. Focused on the security issue, nothing else touched.
- No existing tests cover `GroupSession` (the `MunkelKitTests/` suite targets the Kit, not the App), so no adjacent tests to extend without also adding the first `MunkelApp` test target — out of scope here.

## Scope (intentionally narrow)

This PR fixes only the disk-cache regression. Other findings from the pre-landing review of #120 are tracked separately and intentionally **not** folded in:

- **Convention debt** (tracked in #97): the narrating comments #120 added in `GroupSession.swift` still need removing. Not a security issue, belongs in a cleanup PR.
- **PRIVACY.md / SECURITY.md**: sender IP + User-Agent now leak to arbitrary image hosts on Send (previously the receiver's IP leaked when they clicked the link). New third-party data flow, undocumented. Needs a paragraph in PRIVACY.md.
- **P1**: `URLSession.data(for:)` buffers the full body before the size cap — a hostile host advertising a huge `Content-Length` allocates before the post-hoc cap fires. Streaming via `URLSession.bytes(for:)` or a delegate would close it.
- **P2**: SSRF via redirect (no host filter), silent-fallback UX, CDN URLs without extensions sent as text.

Found in pre-landing review of #120.