### PR TITLE
fix(macos): clear reply draft after sending

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -642,6 +642,7 @@ struct MessageNotchContainer: View {
                     // Allow an image-only reply (mirrors CommandPaletteView.canSend).
                     guard !text.isEmpty || !model.attachedImages.isEmpty else { return }
                     onReply(text, model.attachedImages, model.replyPrivately)
+                    draft = ""
                 }
                 .onExitCommand(perform: onCancelReply)
                 .onAppear {


### PR DESCRIPTION
The reply field now empties after you send, so a new reply always starts fresh instead of keeping the previous text.

Closes #129