### PR TITLE
fix(macos): expand main message to full height

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -41,7 +41,7 @@ struct MessageNotchView: View {
                         text: message.text,
                         font: .systemFont(ofSize: 14, weight: .medium),
                         textColor: .white,
-                        lineLimit: 6
+                        lineLimit: 0
                     ) { [weak model] view in model?.registerLinkHost(view) }
                 }
                 if let url = firstURL(in: message.text) {


### PR DESCRIPTION
The main message text was truncating with an ellipsis after the switch to LinkText, which applied a hard six-line limit. This sets the main message body to expand to its full wrapped height again, so long messages show in full. URL clickability is preserved, and the image caption keeps its line cap.

Closes #130