### PR TITLE
chore: adjust gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules/
 dist/
 *.log
+.omo
+
+**/graphify-out
 
 # Local environment and Worker secrets
 .env


### PR DESCRIPTION
Ignore agent/tooling output that shouldn't be tracked:

- `.omo`
- `**/graphify-out`

## Test plan
- [ ] N/A — `.gitignore`-only change