### PR TITLE
fix(macos): history expand leaves a large empty vertical gap

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -495,6 +495,7 @@ struct MessageNotchContainer: View {
                             .padding(.trailing, 4)
                         }
                     }
+                    .fixedSize(horizontal: false, vertical: true)
                 if model.replySent {
                     sentConfirmation
                 } else if model.replying {
@@ -547,6 +548,9 @@ struct MessageNotchContainer: View {
         .background(AreaMarker { [weak model] in model?.historyMarker = $0 })
         .animation(.spring(duration: 0.3), value: model.history)
         .animation(.spring(duration: 0.3), value: model.historyExpanded)
+        .onChange(of: model.historyExpanded) { _, expanded in
+            if !expanded { historyHeight = 0 }
+        }
     }
 
     /// Expanded history: full text per row, bounded to ~⅓ of the screen and
@@ -554,7 +558,7 @@ struct MessageNotchContainer: View {
     /// Explicit (measured) height — a bare ScrollView collapses inside the
     /// notch's fixedSize layout.
     private var expandedHistory: some View {
-        let cap = (NSScreen.main?.frame.height ?? 900) / 3
+        let cap = historyCap
         return ScrollView {
             // Zero spacing for the same reason as the collapsed list: contiguous,
             // glyph-tall hover zones with no dead gap (each expanded row adds its
@@ -572,7 +576,16 @@ struct MessageNotchContainer: View {
             )
         }
         .frame(height: historyHeight == 0 ? nil : min(historyHeight, cap))
-        .onPreferenceChange(HistoryHeightKey.self) { historyHeight = $0 }
+        .frame(maxHeight: cap)
+        .onPreferenceChange(HistoryHeightKey.self) { height in
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) { historyHeight = height }
+        }
+    }
+
+    private var historyCap: CGFloat {
+        (DisplayPreference.resolvedScreen()?.frame.height ?? 900) / 3
     }
 
     /// Inline reply. Return sends, Escape dismisses; focus lands here as


### PR DESCRIPTION
Closes #135

## Problem

Expanding the in-notch history opened a large empty vertical gap between the current message and the history — the upper (message) region grew — instead of the history sitting directly beneath the message.

## Root cause

Confirmed by instrumenting the views with debug backgrounds: when the history is expanded, its `ScrollView` becomes the flexible element in the message column. Under the notch's `.fixedSize()` host, the current message's `LinkText` (an `NSTextView`, `lineLimit: 0` since #133) is vertically greedy and absorbs the slack — stretching the message frame and leaving the gap. Collapsed (inline, non-flexible rows) it doesn't happen.

## Change

- **The fix:** pin the message to its content height with `.fixedSize(horizontal: false, vertical: true)` so only the history flexes — the gap is gone.
- Bound the expanded history to ~⅓ of the notch's own screen via `DisplayPreference.resolvedScreen()` instead of `NSScreen.main` (correct on multi-monitor), with a hard `.frame(maxHeight:)` cap.
- Reset the measured height on collapse and apply it non-animated, so the scroll region re-measures fresh and doesn't animate/linger stale across expands.

## Verification

- `swift build` (MunkelApp) compiles.
- Manual on a notch Mac (DEBUG "Allow in screenshots" + "Demo image history"): expand history → message hugs its content, history sits directly beneath, no gap; history capped to ~⅓ screen and scrolls. The stretch was localized by coloring the view frames (the message frame fills the gap before the fix, hugs after), and confirmed by the maintainer.
