### PR TITLE
fix(macos): make automatic update checks actually surface

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -156,6 +156,20 @@ in-place update.
   the release workflow uploads as a release asset. Keep its `SPARKLE_VERSION` in
   sync with the Sparkle SPM version in `apps/macos/Package.swift`.
 
+- **Surfacing & scheduling**: `UpdaterController` forces one background check on
+  launch (gated on the user's *Check Automatically* preference) on top of
+  Sparkle's interval timer — without it, every manual *Check for Updates*
+  rewrites `SULastCheckTime` and pushes the next scheduled check a full
+  `SUScheduledCheckInterval` (1 day) out, so the automatic path effectively never
+  surfaces. A scheduled find is a Sparkle "gentle reminder": Munkel has no Dock
+  icon, so it shows as an accent dot on the menu-bar item (`AppDelegate`) plus the
+  *Update to <version>…* menu entry, never an unprompted window.
+- **Testing the automatic path** (release build only — the dev build never
+  creates `UpdaterController`): point the app at an appcast advertising a version
+  newer than the local `CFBundleShortVersionString`, then
+  `defaults delete dev.uq.munkel SULastCheckTime` and relaunch. The menu-bar dot
+  should appear within a couple of seconds, with no manual click.
+
 First-release note: the release that introduces Sparkle produces the first
 appcast, but existing users run a build without an updater: they update once
 manually, and auto-updates take over from the next release onward.

--- a/apps/macos/Sources/MunkelApp/MunkelApp.swift
+++ b/apps/macos/Sources/MunkelApp/MunkelApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 
 /// Owns the status item and the popover. MenuBarExtra(.window) can't draw
@@ -19,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// App-wide ⌘-key monitor that forwards the editing actions to the focused
     /// field editor; retained for the process lifetime.
     private var editingMonitor: Any?
+    private var updateBadgeCancellable: AnyCancellable?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Accessory: no Dock icon — menu bar item and notch are the only UI.
@@ -77,6 +79,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         item.button?.target = self
         item.button?.action = #selector(togglePopover(_:))
         statusItem = item
+
+        #if !DEBUG
+        if let button = item.button {
+            installUpdateBadge(on: button, updater: updater)
+        }
+        #endif
+    }
+
+    private func installUpdateBadge(on button: NSStatusBarButton, updater: UpdaterController) {
+        let badge = NSImageView()
+        badge.image = NSImage(systemSymbolName: "circle.fill", accessibilityDescription: "Update available")
+        badge.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 7, weight: .bold)
+        badge.contentTintColor = .controlAccentColor
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.isHidden = true
+        button.addSubview(badge)
+        NSLayoutConstraint.activate([
+            badge.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -1),
+            badge.topAnchor.constraint(equalTo: button.topAnchor, constant: 2),
+        ])
+        updateBadgeCancellable = updater.$availableUpdateVersion.sink { version in
+            badge.isHidden = version == nil
+        }
     }
 
     /// A standard (never-displayed) main menu so the editing actions reach the

--- a/apps/macos/Sources/MunkelApp/UpdaterController.swift
+++ b/apps/macos/Sources/MunkelApp/UpdaterController.swift
@@ -44,6 +44,9 @@ final class UpdaterController: NSObject, ObservableObject {
         let updater = controller.updater
         automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
         updater.publisher(for: \.canCheckForUpdates).assign(to: &$canCheckForUpdates)
+        if updater.automaticallyChecksForUpdates {
+            updater.checkForUpdatesInBackground()
+        }
     }
 
     /// User-initiated check (menu). Sparkle shows its standard update UI.


### PR DESCRIPTION
Closes #143

## Problem

With **Check Automatically** on, a new release never surfaces on its own. Manual **Check for Updates** works.

## Root cause (verified against Sparkle 2.7.0 source)

The app only ever called the *user-initiated* `checkForUpdates()`. Sparkle's scheduled checks are interval-gated by `SULastCheckTime` + `SUScheduledCheckInterval` (1 day). Every manual check rewrites `SULastCheckTime` to "now", pushing the next automatic check 24h out — so the scheduled path is perpetually starved, and there is no per-launch background nudge to break it.

Two contributing factors:
1. **Starvation** — no forced background check on launch; the automatic path only fires once the full interval elapses, which a manual check keeps resetting.
2. **Invisibility** — Munkel is a dockless `LSUIElement` app. Even when a scheduled check *does* find an update, the gentle reminder only paints a menu item *inside a closed popover* — no Dock badge, no notification — so "automatic update available" is imperceptible.

## Fix

- `UpdaterController.init()` forces one `checkForUpdatesInBackground()` on launch, gated on the user's *Check Automatically* preference. `checkForUpdatesInBackground()` is **not** interval-gated (it only no-ops on an in-progress session), so it reliably breaks the starvation. This is the per-launch force [Sparkle's own header recommends](https://sparkle-project.org/documentation/). It does **not** download or install silently (`automaticallyDownloadsUpdates` stays off) and routes through the existing gentle-reminder path (no unprompted window).
- `AppDelegate` adds an accent dot on the menu-bar item, bound to `availableUpdateVersion`, so an auto-found update is visible without opening the popover — the cue Sparkle's gentle-reminders docs recommend for dockless apps.

Release-only is preserved (`UpdaterController` is only created under `#if !DEBUG`); the user toggle still suppresses everything.

## Test plan

Verified `swift build` (debug) and `swift build -c release -Xswiftc -Onone` (exercises the `#if !DEBUG` badge path) both compile.

Manual (release build — the dev build never creates `UpdaterController`):
- [ ] Point the app at an appcast advertising a version newer than the local `CFBundleShortVersionString`, then `defaults delete dev.uq.munkel SULastCheckTime` and relaunch → the menu-bar dot appears within seconds, no manual click; the *Update to <version>…* item is present in the menu.
- [ ] Toggle **Check Automatically** off, relaunch → no forced check, no dot.
- [ ] Manual **Check for Updates** still works unchanged.

## Out of scope / follow-up

A louder cue (user notification) was considered and deliberately skipped — the passive menu-bar dot is the minimal fix that matches the gentle-reminder model. Open as a follow-up if the dot proves too subtle.
