### PR TITLE
fix(ci): keep releases as prerelease until their assets are uploaded

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,14 +131,19 @@ jobs:
       - name: Upload artifact to GitHub release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
-          # release-please already created the release with changelog notes;
-          # this only attaches the DMG (softprops upserts by tag).
           tag_name: ${{ github.ref_name }}
+          prerelease: true
           files: |
             dist/Munkel-${{ env.VERSION }}.dmg
             dist/Munkel-${{ env.VERSION }}.dmg.sha256
             dist/Munkel-${{ env.VERSION }}.dmg.sigstore.json
             dist/appcast.xml
+
+      - name: Promote release to latest
+        if: success() && hashFiles('dist/appcast.xml') != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "${{ github.ref_name }}" --prerelease=false --latest
 
       - name: Bump cask in homebrew-tap
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -81,7 +81,12 @@ Pushing a tag `v<version>` runs `.github/workflows/release.yml`:
 4. `scripts/build-appcast.sh` EdDSA-signs the notarized DMG and renders the
    Sparkle auto-update feed `appcast.xml` (see **Auto-updates** below).
 5. GitHub release with `Munkel-<version>.dmg` (+ `.sha256` + Sigstore bundle
-   + `appcast.xml`).
+   + `appcast.xml`). release-please creates the release as a **prerelease**
+   (`prerelease: true` in `release-please-config.json`); `release.yml` clears
+   that flag and marks it `latest` only **after** the assets are attached
+   (`gh release edit … --prerelease=false --latest`). Until then GitHub's
+   `releases/latest` skips it, so the Sparkle feed never resolves to a release
+   whose `appcast.xml` isn't uploaded yet (see **Auto-updates**).
 6. `scripts/build-brew-cask.sh` renders `Casks/munkel.rb` (with `auto_updates
    true`) with the new version + DMG sha256 and pushes it to
    `limehq/homebrew-tap`.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
 	"release-type": "simple",
 	"bump-minor-pre-major": true,
 	"include-component-in-tag": false,
+	"prerelease": true,
 	"packages": {
 		".": {
 			"package-name": "munkel",


### PR DESCRIPTION
## Problem

Pressing **Update** in the app right after a new GitHub release is published — but before its binaries are uploaded — fails with:

> An error occurred in retrieving update information. Please try again later.

## Root cause

The app's `SUFeedURL = https://munkel.app/appcast.xml` 302-redirects to `releases/latest/download/appcast.xml`. release-please publishes each GitHub release as a **full** release the moment the release PR merges, then `release.yml` builds/signs/notarizes for ~20–30 min before uploading the DMG + `appcast.xml`.

During that window GitHub's `releases/latest` already points at the new release, but its `appcast.xml` asset doesn't exist yet → the redirect **404s** → Sparkle shows the error. (Matches the observed state: release exists, only source-code assets present.)

## Fix

Make a release become `latest` only once its assets exist:

- `release-please-config.json` — `prerelease: true`: the release is born as a prerelease, so `releases/latest` keeps pointing at the previous good release during the build.
- `release.yml` — `softprops` step gets `prerelease: true` so the asset upload doesn't flip it to latest mid-upload (also covers the manual `v*`-tag path).
- `release.yml` — new **Promote release to latest** step after the upload: `gh release edit … --prerelease=false --latest`.

`prerelease` only flips the GitHub release flag, not the version number (verified against the release-please config schema; `prerelease-type` would be the version-changing one and is untouched). Prereleases are published, so the tag still exists and the `--ref <tag>` dispatch in `release-please.yml` is unaffected.

No change to Swift/Sparkle code, the landing redirect, or `build-appcast.sh`.

## Test plan

Not fully reproducible locally (needs macOS signing/notarization + a real release). Verified statically:

- [x] `release-please-config.json` valid JSON; `prerelease` is a valid top-level config key inherited by the package.
- [x] `gh release edit` supports `--prerelease=false` and `--latest`.
- [ ] **Next real release** (acceptance): the new release shows as *Pre-release* for the build duration, `latest` stays on the prior version, the app reports no error; once the build finishes it flips to *Latest* and the in-app update appears.

## Docs

`RELEASING.md` release-flow step 5 updated to describe the prerelease→promote sequence.