### PR TITLE
feat(macos): show git branch in dev menu header

### DIFF
--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -109,11 +109,18 @@ struct MenuView: View {
                 .scaledToFit()
                 .frame(width: 16, height: 16)
                 .foregroundStyle(.primary)
-            Text("Munkel")
+            Text(appTitle)
                 .font(.headline)
             Spacer()
             settingsMenu
         }
+    }
+
+    private var appTitle: String {
+        if let branch = Bundle.main.infoDictionary?["MunkelGitBranch"] as? String, !branch.isEmpty {
+            return "Munkel (\(branch))"
+        }
+        return "Munkel"
     }
 
     private var settingsMenu: some View {

--- a/apps/macos/make-bundle.sh
+++ b/apps/macos/make-bundle.sh
@@ -83,6 +83,11 @@ if [[ "$CONFIG" == "debug" ]]; then
     || /usr/libexec/PlistBuddy -c "Add :CFBundleName string Munkel Dev" "$plist"
   /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Munkel Dev" "$plist" 2>/dev/null \
     || /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string Munkel Dev" "$plist"
+  # Stamp the source branch into the dev bundle so the menu header can show which
+  # branch a side-by-side dev build came from. Release builds skip this block, so
+  # the key is absent there and the header stays a plain "Munkel".
+  BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+  /usr/libexec/PlistBuddy -c "Add :MunkelGitBranch string $BRANCH" "$plist"
 fi
 
 # Swift Bundler ad-hoc signs; re-sign with our identity (hardened runtime +


### PR DESCRIPTION
## Was
Der Dev-Build zeigt im Menüleisten-Popover oben links jetzt den aktuellen Git-Branch in Klammern an, z. B. `Munkel (feat/dev-git-branch-in-popover)` bzw. `Munkel (main)`. Release-Builds bleiben unverändert bei `Munkel`.

## Warum
Mehrere Dev-Builds laufen Seite an Seite (eigene `.debug`-Identität). Der Branch-Suffix macht auf einen Blick sichtbar, aus welchem Branch ein laufender Dev-Build stammt.

## Wie
- **`make-bundle.sh`** stempelt im bereits vorhandenen Debug-Block den Branch (`git rev-parse --abbrev-ref HEAD`) als Info.plist-Key `MunkelGitBranch`. Der Release-Pfad überspringt diesen Block, also fehlt der Key dort.
- **`MenuView.swift`** liest den Key über `Bundle.main.infoDictionary` und hängt ihn an den Titel an. Da der Key in Release fehlt, ist kein `#if DEBUG` nötig — ein Codepfad, der Titel fällt automatisch auf `Munkel` zurück.

Build-Zeit statt Laufzeit, weil die App aus dem `.app`-Bundle läuft und nicht zuverlässig `git` aufrufen kann.

## Test plan
- [x] `swift build` grün
- [x] `bun run dev` baut + startet *Munkel Dev*; gebautes Bundle enthält `MunkelGitBranch = feat/dev-git-branch-in-popover`
- [x] Popover-Header zeigt `Munkel (feat/dev-git-branch-in-popover)` (visuell bestätigt; Popover ist `excludedFromScreenCapture`, daher kein Screenshot)
- [x] Branch-Name mit `/` übersteht PlistBuddy unverändert
- [ ] Gegencheck: Release-Build (`bun run build:release`) zeigt weiterhin `Munkel` ohne Suffix