### PR TITLE
fix(macos): only show "Install Command Line Tool" when the CLI is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ The cask installs `Munkel.app` and symlinks the bundled `munkel` CLI onto your
 [latest release](https://github.com/limehq/munkel/releases/latest) and drag
 `Munkel.app` into Applications. The `munkel` CLI ships inside the app. To put it
 on your `PATH`, open Munkel and choose **Install Command Line Tool…** from the
-menu-bar gear menu: it links into the first writable directory on your `PATH`
+menu-bar gear menu — an item that shows only while the CLI isn't already on your
+`PATH`. It links into the first writable directory on your `PATH`
 (e.g. Homebrew's `bin`) with no admin password, or falls back to `~/.local/bin`
 and adds it to `~/.zshrc` when Homebrew is absent (reopen your terminal
 afterward). Either way the CLI needs the running app, which it talks to over a

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -15,6 +15,9 @@ struct MenuView: View {
     @StateObject private var loginItem = LoginItemModel()
     /// Empty = automatic (active display); otherwise a display's stable UUID.
     @AppStorage(DisplayPreference.key) private var preferredDisplayID = ""
+    #if !DEBUG
+    @State private var cliInstalled = CLIInstaller.isInstalled
+    #endif
     #if DEBUG
     @AppStorage("devEchoBroadcasts") private var devEchoBroadcasts = true
     @AppStorage(CaptureScreenshotPreference.defaultsKey) private var allowInScreenshots = false
@@ -93,6 +96,9 @@ struct MenuView: View {
         // reads one can join), the outgoing draft and the GitHub device
         // code, so it stays out of screen shares like the notch does.
         .excludedFromScreenCapture()
+        #if !DEBUG
+        .onAppear { cliInstalled = CLIInstaller.isInstalled }
+        #endif
         #if DEBUG
         // Re-apply the sharing type to every on-screen surface the moment the
         // "Allow in screenshots" toggle flips, so it takes effect without a
@@ -134,10 +140,13 @@ struct MenuView: View {
             // Release only: the dev build doesn't embed the CLI (run it from
             // source with `MUNKEL_DEV=1 bun apps/cli/src/munkel.ts`).
             #if !DEBUG
-            Button {
-                CLIInstaller.installFromMenu()
-            } label: {
-                Label("Install Command Line Tool…", systemImage: "terminal")
+            if !cliInstalled {
+                Button {
+                    CLIInstaller.installFromMenu()
+                    cliInstalled = CLIInstaller.isInstalled
+                } label: {
+                    Label("Install Command Line Tool…", systemImage: "terminal")
+                }
             }
             #endif
             Divider()


### PR DESCRIPTION
## What

Hide the **Install Command Line Tool…** item in the menu-bar gear menu unless the `munkel` CLI is actually installed. Homebrew users — whose cask symlinks the CLI onto `PATH` automatically — no longer see a redundant install action; DMG users still see it until they install.

## How

- Gate the button on `CLIInstaller.isInstalled` (release-only `#if !DEBUG`, the config that embeds the CLI).
- State lives in `@State cliInstalled`, seeded at launch and refreshed on each popover open (`.onAppear`) plus right after the in-app install. The popover's `NSHostingController(rootView: MenuView())` is created once and reused, so without a refresh the gate would freeze at its launch value; `.onAppear` keeps it in sync with external install/uninstall while the app stays resident.
- README updated to note the item shows only while the CLI isn't already on `PATH`.

## Review & verification

- Multi-agent recall code review surfaced that the first cut cached install state at launch and never refreshed (stale menu after an external uninstall); fixed with the `.onAppear` refresh.
- Release compile clean: `swift build -c release -Xswiftc -Onone`.

## Test plan (release build — the item is release-only, so the Dev build can't exercise it)

- [x] CLI not installed → item shown
- [x] External install while app running → item disappears on next popover open
- [x] External uninstall while app running → item reappears on next popover open (the bug the review caught)
- [x] Homebrew steady-state (CLI linked at launch) → item hidden