### PR TITLE
fix(macos): close the menu popover when opening About

### DIFF
--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -70,6 +70,7 @@ final class AppModel: ObservableObject {
     /// Sparkle bridge, injected by `AppDelegate` at launch (release build only;
     /// nil in the dev build, which doesn't auto-update).
     var updater: UpdaterController?
+    var closePopover: (() -> Void)?
 
     private static let groupsKey = "groupCodes"
     private static let relayURLKey = "relayURL"

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -229,6 +229,7 @@ struct MenuView: View {
     }
 
     private func showAbout() {
+        model.closePopover?()
         NSApp.activate(ignoringOtherApps: true)
         NSApp.orderFrontStandardAboutPanel(nil)
     }

--- a/apps/macos/Sources/MunkelApp/MunkelApp.swift
+++ b/apps/macos/Sources/MunkelApp/MunkelApp.swift
@@ -61,6 +61,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         // sluggish next to the old MenuBarExtra window.
         popover.animates = false
         popover.delegate = self
+        model.closePopover = { [weak self] in self?.popover.close() }
 
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         // Brand silhouette as a template image, sized for the menu bar;


### PR DESCRIPTION
## What

Clicking **About Munkel** in the menu-bar popover opened the standard About panel but left the popover sitting open behind it. `showAbout()` now dismisses the popover before showing the panel.

## Why it lingered

The popover is `.transient`, which only auto-dismisses when *another app* takes focus — but `orderFrontStandardAboutPanel` opens a window within the same app, so focus never left and the popover stayed.

## The non-obvious part

The close is wired through `AppModel.closePopover` (a callback set by `AppDelegate`, which owns the `NSPopover`) rather than `NSApp.delegate`. Under `@NSApplicationDelegateAdaptor`, **`NSApp.delegate` is SwiftUI's own `SwiftUI.AppDelegate` wrapper**, not `MunkelApp.AppDelegate` — so `NSApp.delegate as? AppDelegate` is always `nil` and any close reached that way silently no-ops. `type(of:)` prints "AppDelegate" for both, which masks it; only `String(reflecting:)` reveals the wrapper.

## Changes

- `AppModel` → `var closePopover: (() -> Void)?`
- `AppDelegate` → `model.closePopover = { [weak self] in self?.popover.close() }`
- `MenuView.showAbout()` → `model.closePopover?()`

## Test plan

- [x] `swift build` green
- [x] Manually verified in **Munkel Dev**: ⚙️ → About Munkel closes the popover and opens the About panel
- [x] Adversarial review (AppKit correctness / regression / simplicity lenses) — all ship
