### PR TITLE
docs: drop stale fluesterung directory note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Overview
 
 Munkel: ephemeral, end-to-end-encrypted messages between friends ("channels") that
-slide out of the MacBook notch. No accounts, no message storage. The repo
-directory is `fluesterung` but the product/brand is **Munkel**.
+slide out of the MacBook notch. No accounts, no message storage.
 
 `docs/ARCHITECTURE.md` is the authoritative, source-linked map of every component
 and the data flow — read it before non-trivial work instead of re-deriving the


### PR DESCRIPTION
## Summary

The project is named **munkel** now, not fluesterung. The rename was already structurally complete — the repo directory (`munkel`), git remote (`limehq/munkel`), and all workspace packages (`@munkel/*`) all use munkel.

The only remaining `fluesterung` reference in tracked source was an obsolete sentence in `CLAUDE.md` claiming "The repo directory is \`fluesterung\`". This drops it.

## Out of scope

- `scripts/simulate-whispers.sh` still contains the German string `"Frohes Flüstern!"` — that's the legacy *whisper* concept the docs deliberately keep, not the project name.

## Test plan

- [x] No `fluesterung` references remain in tracked source (grep clean)
- [x] Docs-only change, no build/behavior impact