### PR TITLE
fix(macos): free ←/→ for text editing in the Quick-Send palette

### DIFF
--- a/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
@@ -106,12 +106,10 @@ final class CommandPalettePresenter {
         panel.setFrameOrigin(NSPoint(x: x, y: y))
     }
 
-    /// Arrow keys are a full D-pad over the target chips while the message
-    /// field keeps focus: left/right within a channel, up/down between
-    /// channels. Bare arrows are consumed (return nil) so they don't move the
-    /// text cursor; arrows held with an editing modifier (⌘/⌥/⌃/⇧) fall through
-    /// to the field editor for word/line/select shortcuts. Tab/Shift+Tab cycle
-    /// through all recipients. Return (onSubmit) sends and Esc (onExitCommand) closes.
+    /// ↑/↓ pick the target chip while the message field keeps focus. Bare ←/→
+    /// and any modifier+arrow fall through to the field editor for normal text
+    /// editing. Tab/Shift+Tab also cycle through all recipients. Return
+    /// (onSubmit) sends and Esc (onExitCommand) closes.
     private func installKeyMonitor() {
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
@@ -134,8 +132,6 @@ final class CommandPalettePresenter {
 
                 let dir: CommandPaletteState.Direction?
                 switch event.keyCode {
-                case 123: dir = .left
-                case 124: dir = .right
                 case 125: dir = .down
                 case 126: dir = .up
                 default: dir = nil

--- a/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPalettePresenter.swift
@@ -108,9 +108,10 @@ final class CommandPalettePresenter {
 
     /// Arrow keys are a full D-pad over the target chips while the message
     /// field keeps focus: left/right within a channel, up/down between
-    /// channels. All four are consumed (return nil) so they don't move the
-    /// text cursor. Tab/Shift+Tab cycle through all recipients. Return (onSubmit)
-    /// sends and Esc (onExitCommand) closes.
+    /// channels. Bare arrows are consumed (return nil) so they don't move the
+    /// text cursor; arrows held with an editing modifier (⌘/⌥/⌃/⇧) fall through
+    /// to the field editor for word/line/select shortcuts. Tab/Shift+Tab cycle
+    /// through all recipients. Return (onSubmit) sends and Esc (onExitCommand) closes.
     private func installKeyMonitor() {
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
@@ -128,6 +129,9 @@ final class CommandPalettePresenter {
                     return
                 }
 
+                let editingModifiers: NSEvent.ModifierFlags = [.command, .option, .control, .shift]
+                let hasEditingModifier = !event.modifierFlags.intersection(editingModifiers).isEmpty
+
                 let dir: CommandPaletteState.Direction?
                 switch event.keyCode {
                 case 123: dir = .left
@@ -136,7 +140,7 @@ final class CommandPalettePresenter {
                 case 126: dir = .up
                 default: dir = nil
                 }
-                if let dir {
+                if let dir, !hasEditingModifier {
                     self.state.move(dir)
                     consumed = true
                 } else if event.keyCode == 48 {

--- a/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
+++ b/apps/macos/Sources/MunkelApp/CommandPaletteState.swift
@@ -93,9 +93,9 @@ final class CommandPaletteState: ObservableObject {
         attachedImages = []
     }
 
-    // MARK: - D-pad navigation
+    // MARK: - Recipient navigation
 
-    enum Direction { case left, right, up, down }
+    enum Direction { case up, down }
 
     /// Flat-index ranges, one per channel, in display order.
     private var channelRanges: [Range<Int>] {
@@ -112,9 +112,8 @@ final class CommandPaletteState: ObservableObject {
         return ranges
     }
 
-    /// Left/right move within the current channel; up/down jump to the
-    /// adjacent channel keeping the column (clamped). With a single channel
-    /// all four arrows move within it.
+    /// ↑/↓ move the selection: within one channel by a step; across several
+    /// channels they jump to the adjacent channel, keeping the column (clamped).
     func move(_ dir: Direction) {
         let ranges = channelRanges
         guard !ranges.isEmpty,
@@ -125,10 +124,6 @@ final class CommandPaletteState: ObservableObject {
         let single = ranges.count <= 1
 
         switch dir {
-        case .left:
-            selectedIndex = max(here.lowerBound, selectedIndex - 1)
-        case .right:
-            selectedIndex = min(here.upperBound - 1, selectedIndex + 1)
         case .up:
             if single {
                 selectedIndex = max(here.lowerBound, selectedIndex - 1)


### PR DESCRIPTION
Closes #138

In the Quick-Send command palette (⌥M), the recipient picker consumed every arrow key by `keyCode` alone, so the message field's text-editing keys never reached its editor.

Fix:
- **←/→ and every modifier+arrow** (⌥←/→ word, ⌘←/→ line, ⇧←/→ select) fall through to the field editor for normal text editing.
- **↑/↓** pick the recipient (also on Tab/⇧Tab and click); ←/→ no longer move the selection.
- Removes the now-unused left/right from the `Direction` model.

## Test plan
- [x] ⌥M, type text: ←/→ move the cursor; ⌥←/→, ⌘←/→, ⇧←/→ move/select by word/line
- [x] ↑/↓ change the recipient
- [x] Tab / ⇧Tab cycle recipients
- [x] ⌘V (image) and emoji picker still work
