### PR TITLE
feat(macos): link preview cards under messages and in history

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// mode flips, so the shape animates between the two sizes seamlessly.
 enum NotchDisplayMode { case message, indicator }
 
-enum LinkPreviewState: Equatable {
+enum LinkPreviewState {
     case loading
     case ready(LinkPreviewData?)
 }

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -10,6 +10,11 @@ import SwiftUI
 /// mode flips, so the shape animates between the two sizes seamlessly.
 enum NotchDisplayMode { case message, indicator }
 
+enum LinkPreviewState: Equatable {
+    case loading
+    case ready(LinkPreviewData?)
+}
+
 @MainActor
 final class MessageDisplayModel: ObservableObject {
     @Published var mode: NotchDisplayMode = .message
@@ -40,11 +45,8 @@ final class MessageDisplayModel: ObservableObject {
     @Published var fullImages: [String: Data] = [:]
     /// Images whose full fetch failed (expired/offline) — show a warning glyph.
     @Published var failedImages: Set<String> = []
-    /// Open Graph previews scraped for URLs in the message text, keyed by the
-    /// absolute URL string. nil while the fetch is in flight; a present-but-nil
-    /// LinkPreviewData means it resolved to nothing (no card). Filled by the
-    /// link card on appear, cleared when the model is reused for a new message.
-    @Published var linkPreviews: [String: LinkPreviewData?] = [:]
+    @Published var linkPreviews: [String: LinkPreviewState] = [:]
+    @Published var loadingPreviews: Set<String> = []
     /// `id` (r2Key) of the album image currently shown in the large hover
     /// "Quick Look" preview, or nil when none. Set by an `AlbumCell` on hover
     /// (debounced) and force-cleared on every teardown path by NotchPresenter,
@@ -145,6 +147,7 @@ final class MessageDisplayModel: ObservableObject {
         fullImages = [:]
         failedImages = []
         linkPreviews = [:]
+        loadingPreviews = []
         attachedImages = []
         historyExpanded = false
         copiedHistoryID = nil
@@ -226,10 +229,15 @@ final class MessageDisplayModel: ObservableObject {
     func loadLinkPreview(for url: URL) async {
         let key = url.absoluteString
         guard linkPreviews[key] == nil else { return }
-        // Mark in-flight so a re-render doesn't kick off a second fetch.
-        linkPreviews[key] = .some(nil)
+        linkPreviews[key] = .loading
+        let skeletonDelay = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(400))
+            if !Task.isCancelled { self?.loadingPreviews.insert(key) }
+        }
         let data = await LinkPreviewFetcher.shared.preview(for: url)
-        linkPreviews[key] = .some(data)
+        skeletonDelay.cancel()
+        linkPreviews[key] = .ready(data)
+        loadingPreviews.remove(key)
     }
 
     private func flashCopied() {
@@ -868,6 +876,10 @@ private struct HistoryRow: View {
     /// sized, easy-to-hit target over maximum density.
     private let glyphDiameter: CGFloat = 20
 
+    private var linkURL: URL? {
+        entry.isImage ? nil : firstURL(in: entry.text)
+    }
+
     var body: some View {
         Group {
             if expanded {
@@ -885,7 +897,14 @@ private struct HistoryRow: View {
                             }
                         } else {
                             text.fixedSize(horizontal: false, vertical: true)
+                            if let linkURL {
+                                LinkPreviewCard(model: model, url: linkURL)
+                                    .padding(.top, 2)
+                            }
                         }
+                    }
+                    .task(id: linkURL) {
+                        if let linkURL { await model.loadLinkPreview(for: linkURL) }
                     }
                     Spacer(minLength: 4)
                     glyph

--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -31,7 +31,8 @@ struct MessageNotchView: View {
     }
 
     private var textBody: some View {
-        HStack(alignment: .top, spacing: 12) {
+        let url = firstURL(in: message.text)
+        return HStack(alignment: .top, spacing: 12) {
             AvatarView(name: message.sender, imageData: message.avatarData)
 
             VStack(alignment: .leading, spacing: 6) {
@@ -44,9 +45,12 @@ struct MessageNotchView: View {
                         lineLimit: 0
                     ) { [weak model] view in model?.registerLinkHost(view) }
                 }
-                if let url = firstURL(in: message.text) {
+                if let url {
                     LinkPreviewCard(model: model, url: url)
                 }
+            }
+            .task(id: url) {
+                if let url { await model.loadLinkPreview(for: url) }
             }
 
             Spacer(minLength: 12)
@@ -312,10 +316,6 @@ struct ImageCopyHitTarget: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
-/// A small card under a text message that links out: the page's Open Graph
-/// title and, if present, its share image. Scraped once on appear (cached on
-/// the model) and silently absent until — and unless — that succeeds, so a
-/// link with no preview just shows the bare text above. Clicking opens the URL.
 struct LinkPreviewCard: View {
     @ObservedObject var model: MessageDisplayModel
     let url: URL
@@ -328,12 +328,9 @@ struct LinkPreviewCard: View {
     }
 
     var body: some View {
-        Group {
-            if let preview {
-                content(preview)
-            }
+        if let preview {
+            content(preview)
         }
-        .task(id: url) { await model.loadLinkPreview(for: url) }
     }
 
     private func content(_ preview: LinkPreviewData) -> some View {

--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -321,7 +321,6 @@ struct LinkPreviewCard: View {
     let url: URL
 
     @State private var image: CGImage?
-    @State private var shimmer = false
 
     var body: some View {
         switch model.linkPreviews[url.absoluteString] {
@@ -341,24 +340,12 @@ struct LinkPreviewCard: View {
             RoundedRectangle(cornerRadius: 6, style: .continuous)
                 .fill(.white.opacity(0.1))
                 .frame(width: 44, height: 44)
-            VStack(alignment: .leading, spacing: 5) {
-                RoundedRectangle(cornerRadius: 3, style: .continuous)
-                    .fill(.white.opacity(0.1))
-                    .frame(maxWidth: .infinity, minHeight: 9, maxHeight: 9)
-                RoundedRectangle(cornerRadius: 3, style: .continuous)
-                    .fill(.white.opacity(0.1))
-                    .frame(width: 64, height: 8)
-            }
-            Spacer(minLength: 0)
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(.white.opacity(0.1))
+                .frame(maxWidth: .infinity, minHeight: 9, maxHeight: 9)
         }
         .padding(6)
         .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .opacity(shimmer ? 0.5 : 1)
-        .onAppear {
-            withAnimation(.easeInOut(duration: 0.85).repeatForever(autoreverses: true)) {
-                shimmer = true
-            }
-        }
     }
 
     private var fallback: some View {
@@ -368,7 +355,7 @@ struct LinkPreviewCard: View {
                 .foregroundStyle(.white.opacity(0.5))
                 .frame(width: 44, height: 44)
                 .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-            Text(url.host ?? url.absoluteString)
+            Text(url.host ?? "")
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.white)
                 .lineLimit(1)

--- a/apps/macos/Sources/MunkelApp/MessageNotchView.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchView.swift
@@ -321,16 +321,63 @@ struct LinkPreviewCard: View {
     let url: URL
 
     @State private var image: CGImage?
-
-    private var preview: LinkPreviewData? {
-        // Outer optional: not yet fetched. Inner: fetched but had no OG data.
-        (model.linkPreviews[url.absoluteString] ?? nil)
-    }
+    @State private var shimmer = false
 
     var body: some View {
-        if let preview {
-            content(preview)
+        switch model.linkPreviews[url.absoluteString] {
+        case .ready(let data?):
+            content(data)
+        case .ready(nil):
+            fallback
+        case .loading:
+            if model.loadingPreviews.contains(url.absoluteString) { skeleton }
+        case nil:
+            EmptyView()
         }
+    }
+
+    private var skeleton: some View {
+        HStack(spacing: 8) {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(.white.opacity(0.1))
+                .frame(width: 44, height: 44)
+            VStack(alignment: .leading, spacing: 5) {
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .fill(.white.opacity(0.1))
+                    .frame(maxWidth: .infinity, minHeight: 9, maxHeight: 9)
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .fill(.white.opacity(0.1))
+                    .frame(width: 64, height: 8)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(6)
+        .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .opacity(shimmer ? 0.5 : 1)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.85).repeatForever(autoreverses: true)) {
+                shimmer = true
+            }
+        }
+    }
+
+    private var fallback: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "globe")
+                .font(.system(size: 17))
+                .foregroundStyle(.white.opacity(0.5))
+                .frame(width: 44, height: 44)
+                .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            Text(url.host ?? url.absoluteString)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .padding(6)
+        .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .onTapGesture { NSWorkspace.shared.open(url) }
     }
 
     private func content(_ preview: LinkPreviewData) -> some View {


### PR DESCRIPTION
Closes #137

## Summary

Makes the Open Graph link preview card (added in #123) actually render — then rounds it out across the places a link can appear.

## The #137 bug

`LinkPreviewCard.body` attached its `.task { loadLinkPreview }` to a `Group` that was `EmptyView` while `preview == nil` — and SwiftUI doesn't run `.task`/`.onAppear` on empty content, so the fetch never fired and the card never appeared. Fixed by moving the load trigger onto the always-present message `VStack` (mirroring `NotchThumb`).

## Then, polish

- **History** — the card now also renders in expanded message history (`HistoryRow`), not just the current message.
- **Loading skeleton** — a shimmer placeholder shows while the fetch is in flight, *delayed ~400 ms* so fast (and OG-less) fetches don't flash a placeholder that immediately vanishes.
- **Fallback card** — links with no OG data show a compact host card (globe + host) instead of nothing, so every link gets a tidy, clickable affordance.

## Refactor

Replaced the ambiguous `[String: LinkPreviewData?]` cache — where "in flight" and "resolved, no data" were both `.some(nil)` — with an explicit `LinkPreviewState` (`.loading` / `.ready(LinkPreviewData?)`). A separate `loadingPreviews: Set<String>` is the (delayed) "show skeleton" signal.

State → view: `.ready(data)` → card · `.ready(nil)` → fallback · `.loading` past the delay → skeleton · otherwise → nothing. The same `LinkPreviewCard` drives both the current message and history, so all four states apply in both.

## Out of scope

A very long URL still wraps in full in the message body (the existing `LinkText`); the cards themselves stay compact (title/host only). Truncating the displayed URL text would be a separate change.

## Test plan

- [x] `swift build --package-path apps/macos` builds & links clean (CI's `swift test` only covers MunkelKit, not MunkelApp where this lives)
- Manual, driven via `apps/server/scripts/dev-send.ts` against a local relay, hovering the notch to expand:
  - [x] full card (image + title + site) for an OG-rich link as the current message
  - [x] same card in history after a newer message arrives
  - [x] loading skeleton appears and resolves
  - [x] no skeleton flash for fast / OG-less links
  - [x] fallback card (globe + host) for `https://api.github.com` (non-HTML → no OG)
  - [x] long URLs: cards stay compact (host/title); only the message text wraps
  - [ ] skeleton on a genuinely slow (>400 ms) load — confirm the shimmer appears
