### PR TITLE
fix(skills): hide internal github-issue-workflow skill from `skills add`

### DIFF
--- a/.claude/skills/github-issue-workflow/SKILL.md
+++ b/.claude/skills/github-issue-workflow/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: github-issue-workflow
 description: How to start work on a GitHub issue in the munkel repo — check for an existing draft PR and the issue's assignee first to avoid duplicating work someone already owns, claim the issue by assigning it, then open a draft PR linked with "Closes #N" so ownership and in-flight work are visible to everyone. Use whenever asked to work on, start, pick up, take, or implement a GitHub issue (e.g. "arbeite an Issue #N", "work on issue 42", "pick up #99").
+metadata:
+  internal: true
 ---
 
 # Starting work on a GitHub issue

--- a/README.md
+++ b/README.md
@@ -314,6 +314,10 @@ npx skills add limehq/munkel
 The skill is send-only by design, like the CLI. (Installing requires the
 repo to be public.)
 
+Only `skills/` is published this way. Contributor-only skills live under
+`.claude/skills/` — which the `skills` CLI also scans — and set
+`metadata.internal: true` in their frontmatter so `npx skills add` skips them.
+
 ## Testing without a second Mac
 
 `apps/server/scripts/dev-send.ts` acts as a second channel member: it


### PR DESCRIPTION
Closes #156

`npx skills add limehq/munkel` was installing **two** skills: the intended `munkel` skill and the contributor-only `github-issue-workflow` workflow. The [vercel-labs/skills](https://github.com/vercel-labs/skills) CLI scans `.claude/skills/` as a skill container by design, and our workflow skill wasn't marked internal.

## Change
- `.claude/skills/github-issue-workflow/SKILL.md` — add `metadata.internal: true`. The CLI hides skills where `data.metadata?.internal === true` unless `INSTALL_INTERNAL_SKILLS=1` (`src/skills.ts`). Claude Code's local loader ignores the extra key, so the skill still works for contributors.
- `README.md` — note that only `skills/` is published; contributor-local skills under `.claude/skills/` set `metadata.internal: true`.

## Test plan
- [ ] After merge: `npx skills add limehq/munkel` offers only the `munkel` skill (no `github-issue-workflow`).
- [ ] `INSTALL_INTERNAL_SKILLS=1 npx skills add limehq/munkel` surfaces it again (proves the gate).
- [ ] Claude Code still loads `github-issue-workflow` locally in this repo.