### PR TITLE
docs(skills): document git worktree setup in the issue workflow

### DIFF
--- a/.claude/skills/github-issue-workflow/SKILL.md
+++ b/.claude/skills/github-issue-workflow/SKILL.md
@@ -33,13 +33,23 @@ Assignment is the ownership signal:
 gh issue edit N --add-assignee @me      # or the relevant GitHub login
 ```
 
-## 3. Open a draft PR immediately
+## 3. Set up an isolated worktree, then open a draft PR immediately
+
+Work in a dedicated **git worktree**, never the shared root checkout: another
+Claude session may drive this checkout concurrently, and a stray `checkout`
+between two of your commands silently moves HEAD — your commit then lands on
+`main` instead of your branch. Branching from a freshly fetched `origin/main`
+into a new worktree also gives you a clean, up-to-date starting point in one move.
 
 Open the PR *before* the work is finished, so the issue↔PR link exists from the
 start. GitHub needs at least one commit on the branch to open a PR:
 
 ```sh
-git checkout -b <type>/<short-slug> origin/main   # feat/ fix/ docs/ chore/ refactor/
+git fetch origin
+git branch <type>/<short-slug> origin/main                            # feat/ fix/ docs/ chore/ refactor/
+git worktree add .claude/worktrees/<type>+<slug> <type>/<short-slug>  # slug = branch with / → +
+cd .claude/worktrees/<type>+<slug>
+
 git commit --allow-empty -m "chore: start #N"     # or your first real commit
 git push -u origin <type>/<short-slug>
 gh pr create --draft --base main \
@@ -61,6 +71,10 @@ gh pr ready <PR>
 
 ## Notes
 
+- Do **all** edits, commits, and pushes from inside the worktree — never the shared
+  root. Concurrent sessions share one HEAD; the worktree is your isolation. After the
+  PR merges, drop it with `git worktree remove .claude/worktrees/<type>+<slug>`
+  (`.claude/worktrees/` is gitignored).
 - Branch from `main`. This repo **squash-merges**, so intermediate commits on the
   branch never reach `main` history — the PR title becomes the squash commit.
 - Use Conventional Commit types for both the branch prefix and the PR title

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,8 @@ fails otherwise): `cd apps/server && bunx wrangler r2 bucket create munkel-blobs
 ## Working on an issue
 
 Follow the **`github-issue-workflow`** skill: check the issue isn't already taken
-(open/draft PR or an assignee) before starting, then claim it and open a draft PR
-linked with `Closes #N`.
+(open/draft PR or an assignee) before starting, then claim it, work in a dedicated
+`.claude/worktrees/` worktree, and open a draft PR linked with `Closes #N`.
 
 ## Conventions
 


### PR DESCRIPTION
Make the documented `github-issue-workflow` steps actually keep work isolated.

Step 3 previously ran `git checkout -b … origin/main` in the shared root checkout. Concurrent Claude sessions drive the same checkout, so a stray checkout between two commands can move HEAD and land a commit on `main` (happened 2026-06-22). The skill now branches from a freshly fetched `origin/main` into a dedicated `.claude/worktrees/<type>+<slug>` worktree — isolation + clean base + up-to-date in one move — plus a Notes bullet on worktree discipline and cleanup. CLAUDE.md's "Working on an issue" pointer gets a matching half-sentence.

Opened via the new flow itself (dogfood); not issue-driven, so no `Closes #N`.
