### PR TITLE
feat: dim backdrop behind the image preview

### DIFF
--- a/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
+++ b/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
@@ -24,20 +24,19 @@ struct ImagePreviewOverlay: View {
                         .transition(.opacity)
                     PreviewCard(model: model, image: image, available: proxy.size)
                         .id(id)
+                        .colorScheme(.dark)
                         .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .center)))
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         }
-        .colorScheme(.dark)
         .excludedFromScreenCapture()
     }
 }
 
 private struct PreviewBackdrop: View {
     var body: some View {
-        VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
-            .overlay(Color.black.opacity(0.25))
+        Color.black.opacity(0.6)
             .ignoresSafeArea()
     }
 }

--- a/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
+++ b/apps/macos/Sources/MunkelApp/ImagePreviewOverlay.swift
@@ -20,6 +20,8 @@ struct ImagePreviewOverlay: View {
             ZStack {
                 if let id = model.previewImageID,
                    let image = resolvedImages.first(where: { $0.id == id }) {
+                    PreviewBackdrop()
+                        .transition(.opacity)
                     PreviewCard(model: model, image: image, available: proxy.size)
                         .id(id)
                         .transition(.opacity.combined(with: .scale(scale: 0.92, anchor: .center)))
@@ -29,6 +31,14 @@ struct ImagePreviewOverlay: View {
         }
         .colorScheme(.dark)
         .excludedFromScreenCapture()
+    }
+}
+
+private struct PreviewBackdrop: View {
+    var body: some View {
+        VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
+            .overlay(Color.black.opacity(0.25))
+            .ignoresSafeArea()
     }
 }
 

--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -191,7 +191,7 @@ final class MessageDisplayModel: ObservableObject {
         previewDebounce = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .milliseconds(180))
             guard !Task.isCancelled, let self else { return }
-            withAnimation(.easeOut(duration: 0.18)) { self.previewImageID = id }
+            withAnimation(.easeInOut(duration: 0.3)) { self.previewImageID = id }
         }
     }
 
@@ -202,7 +202,7 @@ final class MessageDisplayModel: ObservableObject {
         previewDebounce?.cancel()
         if hoveredImageID == id { hoveredImageID = nil }
         if previewImageID == id {
-            withAnimation(.easeOut(duration: 0.18)) { previewImageID = nil }
+            withAnimation(.easeInOut(duration: 0.24)) { previewImageID = nil }
         }
     }
 
@@ -214,7 +214,7 @@ final class MessageDisplayModel: ObservableObject {
         hoveredImageID = nil
         guard previewImageID != nil else { return }
         if animated {
-            withAnimation(.easeOut(duration: 0.18)) { previewImageID = nil }
+            withAnimation(.easeInOut(duration: 0.24)) { previewImageID = nil }
         } else {
             previewImageID = nil
         }


### PR DESCRIPTION
Closes #159

## What

Hovering an image pops a large preview centered on screen (`ImagePreviewOverlay`).
This adds a full-screen **dim** behind the preview card so the enlarged image reads as
a lightbox — the desktop stays fully visible (sharp), just darkened, keeping spatial
context.

## How

- `PreviewBackdrop` = `Color.black.opacity(0.6)`, full-screen (`ignoresSafeArea`),
  gated on `previewImageID`, fading with the preview.
- The preview toggle animation is softened to `.easeInOut` (0.3 in / 0.24 out) so the
  backdrop and card ease in smoothly instead of snapping.
- Inherits the overlay's existing capture-exclusion and click-through; no new window,
  state, or dependency.

## Evaluation notes

Started as a behind-window blur (`NSVisualEffectView`). In practice the vibrancy
materials read as a heavy, opaque tint over a dark desktop and never gave the
"blurred-but-transparent" look, with no public blur-radius control. A true tint-free
blur would need a private API (`CABackdropLayer`) or a Screen Recording snapshot — both
rejected for a privacy app. A plain dim is simpler, predictable, and is what we actually
wanted: keep the background visible, just focus the image. `0.6` is the single knob.

## Test plan

- [x] `swift build` (MunkelApp) green
- [x] On device (demo history): hover image → screen dims behind the centered preview;
      mouse-out clears it; smooth fade
- [ ] Final reviewer eyeball
