### PR TITLE
feat(macos): Mac App Store build flavor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,11 @@ Single tests:
   identity (bundle id `dev.uq.munkel.debug`, own UserDefaults, control socket,
   and menu-bar icon) that runs side by side with an installed release. It is the
   *debug* configuration; *release* is `Munkel` / `dev.uq.munkel`.
+- `./make-bundle.sh mas` (or `bun run build:mas`) builds the **GUI-only Mac App
+  Store** flavor: sandboxed via `Munkel.mas.entitlements`, with Sparkle and the
+  CLI-install/update menu items stripped (`MUNKEL_MAS=1` drops the Sparkle
+  dependency and defines `MAS` → `#if !MAS`). Same bundle id `dev.uq.munkel`.
+  See `RELEASING.md` → *Mac App Store*.
 - The build goes through **Swift Bundler** via `make-bundle.sh` (not raw `swift
   build`): it assembles the `.app` from `Bundler.toml`, injecting version and
   archs. `scripts/ensure-swift-bundler.sh` builds the pinned bundler on demand.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -179,6 +179,63 @@ First-release note: the release that introduces Sparkle produces the first
 appcast, but existing users run a build without an updater: they update once
 manually, and auto-updates take over from the next release onward.
 
+## Mac App Store (separate distribution)
+
+Munkel also ships a **GUI-only** App Store build alongside the Developer ID +
+DMG + Sparkle path above (dual distribution). Both share the bundle id
+`dev.uq.munkel`; the App Store build differs in what the **App Sandbox** forbids:
+
+- **No CLI.** A sandboxed app can't symlink a binary onto `PATH` or edit shell
+  profiles, and Apple rejects apps that do. The store build omits the embedded
+  `munkel` CLI and its **Install Command Line Tool…** menu item; CLI users stay
+  on Homebrew / direct download.
+- **No Sparkle.** App Store apps update through the store; a bundled updater is a
+  rejection. The build drops the Sparkle dependency entirely and hides the update
+  menu items.
+
+### The build flavor
+
+`make-bundle.sh mas` (or `bun run build:mas` for a universal binary) produces the
+sandboxed app:
+
+- `Package.swift` reads `MUNKEL_MAS=1`, drops Sparkle from the dependency graph,
+  and defines the `MAS` compilation condition. `#if !MAS` guards the updater and
+  CLI-installer code, so the corresponding menu items vanish with it.
+- The bundle is signed with `apps/macos/Munkel.mas.entitlements` (App Sandbox +
+  outgoing network client). Locally that is an ad-hoc signature — enough to
+  verify the app launches sandboxed; the real signing happens at upload.
+
+```sh
+cd apps/macos && ./make-bundle.sh mas
+codesign -d --entitlements - .build/Munkel.app   # app-sandbox + network.client
+```
+
+### Producing the upload (manual, not in CI yet)
+
+The store package needs Apple assets that live outside this repo, so it is not
+wired into `release.yml`. One-time and per-release steps:
+
+1. **Certificates & profile**: an *Apple Distribution* cert and a *Mac Installer
+   Distribution* cert, plus a Mac App Store provisioning profile for
+   `dev.uq.munkel` (embedded at `Contents/embedded.provisionprofile`).
+2. **Re-sign** the `mas` bundle with the Apple Distribution identity and the
+   sandbox entitlements, replacing the local ad-hoc signature.
+3. **Package**: `productbuild --component Munkel.app /Applications --sign "3rd
+   Party Mac Developer Installer: …" Munkel.pkg`.
+4. **Upload** the `.pkg` via Transporter to the App Store Connect record for
+   `dev.uq.munkel`.
+5. **App Store Connect**: screenshots and review notes explaining the menu-bar +
+   notch UI, the screen-capture exclusion, and the ephemeral (no-storage) model.
+6. **Export compliance** (`ITSAppUsesNonExemptEncryption`): Munkel uses
+   AES-256-GCM for E2E messaging — set the key and file the self-classification /
+   annual report per the legal call. Deliberately **not** baked into the build:
+   it is a compliance decision, not a build constant.
+7. **Privacy nutrition labels**: near-zero — the relay and R2 see only opaque
+   ciphertext and nothing is stored (see `PRIVACY.md`).
+
+Tracked in issue #72; CI automation (a separate build+upload job with its own
+certs/secrets) is a follow-up.
+
 ## Why notarization is non-negotiable
 
 Homebrew quarantines cask downloads, deprecated `--no-quarantine` in

--- a/apps/macos/Munkel.mas.entitlements
+++ b/apps/macos/Munkel.mas.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -1,13 +1,27 @@
 // swift-tools-version: 6.0
+import Foundation
 import PackageDescription
+
+// The Mac App Store flavor (MUNKEL_MAS=1, set by make-bundle.sh's `mas` config)
+// runs under the App Sandbox, which forbids a bundled self-updater. So Sparkle is
+// dropped from the dependency graph entirely — not merely left unused — and the
+// `MAS` compilation condition guards its call sites (see UpdaterController.swift).
+let mas = ProcessInfo.processInfo.environment["MUNKEL_MAS"] == "1"
+
+let sparkleDependencies: [Package.Dependency] = mas ? [] : [
+    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
+]
+let sparkleProduct: [Target.Dependency] = mas ? [] : [
+    .product(name: "Sparkle", package: "Sparkle"),
+]
+let masSwiftSettings: [SwiftSetting] = mas ? [.define("MAS")] : []
 
 let package = Package(
     name: "Munkel",
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "3.0.0"),
-        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0"),
-    ],
+    ] + sparkleDependencies,
     targets: [
         .target(name: "MunkelKit"),
         .executableTarget(
@@ -15,10 +29,10 @@ let package = Package(
             dependencies: [
                 "MunkelKit",
                 .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
-                .product(name: "Sparkle", package: "Sparkle"),
-            ],
+            ] + sparkleProduct,
             path: "Sources/MunkelApp",
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: masSwiftSettings
         ),
         .testTarget(
             name: "MunkelKitTests",

--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -67,9 +67,11 @@ final class AppModel: ObservableObject {
         }
     }
 
+    #if !MAS
     /// Sparkle bridge, injected by `AppDelegate` at launch (release build only;
     /// nil in the dev build, which doesn't auto-update).
     var updater: UpdaterController?
+    #endif
     var closePopover: (() -> Void)?
 
     private static let groupsKey = "groupCodes"

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -15,7 +15,7 @@ struct MenuView: View {
     @StateObject private var loginItem = LoginItemModel()
     /// Empty = automatic (active display); otherwise a display's stable UUID.
     @AppStorage(DisplayPreference.key) private var preferredDisplayID = ""
-    #if !DEBUG
+    #if !DEBUG && !MAS
     @State private var cliInstalled = CLIInstaller.isInstalled
     #endif
     #if DEBUG
@@ -96,7 +96,7 @@ struct MenuView: View {
         // reads one can join), the outgoing draft and the GitHub device
         // code, so it stays out of screen shares like the notch does.
         .excludedFromScreenCapture()
-        #if !DEBUG
+        #if !DEBUG && !MAS
         .onAppear { cliInstalled = CLIInstaller.isInstalled }
         #endif
         #if DEBUG
@@ -136,9 +136,11 @@ struct MenuView: View {
             } label: {
                 Label("About Munkel", systemImage: "info.circle")
             }
+            #if !MAS
             if let updater = model.updater {
                 UpdaterMenuItems(updater: updater)
             }
+            #endif
             Button {
                 model.openCommandPalette()
             } label: {
@@ -146,7 +148,7 @@ struct MenuView: View {
             }
             // Release only: the dev build doesn't embed the CLI (run it from
             // source with `MUNKEL_DEV=1 bun apps/cli/src/munkel.ts`).
-            #if !DEBUG
+            #if !DEBUG && !MAS
             if !cliInstalled {
                 Button {
                     CLIInstaller.installFromMenu()
@@ -391,6 +393,7 @@ struct MenuView: View {
     }
 }
 
+#if !MAS
 /// The update section of the settings menu: a prominent "Update to <version>…"
 /// item once Sparkle has found a newer release (its menu-bar "gentle reminder"),
 /// the manual check, and a toggle for background checks. Its own
@@ -415,6 +418,7 @@ private struct UpdaterMenuItems: View {
         Toggle("Check Automatically", isOn: $updater.automaticallyChecksForUpdates)
     }
 }
+#endif
 
 /// A selectable round recipient target with an accent ring when chosen and a
 /// fast custom tooltip on hover (the system `.help()` delay felt laggy). On

--- a/apps/macos/Sources/MunkelApp/MunkelApp.swift
+++ b/apps/macos/Sources/MunkelApp/MunkelApp.swift
@@ -10,9 +10,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem?
     private let popover = NSPopover()
     private var model: AppModel?
+    #if !MAS
     /// Sparkle auto-updater, retained for the process lifetime. Release-only —
     /// nil in the dev build, which must not update the installed release.
     private var updater: UpdaterController?
+    #endif
     /// Guards against the transient-popover flicker: clicking the status
     /// button while open first closes the popover (outside click on
     /// mouseDown), then fires the action (mouseUp) — which would reopen it.
@@ -42,7 +44,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         // Sparkle auto-updates. Release-only: the dev build runs as "Munkel Dev"
         // with its own bundle id and must not update the installed release.
-        #if !DEBUG
+        #if !DEBUG && !MAS
         let updater = UpdaterController()
         self.updater = updater
         model.updater = updater
@@ -81,13 +83,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         item.button?.action = #selector(togglePopover(_:))
         statusItem = item
 
-        #if !DEBUG
+        #if !DEBUG && !MAS
         if let button = item.button {
             installUpdateBadge(on: button, updater: updater)
         }
         #endif
     }
 
+    #if !MAS
     private func installUpdateBadge(on button: NSStatusBarButton, updater: UpdaterController) {
         let badge = NSImageView()
         badge.image = NSImage(systemSymbolName: "circle.fill", accessibilityDescription: "Update available")
@@ -104,6 +107,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             badge.isHidden = version == nil
         }
     }
+    #endif
 
     /// A standard (never-displayed) main menu so the editing actions reach the
     /// first responder — the focused field editor. The App and Edit submenus are

--- a/apps/macos/Sources/MunkelApp/UpdaterController.swift
+++ b/apps/macos/Sources/MunkelApp/UpdaterController.swift
@@ -1,3 +1,4 @@
+#if !MAS
 import Combine
 import Sparkle
 import SwiftUI
@@ -85,3 +86,4 @@ extension UpdaterController: SPUStandardUserDriverDelegate {
         Task { @MainActor in self.availableUpdateVersion = version }
     }
 }
+#endif

--- a/apps/macos/make-bundle.sh
+++ b/apps/macos/make-bundle.sh
@@ -31,6 +31,17 @@ BUNDLE=".build/$APP_NAME.app"
 VERSION="${MUNKEL_VERSION:-0.1.0}"
 IDENTITY="${CODESIGN_IDENTITY:--}"
 
+# The Mac App Store flavor is a release build with Sparkle dropped from the
+# package graph (Package.swift keys off MUNKEL_MAS) and the App Sandbox
+# entitlements applied at sign time. Swift Bundler only understands
+# debug/release, so map mas -> release and carry the flavor through the env.
+if [[ "$CONFIG" == "mas" ]]; then
+  SWIFT_CONFIG="release"
+  export MUNKEL_MAS=1
+else
+  SWIFT_CONFIG="$CONFIG"
+fi
+
 SWIFT_BUNDLER="$("$REPO_ROOT/scripts/ensure-swift-bundler.sh")"
 
 # Inject the version through a throwaway config so the tracked Bundler.toml never
@@ -54,13 +65,13 @@ done
 # toolchain ships a fix — debug is already -Onone and so is unaffected.
 # swift-bundler forwards each --Xswiftpm value straight through to `swift build`.
 opt_workaround=()
-if [[ "$CONFIG" == "release" ]]; then
+if [[ "$SWIFT_CONFIG" == "release" ]]; then
   opt_workaround=(--Xswiftpm -Xswiftc --Xswiftpm -Onone)
 fi
 
 "$SWIFT_BUNDLER" bundle \
   --config-file "$CONFIG_DIR/Bundler.toml" \
-  --configuration "$CONFIG" \
+  --configuration "$SWIFT_CONFIG" \
   --scratch-path .build \
   "${arch_flags[@]}" \
   "${opt_workaround[@]}"
@@ -92,10 +103,17 @@ fi
 
 # Swift Bundler ad-hoc signs; re-sign with our identity (hardened runtime +
 # secure timestamp are notarization prerequisites) or a clean ad-hoc signature.
+# The mas flavor adds the App Sandbox entitlements; ad-hoc locally is enough to
+# verify the app launches sandboxed (the real Apple Distribution cert +
+# provisioning profile are applied at packaging/upload time, see RELEASING.md).
+entitlement_flags=()
+if [[ "$CONFIG" == "mas" ]]; then
+  entitlement_flags=(--entitlements Munkel.mas.entitlements)
+fi
 if [[ "$IDENTITY" == "-" ]]; then
-  codesign --force --sign - "$BUNDLE" >/dev/null 2>&1 || true
+  codesign --force "${entitlement_flags[@]}" --sign - "$BUNDLE" >/dev/null 2>&1 || true
 else
-  codesign --force --options runtime --timestamp --sign "$IDENTITY" "$BUNDLE"
+  codesign --force --options runtime --timestamp "${entitlement_flags[@]}" --sign "$IDENTITY" "$BUNDLE"
 fi
 
 echo "built $BUNDLE ($VERSION)"

--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -6,6 +6,7 @@
 		"dev": "./make-bundle.sh && (pkill -x MunkelDev 2>/dev/null || true) && (nohup .build/MunkelDev.app/Contents/MacOS/MunkelDev >/dev/null 2>&1 &)",
 		"build": "./make-bundle.sh",
 		"build:release": "MUNKEL_ARCHS='arm64 x86_64' ./make-bundle.sh release",
+		"build:mas": "MUNKEL_ARCHS='arm64 x86_64' ./make-bundle.sh mas",
 		"test": "swift test"
 	}
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,7 +386,9 @@ sharing.
   [`apps/landing/wrangler.jsonc`](../apps/landing/wrangler.jsonc).
 - **macOS app + CLI** → distributed as a signed, notarized DMG and via the
   Homebrew cask `limehq/tap/munkel`. Sparkle delivers signed (EdDSA) auto-updates
-  with the appcast at `munkel.app/appcast.xml`.
+  with the appcast at `munkel.app/appcast.xml`. A GUI-only, sandboxed **Mac App
+  Store** flavor (no CLI, no Sparkle) builds from the same sources — see
+  [`RELEASING.md`](../RELEASING.md#mac-app-store-separate-distribution).
 
 Both Cloudflare Workers deploy automatically from GitHub Actions on pushes to
 `main` that touch their paths


### PR DESCRIPTION
Part of #72.

GUI-only **Mac App Store build flavor** (dual distribution — the existing Developer ID + DMG + Sparkle path is untouched). Bundle id stays `dev.uq.munkel` (per the decision on the issue).

## What this PR does (the codeable core)

- Adds `apps/macos/Munkel.mas.entitlements` — App Sandbox + outgoing network client.
- `Package.swift` reads `MUNKEL_MAS=1`, **drops Sparkle from the dependency graph**, and defines the `MAS` compilation condition. `#if !MAS` (type-existence) and `#if !DEBUG && !MAS` (instantiation) guard the updater / CLI-installer code and their menu items.
- `make-bundle.sh` gains a `mas` config: maps to a `release` swift build with `MUNKEL_MAS=1`, then signs with the sandbox entitlements. `bun run build:mas` for a universal binary.
- Docs: `RELEASING.md` gains a **Mac App Store** section (the flavor + the manual upload runbook); `ARCHITECTURE.md` and `CLAUDE.md` get pointers.

The control socket needs no change: a Unix socket binds fine inside the sandbox container, it's just unreachable by an external CLI — which the GUI-only build doesn't ship.

## Verified locally

- `swift build` (default debug) — Sparkle linked, builds. ✅
- `swift build -c release -Xswiftc -Onone` (shipping path) — `Sparkle.framework` copied, updater blocks compiled. ✅
- `MUNKEL_MAS=1 swift build` — Sparkle dropped, every guard excludes correctly. ✅
- `./make-bundle.sh mas` → `.build/Munkel.app`: signature carries `app-sandbox` + `network.client`, **no** Sparkle framework, bundle id `dev.uq.munkel`, no embedded CLI. ✅

## What remains (operational — cannot be done in code here)

- [ ] Apple Distribution + Mac Installer Distribution certs, sandbox provisioning profile
- [ ] `productbuild` → signed `.pkg`, upload via Transporter
- [ ] App Store Connect record (`dev.uq.munkel`), screenshots, review notes
- [ ] Encryption export compliance — `ITSAppUsesNonExemptEncryption` is a legal self-classification, **deliberately not baked into the build**; plus privacy nutrition labels
- [ ] CI MAS build+upload job (distinct certs/secrets)
