### PR TITLE
docs(skills): keep the shell inside the worktree in the issue workflow

### DIFF
--- a/.claude/skills/github-issue-workflow/SKILL.md
+++ b/.claude/skills/github-issue-workflow/SKILL.md
@@ -76,9 +76,7 @@ gh pr ready <PR>
   actually in it: driving it from the shared root with `git -C` or absolute paths
   defeats the purpose, and one stray `cd` away (e.g. for an unrelated call) silently
   puts your next commit on the root's shared HEAD. If something sends you back, `cd`
-  in again before the next `git`. After the PR merges, drop the worktree with
-  `git worktree remove .claude/worktrees/<type>+<slug>` (`.claude/worktrees/` is
-  gitignored).
+  in again before the next `git`.
 - Branch from `main`. This repo **squash-merges**, so intermediate commits on the
   branch never reach `main` history — the PR title becomes the squash commit.
 - Use Conventional Commit types for both the branch prefix and the PR title

--- a/.claude/skills/github-issue-workflow/SKILL.md
+++ b/.claude/skills/github-issue-workflow/SKILL.md
@@ -48,7 +48,7 @@ start. GitHub needs at least one commit on the branch to open a PR:
 git fetch origin
 git branch <type>/<short-slug> origin/main                            # feat/ fix/ docs/ chore/ refactor/
 git worktree add .claude/worktrees/<type>+<slug> <type>/<short-slug>  # slug = branch with / → +
-cd .claude/worktrees/<type>+<slug>
+cd .claude/worktrees/<type>+<slug>   # stay here: run all edits, git, and builds from inside
 
 git commit --allow-empty -m "chore: start #N"     # or your first real commit
 git push -u origin <type>/<short-slug>
@@ -71,10 +71,14 @@ gh pr ready <PR>
 
 ## Notes
 
-- Do **all** edits, commits, and pushes from inside the worktree — never the shared
-  root. Concurrent sessions share one HEAD; the worktree is your isolation. After the
-  PR merges, drop it with `git worktree remove .claude/worktrees/<type>+<slug>`
-  (`.claude/worktrees/` is gitignored).
+- **`cd` into the worktree and run *every* command — edits, `git`, builds — from
+  inside it.** A worktree isolates you only while your shell's working directory is
+  actually in it: driving it from the shared root with `git -C` or absolute paths
+  defeats the purpose, and one stray `cd` away (e.g. for an unrelated call) silently
+  puts your next commit on the root's shared HEAD. If something sends you back, `cd`
+  in again before the next `git`. After the PR merges, drop the worktree with
+  `git worktree remove .claude/worktrees/<type>+<slug>` (`.claude/worktrees/` is
+  gitignored).
 - Branch from `main`. This repo **squash-merges**, so intermediate commits on the
   branch never reach `main` history — the PR title becomes the squash commit.
 - Use Conventional Commit types for both the branch prefix and the PR title


### PR DESCRIPTION
Strengthens the `github-issue-workflow` skill: it documented *creating* a worktree but never told Claude Code to **change its shell into the worktree and run everything from there**. An agent that drives the worktree from the shared root (via `git -C` or absolute paths), or that lets a stray `cd` bounce the shell back to root, can land a commit on the root's shared HEAD — the exact failure the worktree is meant to prevent.

- Inline reminder at the `cd` step: stay here, run all edits/git/builds from inside.
- Notes rule now names the anti-pattern (root + `git -C` / absolute paths, or a stray `cd` back) and the recovery (`cd` in again before the next `git`).

No issue — small self-initiated docs fix, made in its own worktree (dogfooding the rule it adds).
