### PR TITLE
fix(macos): align expanded notch corners with hardware (top 15→10, continuous corners)

### DIFF
--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchHostingContent.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchHostingContent.swift
@@ -15,7 +15,7 @@ struct NotchHostingContent<Content: View>: View {
     @State private var floatingHeight: CGFloat = 0
 
     private let safeAreaInset: CGFloat = 15
-    private let expandedTopCornerRadius: CGFloat = 15
+    private let expandedTopCornerRadius: CGFloat = 10
     private let expandedBottomCornerRadius: CGFloat = 20
     private let floatingCornerRadius: CGFloat = 20
 

--- a/apps/macos/Sources/MunkelApp/NotchPanel/NotchShape.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPanel/NotchShape.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct NotchShape: Shape {
     var topRadius: CGFloat
     var bottomRadius: CGFloat
+    var cornerControlRatio: CGFloat = 0.75
 
     init(topCornerRadius: CGFloat, bottomCornerRadius: CGFloat) {
         self.topRadius = topCornerRadius
@@ -19,32 +20,29 @@ struct NotchShape: Shape {
     }
 
     func path(in rect: CGRect) -> Path {
-        // The straight side walls sit `topRadius` in from each edge; the bottom
-        // corners then bulge a further `bottomRadius` outward.
         let leftWall = rect.minX + topRadius
         let rightWall = rect.maxX - topRadius
+        let handle = bottomRadius * cornerControlRatio
 
         return Path { p in
             p.move(to: CGPoint(x: rect.minX, y: rect.minY))
-            // Concave blend: top edge → left wall.
             p.addQuadCurve(
                 to: CGPoint(x: leftWall, y: rect.minY + topRadius),
                 control: CGPoint(x: leftWall, y: rect.minY)
             )
             p.addLine(to: CGPoint(x: leftWall, y: rect.maxY - bottomRadius))
-            // Convex bottom-left corner.
-            p.addQuadCurve(
+            p.addCurve(
                 to: CGPoint(x: leftWall + bottomRadius, y: rect.maxY),
-                control: CGPoint(x: leftWall, y: rect.maxY)
+                control1: CGPoint(x: leftWall, y: rect.maxY - bottomRadius + handle),
+                control2: CGPoint(x: leftWall + bottomRadius - handle, y: rect.maxY)
             )
             p.addLine(to: CGPoint(x: rightWall - bottomRadius, y: rect.maxY))
-            // Convex bottom-right corner.
-            p.addQuadCurve(
+            p.addCurve(
                 to: CGPoint(x: rightWall, y: rect.maxY - bottomRadius),
-                control: CGPoint(x: rightWall, y: rect.maxY)
+                control1: CGPoint(x: rightWall - bottomRadius + handle, y: rect.maxY),
+                control2: CGPoint(x: rightWall, y: rect.maxY - bottomRadius + handle)
             )
             p.addLine(to: CGPoint(x: rightWall, y: rect.minY + topRadius))
-            // Concave blend: right wall → top edge.
             p.addQuadCurve(
                 to: CGPoint(x: rect.maxX, y: rect.minY),
                 control: CGPoint(x: rightWall, y: rect.minY)


### PR DESCRIPTION
Closes #162

Die erweiterte Notch-Fläche fluchtet an den Ecken jetzt näher an der physischen Notch.

## Änderungen

- **`NotchHostingContent.swift`** — `expandedTopCornerRadius` **15 → 10**. Das obere konkave „Ohr" (Übergang in die Menüleiste) ist enger, so tritt die Fläche näher an der HW-Krümmung aus dem Schlitz aus.
- **`NotchShape.swift`** — die konvexen Unterkanten werden mit **continuous kubischen Béziers** (`addCurve`) statt parabolischer `addQuadCurve` gezeichnet. `cornerControlRatio` (Default **0.75**) ist der Squircle-Regler:
  - `≈0.552` → exakter Kreisbogen
  - `≈0.667` → reproduziert die alte quadratische Kurve
  - höher → voller / squircle-näher

## Bewusst unverändert

- **Unterer Radius bleibt 20** — absichtlich größer als die HW-Notch (~8–14 pt); entspricht der DynamicNotchKit-`.notch`-Konvention, die Fläche „blüht" aus dem Schlitz.
- **Keine** programmatische Display-Radius-Konzentrizität — macOS gibt den Display-Eckradius nicht her, und die freischwebende Unterkante hat keinen Container.

## Test

- `swift build --package-path apps/macos` ✅ (Build complete)
- ⚠️ **Sicht-Prüfung auf einem Notch-Mac ausstehend** (`bun run dev`). `cornerControlRatio` ist die eine Stellschraube — bei Bedarf zwischen 0.67 und 0.85 justieren. Draft, bis das Rendering bestätigt ist.
