### PR TITLE
fix(macos): keep the teaser ticker's trailing fade inside the notch

### DIFF
--- a/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
+++ b/apps/macos/Sources/MunkelApp/MessageNotchContainer.swift
@@ -409,6 +409,7 @@ struct MessageNotchContainer: View {
     /// 30pt from the shape's left side) stays clear of the camera cutout:
     /// side zone = (tickerWindow + 60 − notchWidth) / 2 ≥ 55pt for ≤200pt notches.
     private let tickerWindow: CGFloat = 250
+    private let teaserGlyphInset: CGFloat = 20
 
     var body: some View {
         Group {
@@ -799,7 +800,7 @@ struct MessageNotchContainer: View {
         if message.isImage {
             imageTeaserLine
         } else {
-            TickerText(text: message.text, windowWidth: tickerWindow, onFinished: onTeaserFinished)
+            TickerText(text: message.text, windowWidth: tickerWindow - teaserGlyphInset, onFinished: onTeaserFinished)
         }
     }
 


### PR DESCRIPTION
## Bug

In the one-line notch teaser, a leading globe/lock glyph sits before a `TickerText` sized to the full `tickerWindow` (250pt). The glyph + spacing push the ticker ~18pt past the panel's right edge, so the ticker's own trailing edge-fade (`TickerText.edgeFade`, the last ~4% of its window) lands **beyond** the panel's hard clip. A scrolling message is therefore cut off abruptly on the right while fading correctly on the left.

Pre-existing — reproduces on `main`, independent of the link-preview work in #155.

## Fix

Reserve the leading glyph's footprint (`teaserGlyphInset`) in the ticker's window so `[glyph + ticker]` fits the panel and the trailing fade stays visible.

## Test plan

- [x] `swift build --package-path apps/macos` builds & links
- [x] Manual: sent a long scrolling message via `dev-send.ts` against a local relay — the right edge now fades out like the left, no hard cut
