### PR TITLE
chore: collapse generated routeTree.gen.ts in diffs and PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@ graphify-out/** linguist-generated=true
 graphify-out/graph.json           -diff
 graphify-out/graph.html           -diff
 graphify-out/munkel-callflow.html -diff
+
+# TanStack Router generated route tree: collapse in GitHub PRs + skip textual diffs
+apps/landing/src/routeTree.gen.ts linguist-generated=true -diff


### PR DESCRIPTION
## What
`apps/landing/src/routeTree.gen.ts` (TanStack Router's generated route tree) is committed — by design, so a fresh clone typechecks without a pre-`tsr generate` step. But it produces noisy diffs on every route change.

This adds a `.gitattributes` rule (same pattern already used for `graphify-out/`):

```gitattributes
apps/landing/src/routeTree.gen.ts linguist-generated=true -diff
```

- `linguist-generated=true` → collapsed in GitHub PR diffs + excluded from language stats
- `-diff` → no textual diff locally (regenerate on merge conflict, output is deterministic)

## Why keep it committed (vs gitignore)
`tsc`/`typecheck` doesn't run the Vite plugin, so gitignoring it would require an extra generate step before typecheck in CI. Committing is the TanStack default and the lazy-correct choice.