### PR TITLE
feat(landing): loading spinner on the download buttons

### DIFF
--- a/apps/landing/src/components/download-button.tsx
+++ b/apps/landing/src/components/download-button.tsx
@@ -1,0 +1,25 @@
+import { useRef, useState } from 'react'
+import { Download, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { DOWNLOAD_URL } from '@/lib/constants'
+
+export function DownloadButton() {
+  const [loading, setLoading] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const start = () => {
+    setLoading(true)
+    clearTimeout(timer.current)
+    timer.current = setTimeout(() => setLoading(false), 3000)
+  }
+
+  return (
+    <Button asChild variant="primary">
+      <a href={DOWNLOAD_URL} onClick={start} aria-busy={loading}>
+        {loading ? <Loader2 className="animate-spin" aria-hidden /> : <Download aria-hidden />}
+        Download for macOS
+      </a>
+    </Button>
+  )
+}

--- a/apps/landing/src/components/download-button.tsx
+++ b/apps/landing/src/components/download-button.tsx
@@ -1,10 +1,23 @@
-import { useRef, useState } from 'react'
+import { useRef, useState, type ReactNode } from 'react'
 import { Download, Loader2 } from 'lucide-react'
+import { type VariantProps } from 'class-variance-authority'
 
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import { DOWNLOAD_URL } from '@/lib/constants'
 
-export function DownloadButton() {
+type DownloadButtonProps = VariantProps<typeof buttonVariants> & {
+  className?: string
+  children?: ReactNode
+  'aria-label'?: string
+}
+
+export function DownloadButton({
+  variant = 'primary',
+  size,
+  className,
+  children = 'Download for macOS',
+  'aria-label': ariaLabel,
+}: DownloadButtonProps) {
   const [loading, setLoading] = useState(false)
   const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
@@ -15,10 +28,10 @@ export function DownloadButton() {
   }
 
   return (
-    <Button asChild variant="primary">
-      <a href={DOWNLOAD_URL} onClick={start} aria-busy={loading}>
+    <Button asChild variant={variant} size={size} className={className}>
+      <a href={DOWNLOAD_URL} onClick={start} aria-busy={loading} aria-label={ariaLabel}>
         {loading ? <Loader2 className="animate-spin" aria-hidden /> : <Download aria-hidden />}
-        Download for macOS
+        {children}
       </a>
     </Button>
   )

--- a/apps/landing/src/components/sections/cta.tsx
+++ b/apps/landing/src/components/sections/cta.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
-import { Check, Copy, Download } from 'lucide-react'
+import { Check, Copy } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
-import { BREW_CMD, DOWNLOAD_URL, GITHUB_URL } from '@/lib/constants'
+import { DownloadButton } from '@/components/download-button'
+import { BREW_CMD, GITHUB_URL } from '@/lib/constants'
 
 function BrewCmd() {
   const [copied, setCopied] = useState(false)
@@ -44,12 +45,7 @@ export function Cta() {
           company.
         </p>
         <div className="hero-ctas">
-          <Button asChild variant="primary">
-            <a href={DOWNLOAD_URL}>
-              <Download aria-hidden />
-              Download for macOS
-            </a>
-          </Button>
+          <DownloadButton />
           <Button asChild variant="outline">
             <a href={GITHUB_URL}>View on GitHub</a>
           </Button>

--- a/apps/landing/src/components/sections/hero.tsx
+++ b/apps/landing/src/components/sections/hero.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
 import type { CSSProperties, SVGProps } from 'react'
-import { BatteryMedium, Check, ChevronDown, ChevronUp, Copy, Download, Globe, Wifi } from 'lucide-react'
+import { BatteryMedium, Check, ChevronDown, ChevronUp, Copy, Globe, Wifi } from 'lucide-react'
 import { motion, useMotionValueEvent, useReducedMotion, useScroll, useTransform } from 'motion/react'
 
 import { Button } from '@/components/ui/button'
+import { DownloadButton } from '@/components/download-button'
 import { GithubIcon } from '@/components/icons'
-import { DOWNLOAD_URL, GITHUB_URL } from '@/lib/constants'
+import { GITHUB_URL } from '@/lib/constants'
 import { easeInOutQuad } from '@/lib/motion'
 import { sleep } from '@/lib/utils'
 
@@ -241,12 +242,7 @@ export function Hero() {
               The kind of note you'd say across a table. It slips into your notch, then it's gone.
             </p>
             <div className="hero-ctas">
-              <Button asChild variant="primary">
-                <a href={DOWNLOAD_URL}>
-                  <Download aria-hidden />
-                  Download for macOS
-                </a>
-              </Button>
+              <DownloadButton />
               <Button asChild variant="outline">
                 <a href={GITHUB_URL}>
                   <GithubIcon />

--- a/apps/landing/src/components/sections/nav.tsx
+++ b/apps/landing/src/components/sections/nav.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
-import { Download, Moon, Sun } from 'lucide-react'
+import { Moon, Sun } from 'lucide-react'
 import { motion, useMotionValueEvent, useScroll } from 'motion/react'
 
 import { Button } from '@/components/ui/button'
+import { DownloadButton } from '@/components/download-button'
 import { GithubIcon, MeerkatGlyph } from '@/components/icons'
-import { DOWNLOAD_URL, GITHUB_URL } from '@/lib/constants'
+import { GITHUB_URL } from '@/lib/constants'
 
 const NAV_LINKS = [
   ['#how', 'How it works'],
@@ -69,12 +70,9 @@ export function Nav() {
           </div>
         </div>
         <div className="nav-actions">
-          <Button asChild variant="nav" size="nav" className="nav-cta">
-            <a href={DOWNLOAD_URL} aria-label="Download">
-              <Download aria-hidden />
-              <span>Download</span>
-            </a>
-          </Button>
+          <DownloadButton variant="nav" size="nav" className="nav-cta" aria-label="Download">
+            <span>Download</span>
+          </DownloadButton>
           <Button asChild variant="ghost" size="icon">
             <a href={GITHUB_URL} aria-label="GitHub" title="GitHub">
               <GithubIcon />


### PR DESCRIPTION
Follow-up to #167 (the `/download/latest` direct download).

## What

Clicking **Download** navigates to `/download/latest`, which resolves the DMG server-side before redirecting — a brief moment with no feedback. A shared **`DownloadButton`** now swaps the icon for a spinning `Loader2` (shadcn style) on click, so the click registers immediately. Used by all three download CTAs: **hero, final CTA, and the nav bar**.

The `<a>` keeps its native navigation (works without JS; `href` stays intact → `cursor: pointer` preserved). A download keeps the page mounted, so there's no "download started" event — the spinner resets on a short timer (the server's GitHub fetch is capped at 3 s).

## Test plan

- [x] `bun run typecheck` && `bun run build` green
- [x] Clicking Download in the hero, final CTA, and nav swaps the icon to a spinning `Loader2` — verified live (`aria-busy=true`, `svg` gets `animate-spin`); the `.dmg` still downloads
- [x] Buttons keep `cursor: pointer`
