### PR TITLE
ci: scope release-please to the desktop app

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,9 +38,13 @@ the app's control socket), so they never get separate numbers. The
 Conventional Commits on `main` (`feat:` → minor, `fix:` → patch, `feat!:`
 → breaking) feed a rolling release PR that maintains `CHANGELOG.md` and
 computes the next version. **Merging that PR is the release**: it creates
-tag + GitHub release and dispatches the desktop build. Note the scope:
-release-please watches the whole repo, so server/landing commits also land
-in the product changelog, which is intentional (one product, one version).
+tag + GitHub release and dispatches the desktop build. Scope: the version is
+the **desktop app's** version, so release-please's root package excludes the
+independently-deployed surfaces via `exclude-paths` in `release-please-config.json`
+(`apps/landing`, `apps/server`, and the generated `graphify-out/`). A commit that
+only touches those is deployed by its own path-triggered workflow and never cuts
+an app release. Protocol/crypto changes in `apps/server` always co-change the
+Swift mirror in `apps/macos`, so they still land in the release.
 
 Escape hatch: a manually pushed `v*` tag still triggers `release.yml`
 directly, bypassing release-please.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
 	"packages": {
 		".": {
 			"package-name": "munkel",
-			"changelog-path": "CHANGELOG.md"
+			"changelog-path": "CHANGELOG.md",
+			"exclude-paths": ["apps/landing", "apps/server", "graphify-out"]
 		}
 	}
 }


### PR DESCRIPTION
## Problem

The version release-please tracks **is the macOS desktop app's version** — it drives the DMG, the Sparkle auto-update appcast, and the Homebrew cask. But the root package watched the whole repo, so a **landing- or server-only** change still cut a full app release.

Concretely, #172: a landing-only commit (`feat(landing):` #170) bumped to `0.15.0` and would dispatch the entire macOS build → Developer ID sign → notarize → staple → DMG → Sparkle appcast (pushed to every installed app via auto-update) → cask bump — with **nothing in the app changed**.

## Fix

Add `exclude-paths` to the root package in `release-please-config.json`:

```json
"exclude-paths": ["apps/landing", "apps/server", "graphify-out"]
```

- `apps/landing` and `apps/server` each deploy continuously via their own path-triggered workflows (`deploy-landing.yml`, `deploy-server.yml`) — they were never meant to bump the app version.
- `graphify-out/` is a generated knowledge-graph artifact that's intentionally committed and regenerated on essentially every code change (`graphify update .`). #170 touched 12 files there alongside the landing diff — without excluding it the carve-out would be defeated.

A commit touching **only** excluded paths is dropped from the root package's commit attribution → no release PR. Anything touching `apps/macos`, `apps/cli`, `scripts/`, docs, etc. still cuts a release as before.

### Why this stays correct

Per `CLAUDE.md`, the wire protocol (`apps/server/src/protocol.ts`) and crypto interop **must** be mirrored in Swift (`apps/macos`) byte-for-byte — "change one → change all three." So any `apps/server` change that affects the app is always a co-change with `apps/macos` and still triggers a release. Excluding `apps/server` only drops relay-internal changes, which are deployed by their own workflow.

Tag format, `CHANGELOG.md` location, and the manifest key (`.`) are unchanged.

## Effect on #172

Once this lands on `main`, release-please re-scans and finds no releasable commit since `v0.14.0` (the only one is the now-excluded landing change) → it **closes the open release PR #172 automatically**.

## Test plan

- [ ] Merge → confirm release-please run closes #172 and opens no new release PR
- [ ] Next `apps/macos`/`apps/cli` change → confirm a release PR is still created

Docs: `RELEASING.md` scope note updated (it previously claimed "watches the whole repo … intentional").
