### PR TITLE
feat(landing): refine hero scroll pacing (earlier copy fade, slower mockup rise)

### DIFF
--- a/apps/landing/src/components/sections/hero.tsx
+++ b/apps/landing/src/components/sections/hero.tsx
@@ -104,7 +104,7 @@ export function Hero() {
   const pz = useTransform(scrollYProgress, [0.3, 1], [0, 1], { ease: easeInOutQuad })
   const pr = useTransform(scrollYProgress, [0.24, 0.34], [0, 1], { ease: easeInOutQuad })
 
-  const copyOpacity = useTransform(pm, [0.6, 1], [1, 0])
+  const copyOpacity = useTransform(pm, [0.4, 0.9], [1, 0])
   const copyZ = useTransform(pc, [0, 1], [0, -140])
   const copyPointer = useTransform(pc, (v) => (v > 0.5 ? 'none' : 'auto'))
   const hintOpacity = useTransform(pc, [0, 0.25], [1, 0])

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -575,7 +575,7 @@ nav.floating .nav-inner {
   background: radial-gradient(ellipse 50% 60% at 50% 0%, var(--brand-soft), transparent 70%);
   pointer-events: none;
 }
-.hero-stage { height: 220vh; height: 220lvh; position: relative; }
+.hero-stage { height: 280vh; height: 280lvh; position: relative; }
 .hero-sticky { position: sticky; top: 0; height: 100vh; height: 100lvh; overflow: hidden; }
 .hero-copy { position: relative; padding-top: 12vh; will-change: transform, opacity; z-index: 2; }
 /* Anchored to the viewport (not the 100vh sticky, which the in-flow announce bar
@@ -1274,7 +1274,7 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0 calc(2rem + env(sa
   .how-grid { grid-template-columns: 1fr; gap: 2rem; }
   .how-head { position: static; }
   .cli-grid, .privacy-grid, .agents-grid { grid-template-columns: 1fr; }
-  .hero-stage { height: 210vh; height: 210lvh; }
+  .hero-stage { height: 260vh; height: 260lvh; }
   .hero-copy { padding-top: 8vh; }
   .mockup-wrap { margin-top: 3rem; }
   /* The notch is internally 1:1 with the app (310pt etc.); on narrow viewports

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -575,7 +575,7 @@ nav.floating .nav-inner {
   background: radial-gradient(ellipse 50% 60% at 50% 0%, var(--brand-soft), transparent 70%);
   pointer-events: none;
 }
-.hero-stage { height: 280vh; height: 280lvh; position: relative; }
+.hero-stage { height: 320vh; height: 320lvh; position: relative; }
 .hero-sticky { position: sticky; top: 0; height: 100vh; height: 100lvh; overflow: hidden; }
 .hero-copy { position: relative; padding-top: 12vh; will-change: transform, opacity; z-index: 2; }
 /* Anchored to the viewport (not the 100vh sticky, which the in-flow announce bar
@@ -1274,7 +1274,7 @@ footer { border-top: 1px solid var(--border); padding: 2rem 0 calc(2rem + env(sa
   .how-grid { grid-template-columns: 1fr; gap: 2rem; }
   .how-head { position: static; }
   .cli-grid, .privacy-grid, .agents-grid { grid-template-columns: 1fr; }
-  .hero-stage { height: 260vh; height: 260lvh; }
+  .hero-stage { height: 300vh; height: 300lvh; }
   .hero-copy { padding-top: 8vh; }
   .mockup-wrap { margin-top: 3rem; }
   /* The notch is internally 1:1 with the app (310pt etc.); on narrow viewports


### PR DESCRIPTION
Closes #175

Follow-up pacing tweaks to the hero scroll (after #170). Feel-tuning constants only — no logic or types changed, reduced-motion path untouched.

- **Copy fades earlier** — `copyOpacity` input `[0.6, 1] → [0.4, 0.9]` (`hero.tsx`), so the headline/CTA block starts dissolving sooner and clears just before the MacBook fills the frame.
- **Slower mockup rise** — `.hero-stage` height `220vh → 320vh` (narrow breakpoint `210vh → 300vh`) in `styles.css`. `scrub` derives from the stage height, so the whole scrubbed timeline (rise + zoom into the foreground) now plays over more scroll instead of snapping forward.
