### PR TITLE
feat(macos): show your own messages in the notch

### DIFF
--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -86,16 +86,6 @@ final class AppModel: ObservableObject {
     private static let relayURLOverride: String? = ProcessInfo.processInfo
         .environment["MUNKEL_RELAY_URL"].flatMap { $0.isEmpty ? nil : $0 }
 
-    #if DEBUG
-    /// Dev-only: echo my own broadcasts into my notch (Settings toggle), so a
-    /// solo developer can see a sent message without a second member online —
-    /// the relay delivers a broadcast only to the *other* members. Default on.
-    static var devEchoBroadcasts: Bool {
-        get { (UserDefaults.standard.object(forKey: "devEchoBroadcasts") as? Bool) ?? true }
-        set { UserDefaults.standard.set(newValue, forKey: "devEchoBroadcasts") }
-    }
-    #endif
-
     private var sessions: [String: GroupSession] = [:]
     private let notch = NotchPresenter()
     private var controlServer: ControlServer?
@@ -151,12 +141,7 @@ final class AppModel: ObservableObject {
     func send(text: String, group code: String, to memberId: String? = nil) {
         guard let session = sessions[code] else { return }
         Task { await session.sendChat(text, to: memberId) }
-        #if DEBUG
-        // Dev aid: the relay delivers a broadcast only to the *other* members,
-        // so a solo developer never sees their own message. With the Settings
-        // toggle on, echo broadcasts (to: nil) into our own notch as if they
-        // had arrived — same path the live onChat handler uses.
-        if memberId == nil, Self.devEchoBroadcasts {
+        if memberId == nil {
             notch.show(
                 sender: displayName,
                 avatarData: Identity.avatarData,
@@ -173,7 +158,6 @@ final class AppModel: ObservableObject {
                 }
             }
         }
-        #endif
     }
 
     /// Send one or more images (an album), optionally with a caption. The
@@ -182,11 +166,7 @@ final class AppModel: ObservableObject {
     func send(images datas: [Data], caption: String = "", group code: String, to memberId: String? = nil) {
         guard let session = sessions[code], !datas.isEmpty else { return }
         Task { await session.sendImages(datas, caption: caption, to: memberId) }
-        #if DEBUG
-        // Dev echo (same rationale as the text path): a broadcast only reaches
-        // *other* members, so show our own album locally too. Decode off-main;
-        // the per-image loader returns the local full bytes — no R2 round trip.
-        if memberId == nil, Self.devEchoBroadcasts {
+        if memberId == nil {
             Task { [weak self] in
                 let built = await Task.detached { () -> (images: [IncomingImage], fulls: [String: Data])? in
                     let datas = Array(datas.prefix(AppPayload.maxImagesPerMessage))
@@ -195,9 +175,6 @@ final class AppModel: ObservableObject {
                     var fulls: [String: Data] = [:]
                     for (index, data) in datas.enumerated() {
                         guard let full = ImageCodec.prepareFull(from: data) else { continue }
-                        // Mirror sendImages: reuse the full AVIF as the preview
-                        // when it fits, else a small AVIF — so the local echo
-                        // matches what peers actually receive.
                         let thumb = full.data.count <= perThumb
                             ? full.data
                             : ImageCodec.makeThumbnail(from: data, maxBytes: perThumb)
@@ -228,7 +205,6 @@ final class AppModel: ObservableObject {
                 }
             }
         }
-        #endif
     }
 
     #if DEBUG

--- a/apps/macos/Sources/MunkelApp/MenuView.swift
+++ b/apps/macos/Sources/MunkelApp/MenuView.swift
@@ -19,7 +19,6 @@ struct MenuView: View {
     @State private var cliInstalled = CLIInstaller.isInstalled
     #endif
     #if DEBUG
-    @AppStorage("devEchoBroadcasts") private var devEchoBroadcasts = true
     @AppStorage(CaptureScreenshotPreference.defaultsKey) private var allowInScreenshots = false
     #endif
 
@@ -179,7 +178,6 @@ struct MenuView: View {
             }
             #if DEBUG
             Divider()
-            Toggle("Echo my broadcasts to me", isOn: $devEchoBroadcasts)
             Toggle("Allow in screenshots", isOn: $allowInScreenshots)
             // Seed a demo backlog (text + image messages) into the notch so the
             // expanded-history hover preview can be tested without real traffic.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,6 +208,11 @@ AVIF thumbnail plus an `r2Key` pointer per image (see
 [`GroupSession.sendImages`](../apps/macos/Sources/MunkelApp/GroupSession.swift)
 and [`blob.ts`](../apps/server/src/blob.ts)).
 
+The sender also surfaces its own broadcast locally: `AppModel.send` shows it in
+the sender's own notch (broadcasts only, `to` unset), so you see what you sent.
+The relay still never echoes (point 4) — this is a purely local render; direct
+messages (`to` set) are not shown back.
+
 ### Receiving a message
 
 1. On connect the relay sends a `welcome` frame listing the other members


### PR DESCRIPTION
## What

Promotes the dev-only "echo my broadcasts" behavior to a real, always-on
feature: when you send a message to a channel, your own message now appears in
your own notch, the way every chat app shows what you just sent.

Previously this was a `#if DEBUG` Settings toggle ("Echo my broadcasts to me"),
debug-builds only and worded in implementation jargon.

## Why

The toggle was too technical and debug-gated. Sending to a channel gave the
sender zero feedback (the relay delivers a broadcast only to the *other*
members). Seeing your own message is a sent-confirmation users expect.

Direction picked via `/design-shotgun`: **"always on, no setting"** — the
cleanest fix for "too technical" is to delete the setting. No jargon, nothing to
explain, matches the convention of every chat app.

## Changes

- `AppModel.swift` — un-gate both echo paths (text + images); the local echo now
  runs for every broadcast (`to == nil`). Removed `devEchoBroadcasts`.
- `MenuView.swift` — removed the DEBUG toggle + its `@AppStorage`.
- `docs/ARCHITECTURE.md` — documents the local render in the send flow.

## Behavior / scope

- Broadcasts (`to` unset) → shown in your own notch.
- Direct messages (`to` set) → not echoed back.
- Relay unchanged: still never echoes, no storage.

## Test plan

- [x] `swift build` (DEBUG) green
- [ ] Broadcast (`munkel <channel> all "…"`) → own message appears in the notch
- [ ] DM (`munkel dm <name> "…"`) → does not appear in your own notch
- [ ] Reply field from the echoed message still sends (reply-to-self allowed)

## Notes

- No unit test: `send()`'s notch side-effect has no test seam without a
  NotchPresenter injection refactor; the changed logic is a one-line `to == nil`
  branch.
- `graphify-out/` intentionally not regenerated (tracked; would bloat the diff) —
  refresh on main post-merge.
