### PR TITLE
fix(landing): preload Geist webfonts to remove first-load font flicker (FOUT)

### DIFF
--- a/apps/landing/src/routes/__root.tsx
+++ b/apps/landing/src/routes/__root.tsx
@@ -5,6 +5,8 @@ import { PostHogProvider } from '@posthog/react'
 import { useEffect, useState, type ReactNode } from 'react'
 
 import appCss from '../styles.css?url'
+import geistLatinWoff2 from '@fontsource-variable/geist/files/geist-latin-wght-normal.woff2?url'
+import geistMonoLatinWoff2 from '@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2?url'
 
 const SITE_URL = 'https://munkel.app'
 const TITLE = 'Munkel · ephemeral messages from the notch'
@@ -39,6 +41,20 @@ export const Route = createRootRoute({
       { name: 'twitter:image', content: OG_IMAGE },
     ],
     links: [
+      {
+        rel: 'preload',
+        href: geistLatinWoff2,
+        as: 'font',
+        type: 'font/woff2',
+        crossOrigin: 'anonymous',
+      },
+      {
+        rel: 'preload',
+        href: geistMonoLatinWoff2,
+        as: 'font',
+        type: 'font/woff2',
+        crossOrigin: 'anonymous',
+      },
       { rel: 'stylesheet', href: appCss },
       { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
       { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32.png' },

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -57,8 +57,23 @@
   to { height: 0; }
 }
 
+/* Metric-matched fallback so the font-display:swap from the system font to Geist
+   reflows nothing: local Arial scaled to Geist's own box. size-adjust =
+   (Geist xAvg 581/upm 1000) / (Arial xAvg 1117/upm 2048); ascent/descent
+   overrides = Geist sTypoAscender 1005 / -295 over (upm * size-adjust). Derived
+   from the woff2 OS/2 table — regenerate if Geist's metrics change. Sits before
+   system-ui in --font-sans so it wins during the swap window. */
+@font-face {
+  font-family: 'Geist Fallback';
+  src: local('Arial');
+  size-adjust: 106.53%;
+  ascent-override: 94.34%;
+  descent-override: 27.69%;
+  line-gap-override: 0%;
+}
+
 :root {
-  --font-sans: 'Geist Variable', 'Geist', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-sans: 'Geist Variable', 'Geist', 'Geist Fallback', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   --font-heading: var(--font-sans);
   --font-mono: 'Geist Mono Variable', 'Geist Mono', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 


### PR DESCRIPTION
## Problem

On first load the landing page shows a brief flicker: the hero headline (and body copy) paint in the macOS system font, then visibly swap to **Geist** a moment later. It predates the PostHog change and is purely a CSS/font-delivery timing issue.

## Root cause — FOUT (flash of unstyled text)

Geist and Geist Mono are self-hosted via Fontsource. Their `@font-face` rules live **inside** the single render-blocking stylesheet and are all `font-display: swap`, and the `<head>` preloads several images but **no fonts**. So the browser only discovers the woff2 URLs *after* it has downloaded and parsed the CSS, then fetches them — chained, not parallel. Until they arrive, text renders in the system fallback (SF Pro) and then swaps to Geist — a flash of unstyled text, plus a layout shift on the large hero `h1` (Geist is ~5.7% wider, so the line re-balances). Worst on cold/slow loads.

Investigated and ruled out: missing-CSS FOUC (the stylesheet is a render-blocking `<link>` in the SSR head), a Framer-Motion mount snap (the hero's resting transform/opacity are server-rendered inline), Vite dev FOUC (dev serves real render-blocking CSS too), theme/background flash (250+ captured paint frames were all dark), and React-19 stylesheet suspense. The conditional `PostHogProvider` remount is a **separate** latent issue that postdates this report — fixed in its own PR, not here.

## Fix (two complementary parts)

**1. Preload the fonts** so they fetch in parallel with the CSS instead of chained behind it. Latin Geist + Geist-Mono variable woff2, imported via Vite `?url` so the URL tracks the content hash automatically:

```ts
import geistLatinWoff2 from '@fontsource-variable/geist/files/geist-latin-wght-normal.woff2?url'
import geistMonoLatinWoff2 from '@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2?url'
// added to head().links as { rel: 'preload', as: 'font', type: 'font/woff2', crossOrigin: 'anonymous' }
```

The preload scanner now fetches the fonts during initial HTML parse, in parallel with the CSS, so Geist is font-ready at/near first paint and the swap window collapses on normal loads.

**2. Metric-matched fallback** so the residual swap on a cold/slow first load reflows nothing. A `Geist Fallback` `@font-face` (local Arial scaled to Geist's exact box) slotted before `system-ui` in `--font-sans`:

```css
@font-face {
  font-family: 'Geist Fallback';
  src: local('Arial');
  size-adjust: 106.53%;      /* (Geist xAvg 581/1000) / (Arial xAvg 1117/2048) */
  ascent-override: 94.34%;   /* Geist sTypoAscender 1005 / (1000 * size-adjust) */
  descent-override: 27.69%;  /* Geist sTypoDescender 295 / (1000 * size-adjust) */
  line-gap-override: 0%;
}
```

Before Geist loads, text renders in Arial scaled to Geist's metrics → same footprint → the `font-display: swap` to Geist is geometry-neutral (no layout shift). `font-display: swap` is kept, so text is never invisible. Sans only — the hero `h1` is the visible CLS; Geist Mono is small UI labels.

Details:
- `crossOrigin: 'anonymous'` is required even though the files are same-origin — fonts are always fetched in anonymous-CORS mode, and the camelCase prop is what makes React 19 emit `crossorigin`, so the preload shares **one** cache entry with the CSS-triggered fetch (no double download).
- Only the latin subset is preloaded (the copy is English); preloading every subset would waste high-priority bandwidth.
- Source order of the preloads vs the stylesheet is cosmetic — React 19 hoists the `data-precedence` stylesheet above them. The win is the preload existing (parallel fetch), not out-ordering the CSS.
- Fallback override values are derived from the woff2 OS/2 table (documented inline); regenerate if Geist's metrics change.

## Verification

- `bun run typecheck` + `bun run build` (`@munkel/landing`) pass.
- Built worker SSR `<head>` emits both `<link rel="preload" … as="font" … crossorigin="anonymous">` with the hashed URLs; preload `href` and `@font-face` `src` resolve to the same asset → single fetch (no double download).
- Built CSS ships the `Geist Fallback` `@font-face` with `--font-sans` slotting it before `system-ui`; override math independently re-derived from the woff2 metrics (matches the shipped values).
- Browser load of the built worker: `h1` renders in Geist Variable, fonts loaded, no console errors.

## Follow-up (separate PR)

The `PostHogProvider` is conditionally mounted in `__root.tsx` (state flips in `useEffect`), which changes the React tree shape on hydration and remounts the page subtree — a separate minor flicker. Fixed in its own PR by always mounting the provider and gating only `posthog.init()`.
