### PR TITLE
fix(landing): stop remounting the page on hydration (stable PostHogProvider)

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -33,6 +33,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.21.0",
     "motion": "^12.40.0",
+    "posthog-js": "^1.393.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwind-merge": "^3.6.0",

--- a/apps/landing/src/routes/__root.tsx
+++ b/apps/landing/src/routes/__root.tsx
@@ -2,7 +2,8 @@ import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router'
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
 import { TanStackDevtools } from '@tanstack/react-devtools'
 import { PostHogProvider } from '@posthog/react'
-import { useEffect, useState, type ReactNode } from 'react'
+import posthog from 'posthog-js'
+import { useEffect, type ReactNode } from 'react'
 
 import appCss from '../styles.css?url'
 
@@ -70,11 +71,24 @@ function analyticsOptedOut(): boolean {
   return dnt === '1' || dnt === 'yes'
 }
 
+let analyticsInitialized = false
+
 function RootDocument({ children }: { children: ReactNode }) {
   const posthogKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY as string | undefined
-  const [analyticsOn, setAnalyticsOn] = useState(false)
   useEffect(() => {
-    if (posthogKey && !analyticsOptedOut()) setAnalyticsOn(true)
+    if (analyticsInitialized || !posthogKey || analyticsOptedOut()) return
+    analyticsInitialized = true
+    posthog.init(posthogKey, {
+      api_host: '/relay-Hk2p',
+      ui_host: 'https://eu.posthog.com',
+      defaults: '2026-01-30',
+      person_profiles: 'identified_only',
+      cookieless_mode: 'always',
+      disable_session_recording: true,
+      autocapture: false,
+      capture_performance: false,
+      respect_dnt: true,
+    })
   }, [posthogKey])
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
@@ -83,26 +97,7 @@ function RootDocument({ children }: { children: ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        {analyticsOn && posthogKey ? (
-          <PostHogProvider
-            apiKey={posthogKey}
-            options={{
-              api_host: '/relay-Hk2p',
-              ui_host: 'https://eu.posthog.com',
-              defaults: '2026-01-30',
-              person_profiles: 'identified_only',
-              cookieless_mode: 'always',
-              disable_session_recording: true,
-              autocapture: false,
-              capture_performance: false,
-              respect_dnt: true,
-            }}
-          >
-            {children}
-          </PostHogProvider>
-        ) : (
-          children
-        )}
+        <PostHogProvider client={posthog}>{children}</PostHogProvider>
         {/* Stripped from production builds by @tanstack/devtools-vite — do not
             wrap in a manual DEV gate; its AST transform chokes on that. */}
         <TanStackDevtools

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^1.21.0",
         "motion": "^12.40.0",
+        "posthog-js": "^1.393.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwind-merge": "^3.6.0",


### PR DESCRIPTION
## Problem

`RootDocument` mounts `PostHogProvider` conditionally:

```tsx
const [analyticsOn, setAnalyticsOn] = useState(false)
useEffect(() => { if (posthogKey && !analyticsOptedOut()) setAnalyticsOn(true) }, [posthogKey])
// …
{analyticsOn && posthogKey ? <PostHogProvider …>{children}</PostHogProvider> : children}
```

`analyticsOn` starts `false` and flips to `true` in a `useEffect` after hydration. That swaps the element type wrapping `children` (`children` → `PostHogProvider`), and per React's reconciliation rules a direct-parent type change **tears down and remounts the entire landing-page subtree** on first load — a brief flicker (DOM rebuild, re-run mount effects, restarted CSS animations).

This is a separate, smaller issue than the font FOUT (#179) — it postdates that report — but it's a real avoidable remount.

## Fix

Always render the provider with a stable `client`, and gate only initialization:

```tsx
import posthog from 'posthog-js'

let analyticsInitialized = false

useEffect(() => {
  if (analyticsInitialized || !posthogKey || analyticsOptedOut()) return
  analyticsInitialized = true
  posthog.init(posthogKey, { /* same options */ })
}, [posthogKey])
// …
<PostHogProvider client={posthog}>{children}</PostHogProvider>
```

`PostHogProvider` is a context provider that renders **no DOM**, so always mounting it leaves the SSR/hydration output byte-for-byte the same — but the React tree shape no longer changes after hydration, so there's no remount. The privacy gate is unchanged: `posthog.init()` still runs only on the client, only when the key is present and the visitor hasn't opted out via DNT/GPC. This is PostHog's documented `client={…}` pattern.

`DownloadButton`'s `usePostHog()` now receives the singleton via context (instead of `undefined` pre-consent); `posthog.capture()` is a no-op until `init`, so behavior and privacy are equivalent.

## Verification

- `bun run typecheck` + `bun run build` (`@munkel/landing`) pass.
- Built worker SSR response is identical (HTTP 200, same 73,546 bytes, hero rendered, `<body>` structure unchanged) — confirming the always-mounted provider adds no DOM and doesn't change hydration.
- Net `−3` lines in `__root.tsx`; `posthog-js` added as a direct dep (deduped to the single existing `1.393.1`).

Stacks conceptually with #179 (the font flicker); independent change, opened separately for clean review.
