### PR TITLE
feat(landing): track CTA and nav/footer link clicks in PostHog

### DIFF
--- a/apps/landing/src/components/github-button.tsx
+++ b/apps/landing/src/components/github-button.tsx
@@ -1,0 +1,37 @@
+import { type ReactNode } from 'react'
+import { Star } from 'lucide-react'
+import { type VariantProps } from 'class-variance-authority'
+import { usePostHog } from '@posthog/react'
+
+import { Button, buttonVariants } from '@/components/ui/button'
+import { GITHUB_URL } from '@/lib/constants'
+
+type GithubButtonProps = VariantProps<typeof buttonVariants> & {
+  location: string
+  className?: string
+  children?: ReactNode
+}
+
+export function GithubButton({
+  location,
+  variant = 'outline',
+  size,
+  className,
+  children = 'Star on GitHub',
+}: GithubButtonProps) {
+  const posthog = usePostHog()
+
+  return (
+    <Button asChild variant={variant} size={size} className={className}>
+      <a
+        href={GITHUB_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={() => posthog?.capture('cta_github_clicked', { location })}
+      >
+        <Star aria-hidden />
+        {children}
+      </a>
+    </Button>
+  )
+}

--- a/apps/landing/src/components/sections/announce-bar.tsx
+++ b/apps/landing/src/components/sections/announce-bar.tsx
@@ -1,18 +1,21 @@
 import { ArrowRight, MonitorSmartphone } from 'lucide-react'
+import { usePostHog } from '@posthog/react'
 
 import { GITHUB_URL } from '@/lib/constants'
 
 export function AnnounceBar() {
+  const posthog = usePostHog()
   return (
     <a
       className="announce"
       href={GITHUB_URL}
       aria-label="Munkel is coming to Windows soon"
+      onClick={() => posthog?.capture('announce_windows_clicked')}
     >
       <span className="announce-tag">Soon</span>
       <span className="announce-text">
         <MonitorSmartphone aria-hidden />
-        <strong>Windows</strong> is learning to munkel.
+        Windows is learning to munkel.
       </span>
       <ArrowRight className="announce-arrow" aria-hidden />
     </a>

--- a/apps/landing/src/components/sections/cta.tsx
+++ b/apps/landing/src/components/sections/cta.tsx
@@ -1,15 +1,18 @@
 import { useState } from 'react'
 import { Check, Copy } from 'lucide-react'
+import { usePostHog } from '@posthog/react'
 
-import { Button } from '@/components/ui/button'
 import { DownloadButton } from '@/components/download-button'
-import { BREW_CMD, GITHUB_URL } from '@/lib/constants'
+import { GithubButton } from '@/components/github-button'
+import { BREW_CMD } from '@/lib/constants'
 
 function BrewCmd() {
+  const posthog = usePostHog()
   const [copied, setCopied] = useState(false)
 
   const copy = () => {
     if (navigator.clipboard) navigator.clipboard.writeText(BREW_CMD).catch(() => {})
+    posthog?.capture('cta_brew_copied', { location: 'footer' })
     setCopied(true)
     setTimeout(() => setCopied(false), 1400)
   }
@@ -46,9 +49,7 @@ export function Cta() {
         </p>
         <div className="hero-ctas">
           <DownloadButton location="footer" />
-          <Button asChild variant="outline">
-            <a href={GITHUB_URL}>View on GitHub</a>
-          </Button>
+          <GithubButton location="footer" />
         </div>
         <BrewCmd />
         <div className="hero-meta">Signed &amp; notarized · no app telemetry · macOS 14+</div>

--- a/apps/landing/src/components/sections/hero.tsx
+++ b/apps/landing/src/components/sections/hero.tsx
@@ -3,10 +3,8 @@ import type { CSSProperties, SVGProps } from 'react'
 import { BatteryMedium, Check, ChevronDown, ChevronUp, Copy, Globe, Wifi } from 'lucide-react'
 import { motion, useMotionValue, useMotionValueEvent, useReducedMotion, useScroll, useTransform } from 'motion/react'
 
-import { Button } from '@/components/ui/button'
 import { DownloadButton } from '@/components/download-button'
-import { GithubIcon } from '@/components/icons'
-import { GITHUB_URL } from '@/lib/constants'
+import { GithubButton } from '@/components/github-button'
 import { easeInOutQuad } from '@/lib/motion'
 import { sleep } from '@/lib/utils'
 
@@ -246,12 +244,7 @@ export function Hero() {
             </p>
             <div className="hero-ctas">
               <DownloadButton location="hero" />
-              <Button asChild variant="outline">
-                <a href={GITHUB_URL}>
-                  <GithubIcon />
-                  View on GitHub
-                </a>
-              </Button>
+              <GithubButton location="hero" />
             </div>
             <div className="hero-meta">Free and open source · macOS 14+</div>
           </motion.div>

--- a/apps/landing/src/components/sections/nav.tsx
+++ b/apps/landing/src/components/sections/nav.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Moon, Sun } from 'lucide-react'
 import { motion, useMotionValueEvent, useScroll } from 'motion/react'
+import { usePostHog } from '@posthog/react'
 
 import { Button } from '@/components/ui/button'
 import { DownloadButton } from '@/components/download-button'
@@ -18,6 +19,7 @@ const NAV_LINKS = [
 ] as const
 
 export function Nav() {
+  const posthog = usePostHog()
   const [floating, setFloating] = useState(false)
   const [active, setActive] = useState<string | null>(null)
 
@@ -55,7 +57,10 @@ export function Nav() {
                 key={href}
                 href={href}
                 className={active === href ? 'active' : undefined}
-                onClick={() => setActive(href)}
+                onClick={() => {
+                  setActive(href)
+                  posthog?.capture('nav_link_clicked', { label })
+                }}
               >
                 {active === href && (
                   <motion.span
@@ -74,7 +79,12 @@ export function Nav() {
             <span>Download</span>
           </DownloadButton>
           <Button asChild variant="ghost" size="icon">
-            <a href={GITHUB_URL} aria-label="GitHub" title="GitHub">
+            <a
+              href={GITHUB_URL}
+              aria-label="GitHub"
+              title="GitHub"
+              onClick={() => posthog?.capture('cta_github_clicked', { location: 'nav' })}
+            >
               <GithubIcon />
             </a>
           </Button>

--- a/apps/landing/src/components/sections/site-footer.tsx
+++ b/apps/landing/src/components/sections/site-footer.tsx
@@ -1,16 +1,28 @@
 import { Link } from '@tanstack/react-router'
+import { usePostHog } from '@posthog/react'
 
 import { MeerkatGlyph } from '@/components/icons'
 import { CLI_URL, GITHUB_URL, LICENSE_URL, PROTOCOL_URL } from '@/lib/constants'
 
 export function SiteFooter() {
+  const posthog = usePostHog()
   return (
     <footer>
       <div className="container footer-inner">
         <span className="muted footer-brand">
           <MeerkatGlyph />munkel · the note you'd say across a table.
         </span>
-        <div className="footer-links">
+        <div
+          className="footer-links"
+          onClick={(e) => {
+            const link = (e.target as HTMLElement).closest('a')
+            if (link)
+              posthog?.capture('footer_link_clicked', {
+                label: link.textContent?.trim(),
+                href: link.getAttribute('href'),
+              })
+          }}
+        >
           <Link to="/imprint">Imprint</Link>
           <Link to="/privacy">Privacy</Link>
           <Link to="/contact">Contact</Link>


### PR DESCRIPTION
## What

Add PostHog click tracking across the landing page's conversion surfaces, and tidy the Windows announce bar.

Analytics is already opt-in / cookieless / EU (see #173); these events ride that same `usePostHog()` (no-op when analytics is off).

### Events
| Event | Where | Props |
|---|---|---|
| `cta_github_clicked` | hero + footer "Star on GitHub", nav GitHub icon | `location: hero \| footer \| nav` |
| `cta_brew_copied` | Homebrew install copy button | `location: footer` |
| `announce_windows_clicked` | "Windows is learning to munkel" bar | — |
| `nav_link_clicked` | each nav menu link | `label` |
| `footer_link_clicked` | each footer link (delegated) | `label`, `href` |

(`cta_download_clicked` already existed.)

### UI changes
- New shared `GithubButton` replaces the two `View on GitHub` buttons: label is now **Star on GitHub** (Star icon), opens GitHub in a **new tab** (`target="_blank" rel="noopener noreferrer"`).
- Announce bar copy collapsed to a single string. It was `inline-flex; gap: 0.5rem`, so `<strong>Windows</strong>` and the trailing text were separate flex items — the gap plus the text node's leading space opened a visible gap between "Windows" and "is". One string removes it.

## Test plan
- [x] `bun run typecheck` (landing) passes
- [ ] Local: each event fires once in the PostHog debugger
- [ ] Announce bar reads as one evenly-spaced line
- [ ] "Star on GitHub" opens GitHub in a new tab

## Notes
- Left the now-dead `.announce-text strong` CSS rule and the nav wordmark/theme-toggle untracked — out of scope; easy follow-ups.
