### PR TITLE
fix(landing): resolve Lighthouse accessibility violations

### DIFF
--- a/apps/landing/src/components/sections/agents.tsx
+++ b/apps/landing/src/components/sections/agents.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Check, Copy, Sparkles } from 'lucide-react'
 
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 
 const INSTALL_CMDS = {
   npx: 'npx skills add limehq/munkel',
@@ -41,10 +41,12 @@ function InstallCmd() {
           <Check className="ic-check" strokeWidth={2.5} aria-hidden />
         </button>
       </div>
-      <div className="install-body">
-        <span className="prompt">$</span>
-        <span>{INSTALL_CMDS[pm]}</span>
-      </div>
+      {(Object.keys(INSTALL_CMDS) as Pm[]).map((key) => (
+        <TabsContent key={key} value={key} forceMount className="install-body">
+          <span className="prompt">$</span>
+          <span>{INSTALL_CMDS[key]}</span>
+        </TabsContent>
+      ))}
     </Tabs>
   )
 }

--- a/apps/landing/src/components/sections/announce-bar.tsx
+++ b/apps/landing/src/components/sections/announce-bar.tsx
@@ -9,7 +9,6 @@ export function AnnounceBar() {
     <a
       className="announce"
       href={GITHUB_URL}
-      aria-label="Munkel is coming to Windows soon"
       onClick={() => posthog?.capture('announce_windows_clicked')}
     >
       <span className="announce-tag">Soon</span>

--- a/apps/landing/src/components/sections/launch-badges.tsx
+++ b/apps/landing/src/components/sections/launch-badges.tsx
@@ -21,7 +21,13 @@ const LAUNCH_PLATFORMS: LaunchPlatform[] = [
   { name: 'Dang.ai', href: 'https://dang.ai' },
 ]
 
-function LaunchBadge({ platform }: { platform: LaunchPlatform }) {
+function LaunchBadge({
+  platform,
+  duplicate = false,
+}: {
+  platform: LaunchPlatform
+  duplicate?: boolean
+}) {
   const { name, href, img, alt } = platform
   return (
     <a
@@ -29,7 +35,7 @@ function LaunchBadge({ platform }: { platform: LaunchPlatform }) {
       href={href}
       target="_blank"
       rel="noopener"
-      aria-label={`Featured on ${name}`}
+      tabIndex={duplicate ? -1 : undefined}
     >
       {img ? (
         <img src={img} alt={alt ?? `Featured on ${name}`} loading="lazy" decoding="async" />
@@ -65,7 +71,7 @@ export function LaunchBadgeTrack({ liveOnly = false }: { liveOnly?: boolean }) {
           ))}
           <span className="badge-dup" aria-hidden>
             {platforms.map((p) => (
-              <LaunchBadge key={`${p.name}-dup`} platform={p} />
+              <LaunchBadge key={`${p.name}-dup`} platform={p} duplicate />
             ))}
           </span>
         </div>

--- a/apps/landing/src/components/sections/screenshots.tsx
+++ b/apps/landing/src/components/sections/screenshots.tsx
@@ -62,13 +62,11 @@ export function Screenshots() {
                     </div>
                     <div className="nx-album">
                       {ALBUM.map((img) => (
-                        <button
+                        <span
                           key={img.id}
-                          type="button"
                           className="nx-thumb"
                           style={{ backgroundImage: img.grad }}
                           onMouseEnter={() => show(img)}
-                          aria-label="Preview image"
                         />
                       ))}
                     </div>
@@ -86,13 +84,11 @@ export function Screenshots() {
                     </span>
                     <span className="nx-ralbum">
                       {HIST_ALBUM.map((img) => (
-                        <button
+                        <span
                           key={img.id}
-                          type="button"
                           className="nx-rthumb"
                           style={{ backgroundImage: img.grad }}
                           onMouseEnter={() => show(img)}
-                          aria-label="Preview image"
                         />
                       ))}
                     </span>

--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -22,16 +22,18 @@ function LandingPage() {
     <MotionConfig reducedMotion="user">
       <AnnounceBar />
       <Nav />
-      <Hero />
-      <HowItWorks />
-      <Features />
-      <Screenshots />
-      <Cli />
-      <Agents />
-      <Privacy />
-      <Faq />
-      <LaunchBadgeTrack />
-      <Cta />
+      <main>
+        <Hero />
+        <HowItWorks />
+        <Features />
+        <Screenshots />
+        <Cli />
+        <Agents />
+        <Privacy />
+        <Faq />
+        <LaunchBadgeTrack />
+        <Cta />
+      </main>
       <SiteFooter />
     </MotionConfig>
   )

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -379,7 +379,8 @@ nav.floating .nav-inner {
   padding: 0 14px;
   font-family: -apple-system, system-ui, sans-serif;
   font-size: 13px; color: oklch(0.97 0 0 / 0.85);
-  background: oklch(0 0 0 / 0.26);
+  background: oklch(0 0 0 / 0.5);
+  -webkit-backdrop-filter: blur(12px); backdrop-filter: blur(12px);
 }
 .mb-menu { display: flex; align-items: center; gap: 15px; }
 /* U+F8FF = the Apple logo glyph in the system font on Apple devices. */

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -556,7 +556,7 @@ nav.floating .nav-inner {
 }
 .nx-rhead { flex: none; display: flex; align-items: center; gap: 4px; }
 .nx-rdot { flex: none; width: 5px; height: 5px; border-radius: 50%; }
-.nx-rsender { font-size: 10px; font-weight: 600; color: oklch(1 0 0 / 0.4); }
+.nx-rsender { font-size: 10px; font-weight: 600; color: oklch(1 0 0 / 0.5); }
 .nx-rchan { flex: none; width: 9px; height: 9px; color: oklch(1 0 0 / 0.3); }
 .nx-rchan.is-globe { width: 8px; height: 8px; }
 .nx-rtext {
@@ -897,6 +897,7 @@ html:not(.dark) .install-cmd { background: oklch(0.205 0 0); }
   color: oklch(0.92 0 0);
   white-space: nowrap; overflow-x: auto;
 }
+.install-body[data-state="inactive"] { display: none; }
 .install-body .prompt { color: oklch(0.97 0 0 / 0.45); margin-right: 0.75ch; user-select: none; }
 
 /* ---------- CLI ---------- */
@@ -1128,7 +1129,7 @@ html:not(.dark) .terminal { background: oklch(0.205 0 0); }
 .pv-rec { width: 8px; height: 8px; border-radius: 50%; background: #ff453a; box-shadow: 0 0 0 3px rgb(255 69 58 / 0.25); }
 .pv-divider { width: 1px; height: 14px; background: oklch(1 0 0 / 0.18); }
 .pv-cicon { width: 13px; height: 13px; color: oklch(1 0 0 / 0.8); }
-.pv-stop { padding: 2px 9px; border-radius: 999px; background: #ff453a; color: #fff; font-weight: 600; }
+.pv-stop { padding: 2px 9px; border-radius: 999px; background: #c7362d; color: #fff; font-weight: 600; }
 
 /* Right panel = a viewer's machine: different wallpaper, a meeting app with the
    participant grid and the shared screen mirrored below it (note: no notch). */


### PR DESCRIPTION
## What

Fixes every **scored** axe failure flagged by the Lighthouse runs on
`munkel.app/` (desktop accessibility **0.87**, mobile **0.83** → expected
**100**). Performance / SEO / Best-Practices were already green; this PR is
markup/CSS only.

| Audit | Wt | Fix |
|---|---|---|
| `aria-valid-attr-value` (critical) | 10 | Install-command body is now one Radix `TabsContent` per package manager (`forceMount`, inactive hidden via CSS), so each tab trigger's auto-generated `aria-controls` points at a real panel. Previously there were no panels, so the id dangled. |
| `aria-hidden-focus` | 7 | The marquee duplicates the launch-badge row inside an `aria-hidden` clone for the infinite scroll; those `<a>`s were still tabbable. They now get `tabIndex={-1}`. |
| `color-contrast` | 7 | Muted notch sender text `oklch(1 0 0 / 0.4)` → `0.5` (3.65 → **5.28**) and the screen-share "Stop" pill `#ff453a` → `#c7362d` (3.4 → **5.26**), both ≥ 4.5:1. |
| `target-size` (mobile) | 7 | The notch preview thumbnails were `<button aria-label="Preview image">` with no click/keyboard handler — fake buttons, 20×15 px. They are decorative hover-preview triggers, so they're now plain `<span>`s (out of the a11y tree, no target-size rule). |
| `landmark-one-main` | 3 | Page body wrapped in `<main>`. |
| `label-content-name-mismatch` | 0 | Redundant `aria-label`s removed from the announce bar and launch badges so the visible text is the accessible name. |

## Test plan

- [x] `bunx turbo typecheck --filter=@munkel/landing`
- [x] `bunx turbo build --filter=@munkel/landing`
- [x] Contrast ratios recomputed: sender **5.28:1**, Stop pill **5.26:1**
- [ ] Re-run Lighthouse on a preview deploy and confirm accessibility = 100
