### PR TITLE
fix(landing): remove trailing period in announce bar

### DIFF
--- a/apps/landing/src/components/sections/announce-bar.tsx
+++ b/apps/landing/src/components/sections/announce-bar.tsx
@@ -14,7 +14,7 @@ export function AnnounceBar() {
       <span className="announce-tag">Soon</span>
       <span className="announce-text">
         <MonitorSmartphone aria-hidden />
-        Windows is learning to munkel.
+        Windows is learning to munkel
       </span>
       <ArrowRight className="announce-arrow" aria-hidden />
     </a>


### PR DESCRIPTION
Closes #183

## Summary
The announce bar read "Windows is learning to munkel." — the trailing period was unnecessary. Removed it so it now reads "Windows is learning to munkel".

## Changes
- `apps/landing/src/components/sections/announce-bar.tsx`: drop the trailing `.` from the announce text.

## Test plan
- [x] Visual: announce bar text renders without a trailing period.
- [x] No logic/markup change beyond the string; typecheck unaffected.