### PR TITLE
chore: add Claude Code GitHub Action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/claude.yml` so Claude responds to `@claude` mentions in issues, PR comments, and PR reviews.

## What this does
- Triggers on `issue_comment`, `pull_request_review_comment`, `issues` (opened/assigned), and `pull_request_review` events containing `@claude`.
- Runs `anthropics/claude-code-action@v1`, authenticating via the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (Pro/Max OAuth).

## Setup checklist (outside this PR)
- [ ] `CLAUDE_CODE_OAUTH_TOKEN` secret added to repo (via `claude setup-token`)
- [ ] Claude GitHub App installed on `limehq/munkel` (https://github.com/apps/claude)

Source: https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md