### PR TITLE
fix(macos): order notch history by message sentAt, not arrival

### DIFF
--- a/apps/macos/Sources/MunkelApp/AppModel.swift
+++ b/apps/macos/Sources/MunkelApp/AppModel.swift
@@ -146,6 +146,7 @@ final class AppModel: ObservableObject {
                 sender: displayName,
                 avatarData: Identity.avatarData,
                 text: text,
+                sentAt: Date(),
                 isDirect: false,
                 group: code,
                 groupColor: .groupColor(index: groupCodes.firstIndex(of: code) ?? 0),
@@ -190,6 +191,7 @@ final class AppModel: ObservableObject {
                     sender: self.displayName,
                     avatarData: Identity.avatarData,
                     text: caption,
+                    sentAt: Date(),
                     isDirect: false,
                     group: code,
                     groupColor: .groupColor(index: self.groupCodes.firstIndex(of: code) ?? 0),
@@ -228,6 +230,7 @@ final class AppModel: ObservableObject {
             sender: "Sebil",
             avatarData: Identity.avatarData,
             text: demo.currentText,
+            sentAt: Date(),
             isDirect: false,
             group: code,
             groupColor: demo.color,
@@ -654,12 +657,13 @@ final class AppModel: ObservableObject {
         session.onStateChange = { [weak self] in
             self?.presenceVersion += 1
         }
-        session.onChat = { [weak self] sender, text, isDirect in
+        session.onChat = { [weak self] sender, text, sentAt, isDirect in
             guard let self else { return }
             self.notch.show(
                 sender: sender.label,
                 avatarData: sender.avatar,
                 text: text,
+                sentAt: sentAt,
                 isDirect: isDirect,
                 group: code,
                 groupColor: .groupColor(index: self.groupCodes.firstIndex(of: code) ?? 0),
@@ -676,7 +680,7 @@ final class AppModel: ObservableObject {
                 }
             }
         }
-        session.onImages = { [weak self] sender, items, caption, isDirect, loadFull in
+        session.onImages = { [weak self] sender, items, caption, sentAt, isDirect, loadFull in
             guard let self else { return }
             let images = items.map {
                 IncomingImage(id: $0.r2Key, thumb: $0.thumb, width: $0.width, height: $0.height, mime: $0.mime)
@@ -685,6 +689,7 @@ final class AppModel: ObservableObject {
                 sender: sender.label,
                 avatarData: sender.avatar,
                 text: caption,
+                sentAt: sentAt,
                 isDirect: isDirect,
                 group: code,
                 groupColor: .groupColor(index: self.groupCodes.firstIndex(of: code) ?? 0),

--- a/apps/macos/Sources/MunkelApp/DebugDemoHistory.swift
+++ b/apps/macos/Sources/MunkelApp/DebugDemoHistory.swift
@@ -87,7 +87,7 @@ enum DemoHistory {
             }
             return HistoryEntry(
                 sender: "Sebil", text: label, isDirect: false, group: group, groupColor: color,
-                receivedAt: Date(), images: images, caption: caption,
+                receivedAt: Date(), sentAt: Date(), images: images, caption: caption,
                 loadFull: { id in resolved[id] }
             )
         }

--- a/apps/macos/Sources/MunkelApp/GroupSession.swift
+++ b/apps/macos/Sources/MunkelApp/GroupSession.swift
@@ -51,12 +51,12 @@ final class GroupSession {
     var onStateChange: (() -> Void)?
     /// Called when a chat message arrives; `isDirect` distinguishes a
     /// private message (relay `to` set) from a group broadcast.
-    var onChat: ((_ sender: Member, _ text: String, _ isDirect: Bool) -> Void)?
+    var onChat: ((_ sender: Member, _ text: String, _ sentAt: Date, _ isDirect: Bool) -> Void)?
     /// Called when an image album arrives (1–10 images). `caption` is the
     /// optional shared message (empty if none). `loadFull` fetches + decrypts
     /// one image's full resolution from R2 on demand, keyed by its r2Key
     /// (nil on failure/expiry).
-    var onImages: ((_ sender: Member, _ items: [ImageItem], _ caption: String, _ isDirect: Bool, _ loadFull: @escaping @Sendable (String) async -> Data?) -> Void)?
+    var onImages: ((_ sender: Member, _ items: [ImageItem], _ caption: String, _ sentAt: Date, _ isDirect: Bool, _ loadFull: @escaping @Sendable (String) async -> Data?) -> Void)?
 
     init(code: String, relayURL: URL) {
         self.code = code
@@ -333,12 +333,12 @@ final class GroupSession {
                 onStateChange?()
             }
 
-        case let .chat(text, _):
+        case let .chat(text, sentAt):
             let sender = members.first { $0.id == memberId }
                 ?? Member(id: memberId)
-            onChat?(sender, MessageLimits.clamp(text), to != nil)
+            onChat?(sender, MessageLimits.clamp(text), sentAt, to != nil)
 
-        case let .image(items, caption, _):
+        case let .image(items, caption, sentAt):
             // Drop items with an implausibly large inline thumb; the relay
             // frame cap already bounds the total, this guards each one.
             let safeItems = items.filter { $0.thumb.count <= Self.maxIncomingThumbBytes }
@@ -366,7 +366,7 @@ final class GroupSession {
                     }
                 }.value
             }
-            onImages?(sender, safeItems, MessageLimits.clamp(caption), to != nil, loadFull)
+            onImages?(sender, safeItems, MessageLimits.clamp(caption), sentAt, to != nil, loadFull)
         }
     }
 }

--- a/apps/macos/Sources/MunkelApp/IncomingMessage.swift
+++ b/apps/macos/Sources/MunkelApp/IncomingMessage.swift
@@ -47,6 +47,7 @@ struct HistoryEntry: Identifiable, Equatable {
     let group: String
     let groupColor: Color
     let receivedAt: Date
+    let sentAt: Date
     /// Album images for an image message (empty for plain text), carried so the
     /// EXPANDED history can render thumbnails that upgrade to full resolution
     /// just like the current message. RAM-only — gone when the entry is pruned.

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -638,12 +638,12 @@ final class NotchPresenter {
         removeClickMonitors()
         hoverObservation = nil
         turnOffHoverCopy()
-        await notch.hide()
         if currentNotch === notch {
             currentNotch = nil
             currentModel = nil
             notchVisible = false
         }
+        await notch.hide()
     }
 
     /// Show the GitHub device-flow user code in the notch. Driven by AppModel's

--- a/apps/macos/Sources/MunkelApp/NotchPresenter.swift
+++ b/apps/macos/Sources/MunkelApp/NotchPresenter.swift
@@ -76,6 +76,7 @@ final class NotchPresenter {
         sender: String,
         avatarData: Data?,
         text: String = "",
+        sentAt: Date,
         isDirect: Bool,
         group: String,
         groupColor: Color,
@@ -112,6 +113,7 @@ final class NotchPresenter {
             group: group,
             groupColor: groupColor,
             receivedAt: Date(),
+            sentAt: sentAt,
             // Carry the album so the expanded history can show it later; the
             // collapsed row still reads as the 📷 label above. `text` is the
             // raw caption here (empty for a captionless album / plain message).
@@ -394,7 +396,9 @@ final class NotchPresenter {
     /// displayed — chronological, so live-pushed newcomers appear as the
     /// bottom-most row, directly above the current message.
     private func visibleHistory(excluding id: UUID) -> [HistoryEntry] {
-        history.filter { $0.id != id }
+        history
+            .filter { $0.id != id }
+            .sorted { ($0.sentAt, $0.receivedAt) < ($1.sentAt, $1.receivedAt) }
     }
 
     private func pruneHistory() {


### PR DESCRIPTION
Closes #191

Two distinct root causes behind "messages sometimes missing **or** out of order". Both fixed; both independently verified.

## 1. Out of order — `sentAt` was discarded
History rows were appended in **arrival order** and stamped only with `receivedAt: Date()` (`NotchPresenter`). The message's own `sentAt` was decoded but thrown away at the `GroupSession` boundary (`case let .chat(text, _)` / `.image(..., _)`), and the `onChat`/`onImages` callbacks + `show(...)` never carried it. Relay-reordered or cross-sender messages therefore landed in the wrong slot.

**Fix:** thread `sentAt` from decode → `GroupSession` callbacks → `AppModel` → `NotchPresenter.show` → `HistoryEntry`, and render the history sorted by `(sentAt, receivedAt)`. `receivedAt` is a stable tiebreaker for same-second sends (Swift encodes `sentAt` at whole-second resolution), so a burst over one ordered connection keeps arrival order. The underlying `history` buffer stays append-ordered, so pruning (by `receivedAt`, the 60 s window) and the anchor-ring countdown are unchanged. **Wire-compatible** — `sentAt` already travels on the wire; this only stops the client discarding it. No protocol/TS change.

## 2. Missing — a teardown re-entrancy race (genuinely dropped messages)
Found during an adversarial pass on the "missing" symptom. `tearDownNotch` nil'd `currentNotch`/`currentModel`/`notchVisible` **after** `await notch.hide()`, which yields the `@MainActor` for ~0.4 s. A message arriving in that window saw `currentNotch != nil`, took the morph path, and was recorded onto the panel being destroyed; teardown then completed, nil'd everything, and the prune loop exited — the entry orphaned in `history[]` with no renderer. Sporadic, and matches "first message of a burst after a lull" (~60 s after the previous one).

**Fix:** detach the presenter's current refs **synchronously, before** the async hide. A racing `show()` then sees `currentNotch == nil` and builds a fresh panel (rendering the message) instead of morphing into a half-torn-down one. The old panel finishes fading out independently (~0.4 s cosmetic overlap in the race window only). Respects the no-storage/ephemerality invariant — nothing is buffered or persisted.

## Verification
- `swift build` ✅ · `swift test` ✅ (MunkelKit interop) · **CI all green incl. `macos`** ✅
- Two independent adversarial agents: one isolated the teardown drop with a deterministic interleaving; a second stress-tested the fix and confirmed it closes the race with no leaks, no wedged prune loop, no cancellation-aborted hide, and zero force-unwraps on the affected refs.

## Notes
- A presenter-level regression test would require introducing a `MunkelApp` test target (the app target has none today, and SPM can't `@testable import` an executable target without restructuring) — out of scope for this fix; flagged as a follow-up.

## Test plan
- [x] `swift build`
- [x] `swift test`
- [x] CI (`macos`, checks, CodeQL analyze) green
- [ ] Manual: rapid multi-sender burst → history matches send order; a message arriving exactly as the notch collapses still appears