### PR TITLE
chore: pin Claude Code workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Follow-up to #196. The merged workflow used `actions/checkout@v6` and `anthropics/claude-code-action@v1`, which the org's "actions must be pinned to a full-length commit SHA" policy rejects (runs fail at *Prepare all required actions* in 0s).

Pins both to commit SHAs and bumps checkout to v7.0.0 to match the other workflows:
- `actions/checkout` → `9c091bb…` # v7.0.0
- `anthropics/claude-code-action` → `428971d…` # v1