### PR TITLE
fix(landing): stop launch-badge hover from clipping at the section edge

### DIFF
--- a/apps/landing/src/components/sections/launch-badges.tsx
+++ b/apps/landing/src/components/sections/launch-badges.tsx
@@ -66,7 +66,7 @@ export function LaunchBadgeTrack({ liveOnly = false }: { liveOnly?: boolean }) {
           Spotted us on a launch board? An upvote is always welcome.
         </p>
       </div>
-      <div className="group mt-12 [mask-image:linear-gradient(90deg,transparent,#000_8%,#000_92%,transparent)] [-webkit-mask-image:linear-gradient(90deg,transparent,#000_8%,#000_92%,transparent)] motion-reduce:[mask-image:none] motion-reduce:[-webkit-mask-image:none]">
+      <div className="group mt-12 py-3 [mask-image:linear-gradient(90deg,transparent,#000_8%,#000_92%,transparent)] [-webkit-mask-image:linear-gradient(90deg,transparent,#000_8%,#000_92%,transparent)] motion-reduce:[mask-image:none] motion-reduce:[-webkit-mask-image:none]">
         <div className="flex items-center gap-4 w-max animate-[badge-scroll_38s_linear_infinite] group-hover:[animation-play-state:paused] motion-reduce:animate-none motion-reduce:flex-wrap motion-reduce:justify-center motion-reduce:w-auto">
           {platforms.map((p) => (
             <LaunchBadge key={p.name} platform={p} />


### PR DESCRIPTION
Closes #190

## Problem
Hovering a launch badge applies `hover:-translate-y-0.5` (a 2px lift) and `hover:shadow-[var(--shadow-md)]`. The scrolling track sits flush inside a section with `overflow-hidden` — which is required to clip the horizontally-scrolling `w-max` marquee. Because the badge row fills the container height (`h-[54px]`) with no vertical breathing room, the lift and the ~10px downward `shadow-md` (`0 4px 6px -1px …` + `0 2px 4px -2px …`) hit that clip boundary and get cut off on hover.

## Fix
Add vertical padding (`py-3`) to the masked track container so the hover lift + shadow render fully **inside** the clipped region. This:
- keeps the horizontal marquee clip (`overflow-hidden`) unchanged,
- doesn't switch clip semantics (no `overflow-x-clip`/scrollbar risk),
- adds no bleed into the neighboring Faq/Cta sections.

The mask is a horizontal gradient, so the added vertical padding doesn't affect the left/right fade.

## Verification
- Diagnosis is forced by the code: the only hover-state changes are border *color* (no size change), the transform lift, and the box-shadow — so the clipped lift/shadow is the sole possible "overflow."
- Change is a single standard Tailwind utility on a `className` string (type-safe; compiles). The landing build runs in CI on this PR.
- ⚠️ Not visually confirmed locally — the repo has no Playwright and the worktree has no `node_modules`. **Recommend a quick visual glance**: hover a badge and confirm the lift + soft shadow are no longer cut off at the top/bottom.

## Test plan
- [ ] CI: landing typecheck/build green
- [ ] Visual: hover badges → lift + shadow fully visible, marquee still clipped horizontally, no layout shift