### PR TITLE
feat(landing): real macOS-style battery + wifi in the menu-bar mockup

### DIFF
--- a/apps/landing/src/components/icons.tsx
+++ b/apps/landing/src/components/icons.tsx
@@ -37,3 +37,23 @@ export function KofiIcon({ className = '' }: { className?: string }) {
     </svg>
   )
 }
+
+export function MenuBarBattery({ className = '' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 28 13" fill="none" className={className} aria-hidden>
+      <rect x="0.6" y="0.6" width="23" height="11.8" rx="3.4" stroke="currentColor" strokeOpacity="0.5" strokeWidth="1" />
+      <rect x="2.2" y="2.2" width="15.5" height="8.6" rx="1.8" fill="currentColor" />
+      <rect x="24.4" y="4" width="1.8" height="5" rx="0.9" fill="currentColor" fillOpacity="0.5" />
+    </svg>
+  )
+}
+
+export function MenuBarWifi({ className = '' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 13" fill="none" className={className} aria-hidden>
+      <path d="M1.7 5.3a9 9 0 0 1 12.6 0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M4.2 8a5.4 5.4 0 0 1 7.6 0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="8" cy="10.7" r="1.05" fill="currentColor" />
+    </svg>
+  )
+}

--- a/apps/landing/src/components/sections/hero.tsx
+++ b/apps/landing/src/components/sections/hero.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
 import type { CSSProperties, SVGProps } from 'react'
-import { BatteryMedium, Check, ChevronDown, ChevronUp, Copy, Globe, Wifi } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp, Copy, Globe } from 'lucide-react'
 import { motion, useMotionValue, useMotionValueEvent, useReducedMotion, useScroll, useTransform } from 'motion/react'
 
 import { DownloadButton } from '@/components/download-button'
 import { GithubButton } from '@/components/github-button'
+import { MenuBarBattery, MenuBarWifi } from '@/components/icons'
 import { easeInOutQuad } from '@/lib/motion'
 import { cn, sleep } from '@/lib/utils'
 
@@ -282,8 +283,8 @@ export function Hero() {
                       <span className="text-[15px] leading-[0] opacity-[0.92] max-[900px]:text-[13px] max-[600px]:text-[11px]" aria-hidden>&#xF8FF;</span>
                     </div>
                     <div className="flex items-center gap-[11px] [font-variant-numeric:tabular-nums]">
-                      <BatteryMedium className="w-[15px]! h-[15px]! max-[900px]:w-[13px]! max-[900px]:h-[13px]!" aria-hidden />
-                      <Wifi className="w-[15px]! h-[15px]! max-[900px]:w-[13px]! max-[900px]:h-[13px]!" aria-hidden />
+                      <MenuBarBattery className="w-[24px] h-[12px] max-[900px]:w-[20px] max-[900px]:h-[10px] max-[600px]:w-[16px] max-[600px]:h-[8px]" />
+                      <MenuBarWifi className="w-[15px] h-[12px] max-[900px]:w-[13px] max-[900px]:h-[10px] max-[600px]:w-[11px] max-[600px]:h-[9px]" />
                       <span className="font-medium">{clock}</span>
                     </div>
                   </div>

--- a/apps/landing/src/components/sections/mac-screen.tsx
+++ b/apps/landing/src/components/sections/mac-screen.tsx
@@ -1,26 +1,7 @@
 import type { ReactNode } from 'react'
 
+import { MenuBarBattery, MenuBarWifi } from '@/components/icons'
 import { cn } from '@/lib/utils'
-
-function MenuBarBattery({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 28 13" fill="none" className={className} aria-hidden>
-      <rect x="0.6" y="0.6" width="23" height="11.8" rx="3.4" stroke="currentColor" strokeOpacity="0.5" strokeWidth="1" />
-      <rect x="2.2" y="2.2" width="15.5" height="8.6" rx="1.8" fill="currentColor" />
-      <rect x="24.4" y="4" width="1.8" height="5" rx="0.9" fill="currentColor" fillOpacity="0.5" />
-    </svg>
-  )
-}
-
-function MenuBarWifi({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 16 13" fill="none" className={className} aria-hidden>
-      <path d="M1.7 5.3a9 9 0 0 1 12.6 0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      <path d="M4.2 8a5.4 5.4 0 0 1 7.6 0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      <circle cx="8" cy="10.7" r="1.05" fill="currentColor" />
-    </svg>
-  )
-}
 
 const AVATAR_PALETTES: [string, string][] = [
   ['#f56b6b', '#d93069'],

--- a/apps/landing/src/components/sections/mac-screen.tsx
+++ b/apps/landing/src/components/sections/mac-screen.tsx
@@ -1,7 +1,26 @@
 import type { ReactNode } from 'react'
-import { BatteryMedium, Wifi } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
+
+function MenuBarBattery({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 28 13" fill="none" className={className} aria-hidden>
+      <rect x="0.6" y="0.6" width="23" height="11.8" rx="3.4" stroke="currentColor" strokeOpacity="0.5" strokeWidth="1" />
+      <rect x="2.2" y="2.2" width="15.5" height="8.6" rx="1.8" fill="currentColor" />
+      <rect x="24.4" y="4" width="1.8" height="5" rx="0.9" fill="currentColor" fillOpacity="0.5" />
+    </svg>
+  )
+}
+
+function MenuBarWifi({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 13" fill="none" className={className} aria-hidden>
+      <path d="M1.7 5.3a9 9 0 0 1 12.6 0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M4.2 8a5.4 5.4 0 0 1 7.6 0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="8" cy="10.7" r="1.05" fill="currentColor" />
+    </svg>
+  )
+}
 
 const AVATAR_PALETTES: [string, string][] = [
   ['#f56b6b', '#d93069'],
@@ -55,8 +74,8 @@ export function MacScreen({
               </span>
             </div>
             <div className="flex items-center gap-[11px] [font-variant-numeric:tabular-nums]">
-              <BatteryMedium className="w-[15px]! h-[15px]! max-[900px]:w-[13px]! max-[900px]:h-[13px]!" aria-hidden />
-              <Wifi className="w-[15px]! h-[15px]! max-[900px]:w-[13px]! max-[900px]:h-[13px]!" aria-hidden />
+              <MenuBarBattery className="w-[24px] h-[12px] max-[900px]:w-[20px] max-[900px]:h-[10px] max-[600px]:w-[16px] max-[600px]:h-[8px]" />
+              <MenuBarWifi className="w-[15px] h-[12px] max-[900px]:w-[13px] max-[900px]:h-[10px] max-[600px]:w-[11px] max-[600px]:h-[9px]" />
               <span className="font-medium">Sun 22. Jun 09:41</span>
             </div>
           </div>


### PR DESCRIPTION
Closes #186

## Change
The menu-bar mockup's stand-in icons were lucide's generic `BatteryMedium`/`Wifi`. Replaced them with custom SVGs drawn to match the macOS menu bar:
- **Battery** — rounded body outline + terminal nub + inner charge fill.
- **Wifi** — solid two-arc fan + dot.

The Apple logo (``) was already the authentic glyph. Built from reliable SVG primitives (rects + arcs), with responsive size variants matching the existing `max-[900px]`/`max-[600px]` menu-bar scaling.

**Bonus:** these live in the shared `MacScreen`, used by both `privacy.tsx` **and** `screenshots.tsx`, so the screenshots-section menu bar gets real icons too (part of #188's ask).

## On "original Apple icons"
Apple's actual icon files are proprietary and can't be bundled, so these are faithful **custom recreations** of the macOS look — the standard approach for an illustrative mockup. If you'd rather ship exact Apple assets, drop them in and I'll wire them up.

## ⚠️ Visual fidelity — please verify on the preview
I can't render headlessly, so the exact proportions/alignment are reasoned, not seen. Kept **draft**. On the preview, check the battery + wifi read as authentic and sit aligned with the clock at all three breakpoints; the sizes/paths are trivial to tune (or add a Control Center / Spotlight glyph if you want more menu-bar items).

## Test plan
- [ ] CI: landing typecheck/build green (lucide import removed cleanly)
- [ ] Visual (preview): battery + wifi look macOS-authentic and aligned, in hero-adjacent privacy + screenshots mockups, across breakpoints