### PR TITLE
feat(landing): shrink the screenshots display so it fits the page

### DIFF
--- a/apps/landing/src/components/sections/screenshots.tsx
+++ b/apps/landing/src/components/sections/screenshots.tsx
@@ -47,7 +47,7 @@ export function Screenshots() {
         </div>
 
         <div className="flex justify-center ml-[calc(50%_-_50vw)] mr-[calc(50%_-_50vw)]">
-          <MacScreen className="w-[min(1560px,94vw)] max-w-none [transform:none]">
+          <MacScreen className="w-[min(1180px,90vw)] max-w-none [transform:none]">
             <div className="absolute top-[7px] left-1/2 bg-black z-[5] [transform:translateX(-50%)] [transform-origin:top_center] cursor-pointer w-[420px] h-[310px] [clip-path:path('M0_0_Q15_0_15_15_L15_290_Q15_310_35_310_L385_310_Q405_310_405_290_L405_15_Q405_0_420_0_Z')] [filter:drop-shadow(0_10px_16px_oklch(0_0_0_/_0.5))] [transition:width_0.42s_cubic-bezier(0.33,1,0.68,1),height_0.42s_cubic-bezier(0.33,1,0.68,1),clip-path_0.42s_cubic-bezier(0.33,1,0.68,1),filter_0.3s_ease] motion-reduce:[transition:none] max-[900px]:[transform:translateX(-50%)_scale(0.75)] max-[600px]:[transform:translateX(-50%)_scale(0.58)]">
               <span className="absolute left-1/2 -translate-x-1/2 top-[11px] w-[7px] h-[7px] z-[3] rounded-full [background:radial-gradient(circle_at_35%_35%,oklch(0.38_0.05_250),oklch(0.17_0.03_255)_55%,oklch(0.05_0_0)_100%)] shadow-[0_0_0_1.5px_oklch(0.09_0_0),inset_0_0_2px_oklch(0.6_0.08_250_/_0.5)]"></span>
               <div className="absolute inset-0 overflow-hidden rounded-b-[20px] opacity-100 visible [font-family:system-ui,-apple-system,sans-serif] [-webkit-font-smoothing:antialiased] flex flex-col [padding:38px_26px_18px] gap-[9px] text-left" onMouseLeave={hide}>


### PR DESCRIPTION
Part of #188 (does **not** close it — the asset-dependent items remain)

## Done here
- **Display too large** → the screenshots `MacScreen` was `w-[min(1560px,94vw)]` (near full-viewport). Brought to **`w-[min(1180px,90vw)]`** so the whole screen fits comfortably. As a side effect the menu bar + Apple glyph now read larger relative to the smaller display.

## Covered by other PRs
- **Menu bar uses stand-in icons** → ✅ already fixed in **#208** (real macOS-style battery + wifi in the shared `MacScreen`, which this section uses).
- **Apple icon too small** → the smaller display already helps; if you want the `` glyph itself bumped, that's a one-line `MacScreen` tweak I'll fold into **#208** (keeping all menu-bar-icon changes in one PR) on your word.

## ⛔ Blocked on your assets (the issue stays open for these)
- **"Use real images for the demo screenshots"** — `ALBUM`/`HIST_ALBUM` are gradient placeholders. Drop the real product images in (`/public/shots/...`) and I'll wire them in (the structure already swaps `grad` → `url(...)` cleanly).
- **"Replace the placeholder avatars (initials + colored circle) with real profile pictures"** — you said you'd deliver these. Once I have them I'll swap the shared `Avatar` to render real images.

So: send the demo screenshots + profile pics whenever, and I'll do the rest in a follow-up that closes #188.

## Test plan
- [ ] Visual (preview): the display fits the page nicely at desktop; hover-to-preview album still works; `max-[900px]`/`max-[600px]` scaling unaffected
- [ ] CI typecheck/build green