### PR TITLE
fix(landing): keep active nav pill text readable on hover

### DIFF
--- a/apps/landing/src/components/sections/nav.tsx
+++ b/apps/landing/src/components/sections/nav.tsx
@@ -73,8 +73,8 @@ export function Nav() {
                 key={href}
                 href={href}
                 className={cn(
-                  'relative z-[1] rounded-full px-3 py-1.5 text-[length:var(--text-sm)] whitespace-nowrap text-muted-foreground transition-[color] duration-200 hover:text-foreground',
-                  active === href && 'text-primary-foreground',
+                  'relative z-[1] rounded-full px-3 py-1.5 text-[length:var(--text-sm)] whitespace-nowrap text-muted-foreground transition-[color] duration-200',
+                  active === href ? 'text-primary-foreground' : 'hover:text-foreground',
                 )}
                 onClick={() => {
                   setActive(href)


### PR DESCRIPTION
## What

Hovering the **active** nav link turned its text near-white over the gold pill in dark mode — low contrast, looked broken.

The active link carried both `text-primary-foreground` and `hover:text-foreground`. The `:hover` pseudo-class outranks the plain class, so on hover the text fell back to the light `--foreground` instead of the intended dark `--primary-foreground`.

## Fix

Apply the hover color only to inactive links:

```diff
- ... text-muted-foreground transition-[color] duration-200 hover:text-foreground',
- active === href && 'text-primary-foreground',
+ ... text-muted-foreground transition-[color] duration-200',
+ active === href ? 'text-primary-foreground' : 'hover:text-foreground',
```

The active pill now keeps its dark `primary-foreground` text in all states.

## Test plan

- [ ] Dark mode: hover the active nav item → text stays dark on the gold pill
- [ ] Inactive items still lighten to `--foreground` on hover
- [ ] Light mode unaffected
