### PR TITLE
feat(landing): MacBook Ultra Dynamic Island SEO section and metadata

### DIFF
--- a/apps/landing/src/components/sections/faq.tsx
+++ b/apps/landing/src/components/sections/faq.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from 'react'
-
 import {
   Accordion,
   AccordionContent,
@@ -8,7 +6,7 @@ import {
 } from '@/components/ui/accordion'
 import { DISCUSSIONS_URL } from '@/lib/constants'
 
-const FAQS: { q: string; a: ReactNode }[] = [
+const FAQS: { q: string; a: string }[] = [
   {
     q: 'Can anyone else read my messages?',
     a: 'Only the people you share the channel name with. Munkels are end-to-end encrypted, the name doubles as the key, the relay cannot read them, and nothing is stored on the server.',
@@ -33,11 +31,26 @@ const FAQS: { q: string; a: ReactNode }[] = [
     q: 'Will friends on older or non-notch Macs miss out?',
     a: 'Not at all. One universal binary covers Apple Silicon and Intel, and without a notch your munkels fall back to a tidy floating panel. Windows is coming soon.',
   },
+  {
+    q: 'Does Munkel work with the MacBook Ultra Dynamic Island?',
+    a: "The MacBook Ultra is still a rumor, and we'll be honest about that. But munkels already live in the notch, the exact spot a Dynamic Island would take over. The day it ships, your munkels slide out of the island like they always lived there.",
+  },
 ]
+
+const FAQ_LD = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQS.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+})
 
 export function Faq() {
   return (
     <section id="faq">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: FAQ_LD }} />
       <div className="mx-auto max-w-[1400px] px-8 flex flex-col items-center">
         <div className="text-center max-w-[600px] mb-14">
           <div className="font-mono text-[length:var(--text-xs)] text-brand tracking-[0.06em] uppercase">FAQ</div>

--- a/apps/landing/src/components/sections/features.tsx
+++ b/apps/landing/src/components/sections/features.tsx
@@ -85,10 +85,10 @@ export function Features() {
             <div className="inline-flex items-center justify-center w-9 h-9 rounded-[var(--radius-md)] bg-[var(--brand-soft)] text-brand shadow-[0_0_calc(var(--glow)*20px)_color-mix(in_oklab,var(--brand)_20%,transparent)] mb-4 [&_svg]:w-[18px]! [&_svg]:h-[18px]!">
               <Laptop aria-hidden />
             </div>
-            <h3 className="text-[length:var(--text-base)] font-semibold">Works on any Mac</h3>
+            <h3 className="text-[length:var(--text-base)] font-semibold">Notch, island, or neither</h3>
             <p className="mt-2 text-[length:var(--text-sm)] text-muted-foreground leading-relaxed text-pretty max-w-[46ch]">
-              No notch? No problem. Munkels slide into a tidy floating panel instead — same munkel,
-              different spot.
+              Notch today, Dynamic Island when the rumors come true, a tidy floating panel
+              everywhere else. Same munkel, different spot.
             </p>
             <div className="mt-auto pt-5 flex justify-center" aria-hidden>
               <div className="flex items-center gap-[10px] bg-[color-mix(in_oklab,var(--background)_64%,#000)] border border-[oklch(1_0_0_/_0.12)] rounded-full py-2 pr-[18px] pl-2 shadow-[var(--shadow-md)]">

--- a/apps/landing/src/components/sections/ultra.tsx
+++ b/apps/landing/src/components/sections/ultra.tsx
@@ -1,0 +1,30 @@
+export function Ultra() {
+  return (
+    <section id="ultra">
+      <div className="mx-auto max-w-[1400px] px-8 flex flex-col items-center text-center">
+        <div className="font-mono text-[length:var(--text-xs)] text-brand tracking-[0.06em] uppercase">
+          MacBook Ultra
+        </div>
+        <h2 className="text-[length:var(--text-4xl)] font-semibold tracking-tight mt-4 text-balance max-w-[720px]">
+          Born in the notch. Ready for the Dynamic Island.
+        </h2>
+        <p className="mt-[1.125rem] text-muted-foreground text-[length:var(--text-lg)] leading-relaxed text-pretty max-w-[620px]">
+          Rumor has it the MacBook Ultra swaps the notch for a Dynamic Island. Munkels already live
+          in that exact spot, sliding out to say hi and vanishing again. The day such a MacBook
+          ships, Munkel is ready. Same note across the table, slightly fancier table.
+        </p>
+        <div
+          className="mt-12 flex items-center gap-[10px] bg-black border border-[oklch(1_0_0_/_0.12)] rounded-full py-2 pr-[20px] pl-3 shadow-[var(--shadow-md)]"
+          aria-hidden
+        >
+          <span className="w-[9px] h-[9px] rounded-full bg-[radial-gradient(circle_at_35%_35%,oklch(0.38_0.05_250),oklch(0.17_0.03_255)_55%,oklch(0.05_0_0)_100%)] shadow-[0_0_0_1.5px_oklch(0.09_0_0)]" />
+          <img src="/avatars/01.png" alt="" className="w-[26px] h-[26px] rounded-full object-cover" />
+          <div className="flex flex-col leading-[1.25] text-left">
+            <span className="font-mono text-[10px] text-brand">Alex</span>
+            <span className="text-[12px] text-white">down in 5</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/landing/src/routes/__root.tsx
+++ b/apps/landing/src/routes/__root.tsx
@@ -10,10 +10,21 @@ import geistLatinWoff2 from '@fontsource-variable/geist/files/geist-latin-wght-n
 import geistMonoLatinWoff2 from '@fontsource-variable/geist-mono/files/geist-mono-latin-wght-normal.woff2?url'
 
 const SITE_URL = 'https://munkel.app'
-const TITLE = 'Munkel · ephemeral messages from the notch'
+const TITLE = 'Munkel · Notch messages, ready for the Dynamic Island MacBook'
 const DESCRIPTION =
-  'Quick pings between friends, end-to-end encrypted — they slide out of the MacBook notch, linger a moment, and vanish. Nothing is ever stored.'
+  "Munkel slides tiny encrypted messages out of the MacBook notch today. Rumor has it the MacBook Ultra swaps it for a Dynamic Island. We'll be there on day one."
 const OG_IMAGE = `${SITE_URL}/og.png`
+
+const APP_LD = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'Munkel',
+  operatingSystem: 'macOS',
+  applicationCategory: 'CommunicationApplication',
+  description: DESCRIPTION,
+  url: SITE_URL,
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+})
 
 // Restore the stored theme before first paint to avoid a light-mode flash.
 // Dark is the default; only an explicit 'light' choice removes the class.
@@ -41,6 +52,7 @@ export const Route = createRootRoute({
       { name: 'twitter:description', content: DESCRIPTION },
       { name: 'twitter:image', content: OG_IMAGE },
     ],
+    scripts: [{ type: 'application/ld+json', children: APP_LD }],
     links: [
       {
         rel: 'preload',

--- a/apps/landing/src/routes/index.tsx
+++ b/apps/landing/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { Hero } from '@/components/sections/hero'
 import { HowItWorks } from '@/components/sections/how-it-works'
 import { Features } from '@/components/sections/features'
 import { Screenshots } from '@/components/sections/screenshots'
+import { Ultra } from '@/components/sections/ultra'
 import { Cli } from '@/components/sections/cli'
 import { Agents } from '@/components/sections/agents'
 import { Privacy } from '@/components/sections/privacy'
@@ -28,6 +29,7 @@ function LandingPage() {
         <HowItWorks />
         <Features />
         <Screenshots />
+        <Ultra />
         <Cli />
         <Agents />
         <Privacy />


### PR DESCRIPTION
An SEO play for the rumored MacBook Ultra: people searching "MacBook Ultra", "MacBook Ultra Dynamic Island" or "Dynamic Island MacBook" should find Munkel, since munkels already live in exactly that spot.

## What's in
- **New section** between Screenshots and CLI: kicker "MacBook Ultra", H2 **"Born in the notch. Ready for the Dynamic Island."**, honest rumor framing ("Rumor has it… The day such a MacBook ships, Munkel is ready."), plus a small Dynamic-Island pill visual.
- **Title tag** → "Munkel · Notch messages, ready for the Dynamic Island MacBook"; **meta description** rewritten around the target phrases (158 chars).
- **New FAQ entry** matching the long-tail query "Does Munkel work with the MacBook Ultra Dynamic Island?".
- **Structured data**: FAQPage JSON-LD (generated from the FAQ array, stays in sync) and SoftwareApplication JSON-LD.
- **Feature card** "Works on any Mac" → "Notch, island, or neither".

Copy is deliberately honest: the device is only ever described as a rumor. No em-dashes, channel wording, house voice.

All changes under `apps/landing/`. Verified: typecheck clean, title/H2/FAQ/JSON-LD present in the rendered HTML, sections screenshot-checked.